### PR TITLE
Fix Plugin-Development-Project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.idea/
+.idea/*
+!.idea/modules.xml
 
 /out
 /gen

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/eplug.iml" filepath="$PROJECT_DIR$/eplug.iml" />
+    </modules>
+  </component>
+</project>


### PR DESCRIPTION
Right now without "modules.xml" Intellij IDEA is not able to create a Plugin-Project from the sources.

After providing the ".idea/modules.xml" file, Intellij happily imports the checked out sources as a Plugin-Project