### PR TITLE
Implement 'Add Import' intention

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
+import org.elm.ide.intentions.ElmImportIntentionAction
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmUpperCaseQID
 import org.elm.lang.core.psi.elements.ElmValueExpr
@@ -19,6 +20,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
                 // so that we don't report a double error when really the problem
                 // is with the qualified module name reference.
                 holder.createErrorAnnotation(element, "Unresolved reference '${ref.canonicalText}'")
+                        .also { it.registerFix(ElmImportIntentionAction()) }
             }
         }
     }

--- a/src/main/kotlin/org/elm/ide/intentions/ElmAtCaretIntentionActionBase.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmAtCaretIntentionActionBase.kt
@@ -39,12 +39,12 @@ abstract class ElmAtCaretIntentionActionBase<Ctx> : BaseElementAtCaretIntentionA
      */
     abstract fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Ctx?
 
-    abstract fun invoke(project: Project, editor: Editor, ctx: Ctx)
+    abstract fun invoke(project: Project, editor: Editor, context: Ctx)
 
     final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
-        val ctx = findApplicableContext(project, editor, element) ?: return
+        val context = findApplicableContext(project, editor, element) ?: return
         checkWriteAccessAllowed()
-        invoke(project, editor, ctx)
+        invoke(project, editor, context)
     }
 
     final override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {

--- a/src/main/kotlin/org/elm/ide/intentions/ElmAtCaretIntentionActionBase.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmAtCaretIntentionActionBase.kt
@@ -1,0 +1,54 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ *
+ * From intellij-rust
+ */
+
+package org.elm.ide.intentions
+
+import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.elm.openapiext.checkReadAccessAllowed
+import org.elm.openapiext.checkWriteAccessAllowed
+
+/**
+ * A base class for implementing intentions: actions available via "light bulb" / `Alt+Enter`.
+ *
+ * The cool thing about intentions is their UX: there is a huge number of intentions,
+ * and they all can be invoked with a single `Alt + Enter` shortcut. This is possible
+ * because at the position of the cursor only small number of intentions is applicable.
+ *
+ * So, intentions consists of two functions: [findApplicableContext] functions determines
+ * if the intention can be applied at the given position, it is used to populate "light bulb" list.
+ * [invoke] is called when the user selects the intention from the list and must apply the changes.
+ *
+ * The context collected by [findApplicableContext] is gathered into [Ctx] object and is passed to
+ * [invoke]. In general, [invoke] should never fail: if you need to check if some element is not
+ * null, do this in [findApplicableContext] and pass the element via the context.
+ *
+ * [findApplicableContext] is executed under a read action, and [invoke] under a write action.
+ */
+abstract class ElmAtCaretIntentionActionBase<Ctx> : BaseElementAtCaretIntentionAction() {
+
+    /**
+     * Return `null` if the intention is not applicable, otherwise collect and return
+     * all the necessary info to actually apply the intention.
+     */
+    abstract fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Ctx?
+
+    abstract fun invoke(project: Project, editor: Editor, ctx: Ctx)
+
+    final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
+        val ctx = findApplicableContext(project, editor, element) ?: return
+        checkWriteAccessAllowed()
+        invoke(project, editor, ctx)
+    }
+
+    final override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
+        checkReadAccessAllowed()
+        return findApplicableContext(project, editor, element) != null
+    }
+}

--- a/src/main/kotlin/org/elm/ide/intentions/ElmImportIntentionAction.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmImportIntentionAction.kt
@@ -1,0 +1,218 @@
+package org.elm.ide.intentions
+
+import com.intellij.lang.ASTNode
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmNamedElement
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.ElmTypes.START_DOC_COMMENT
+import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.resolve.ElmReferenceElement
+import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.stubs.index.ElmNamedElementIndex
+import org.elm.openapiext.toPsiFile
+
+data class Context(val fullRefName: String, val candidates: List<Candidate>) {
+    val importAsQualified: Boolean
+        get() = fullRefName.contains(".")
+}
+
+class ElmImportIntentionAction: ElmAtCaretIntentionActionBase<Context>() {
+
+    override fun getText() = "Import"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        if (element.parentOfType<ElmImportClause>() != null) return null
+        val refElement = element.parentOfType<ElmReferenceElement>() ?: return null
+
+        val name = refElement.referenceName
+        val scope = GlobalSearchScope.allScope(project)
+        val candidates = ElmNamedElementIndex.find(name, project, scope)
+                .mapNotNull { Candidate.fromNamedElement(it) }
+
+        if (candidates.isEmpty())
+            return null
+
+        return Context(refElement.text, candidates)
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        val file = editor.toPsiFile(project) as? ElmFile ?: error("no file: should not happen")
+        when (context.candidates.size) {
+            0 -> error("should not happen: must be at least one candidate")
+            1 -> addImportForCandidate(context.candidates.first(), file, context)
+            else -> promptToSelectCandidate(context, file)
+        }
+    }
+
+    private fun addImportForCandidate(candidate: Candidate, file: ElmFile, context: Context) {
+        val factory = ElmPsiFactory(file.project)
+        val newImport = if (context.importAsQualified)
+            factory.createImport(candidate.moduleName)
+        else
+            factory.createImportExposing(candidate.moduleName, listOf(candidate.nameForImport))
+
+        // TODO [kl] find existing import
+        val existingImport: ElmImportClause? = null
+        if (existingImport != null) {
+            // merge with existing import
+            // TODO [kl]
+        } else {
+            // insert a new import clause
+            val insertPosition = getInsertPosition(file, candidate.moduleName)
+            doInsert(newImport, insertPosition)
+        }
+    }
+
+    private fun getInsertPosition(file: ElmFile, moduleName: String): ASTNode {
+        val existingImportClauses = ModuleScope(file).getImportDecls()
+        return if (existingImportClauses.isEmpty())
+            prepareInsertInNewSection(file)
+        else
+            getSortedInsertPosition(moduleName, existingImportClauses.toList())
+    }
+
+    private fun prepareInsertInNewSection(sourceFile: ElmFile): ASTNode {
+        val project = sourceFile.project
+        val moduleDecl = sourceFile.getModuleDecl()
+
+        if (moduleDecl == null) {
+            // source file does not have an explicit module declaration
+            // so just insert at the front of the file.
+            return sourceFile.node.firstChildNode
+        } else {
+            // it does have a module decl, so find the right place to insert
+            // the import after the module decl
+
+            // import clauses must come *after* module documentation comments
+            val importSectionAnchor = skipOverDocComments(moduleDecl)
+
+            // insert blanklines flanking the new import section
+            val newFreshline = ElmPsiFactory(project).createFreshLine().getNode()
+            sourceFile.node.addChild(newFreshline, importSectionAnchor!!.node)
+            val newFreshline2 = ElmPsiFactory(project).createFreshLine().getNode()
+            sourceFile.node.addChild(newFreshline2, newFreshline)
+            return newFreshline.treeNext
+        }
+    }
+
+    private fun skipOverDocComments(startElement: PsiElement): PsiElement? {
+        val elt = startElement.nextSibling
+                ?: return startElement
+
+        if (elt is PsiComment)
+            if (elt.tokenType === START_DOC_COMMENT)
+                return PsiTreeUtil.skipSiblingsForward(elt, PsiComment::class.java)
+
+        return elt
+    }
+
+    private fun compareImportAndModule(importClause: ElmImportClause, moduleName: String): Int {
+        return importClause.moduleQID.text.compareTo(moduleName)
+    }
+
+    private fun getSortedInsertPosition(moduleName: String, existingImportClauses: List<ElmImportClause>): ASTNode {
+        // NOTE: we *assume* that the imports are already sorted and we
+        // do not make any distinction between import groups/sections
+        // (e.g. the practice of putting core libs in the first group,
+        // 3rd party libs in a second group, and project files in the
+        // final group).
+
+        val firstImport = existingImportClauses[0]
+        val lastImport = existingImportClauses[existingImportClauses.size - 1]
+
+        return when {
+            compareImportAndModule(firstImport, moduleName) >= 0 ->
+                firstImport.node
+
+            compareImportAndModule(lastImport, moduleName) < 0 ->
+                lastImport.node.treeNext
+
+            else ->
+                // find the correct position somewhere in the middle
+                // TODO [kl] simplify this ordering logic (code was ported from Java 8)
+                existingImportClauses
+                        .zip(existingImportClauses.subList(1, existingImportClauses.size))
+                        .filter({ pair -> compareImportAndModule(pair.first, moduleName) < 0
+                                       && compareImportAndModule(pair.second, moduleName) >= 0 })
+                        .map({ pair -> pair.second.node })
+                        .firstOrNull()
+                        ?: error("should not happen: import not found in the middle")
+        }
+    }
+
+    private fun doInsert(importClause: ElmImportClause, insertPosition: ASTNode) {
+        val project = importClause.project
+        val parent = insertPosition.treeParent
+        val beforeInsertPosition = insertPosition.treePrev
+
+        // ensure that a freshline exists immediately following
+        // where we are going to insert the new import clause.
+        var prevFreshline: ASTNode? = null
+        if (insertPosition.elementType !== ElmTypes.NEWLINE) {
+            prevFreshline = ElmPsiFactory(project).createFreshLine().getNode()
+            parent.addChild(prevFreshline!!, insertPosition)
+        } else {
+            prevFreshline = insertPosition
+        }
+
+        // insert the import clause before the freshline
+        parent.addChild(importClause.node, prevFreshline)
+
+        // ensure that freshline exists *before* the new import clause
+        if (beforeInsertPosition != null && beforeInsertPosition.elementType !== ElmTypes.NEWLINE) {
+            val newFreshline = ElmPsiFactory(project).createFreshLine().getNode()
+            parent.addChild(newFreshline, importClause.node)
+        }
+    }
+
+    private fun promptToSelectCandidate(context: Context, file: ElmFile) {
+        // TODO implement me
+        throw UnsupportedOperationException("not implemented")
+    }
+}
+
+
+/**
+ * @param moduleName    the module where this value/type lives
+ * @param name          the name of the value/type
+ * @param nameForImport the name suitable for insert into an exposing clause.
+ *                      Typically this is the same as `name`, but when importing
+ *                      a bare union type member, it will be the parenthesized
+ *                      form: "TypeName(MemberName)"
+ * @param targetElement the value/type element in the module-to-be-imported
+ */
+data class Candidate(
+        val moduleName: String,
+        val name: String,
+        val nameForImport: String,
+        val targetElement: ElmNamedElement) {
+
+    companion object {
+
+        /**
+         * Returns a candidate if the named element is exposed by its containing module
+         */
+        fun fromNamedElement(element: ElmNamedElement): Candidate? {
+            val moduleDecl = element.elmFile.getModuleDecl() ?: return null
+            val exposingList = moduleDecl.exposingList ?: return null
+            val name = element.name!!
+            return if (moduleDecl.exposesAll || exposingList.exposesName(name))
+                Candidate(
+                        moduleName = moduleDecl.name,
+                        name = name,
+                        nameForImport = name,
+                        targetElement = element)
+            else
+                null
+        }
+    }
+}

--- a/src/main/kotlin/org/elm/ide/intentions/MergeImports.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MergeImports.kt
@@ -1,0 +1,74 @@
+package org.elm.ide.intentions
+
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.elements.ElmExposedType
+import org.elm.lang.core.psi.elements.ElmExposingList
+import org.elm.lang.core.psi.elements.ElmImportClause
+
+
+fun mergeImports(sourceFile: ElmFile, import1: ElmImportClause, import2: ElmImportClause): ElmImportClause {
+    require(import1.moduleQID.text == import2.moduleQID.text)
+
+    val project = sourceFile.getProject()
+    val exposing1 = import1.exposingList
+    val exposing2 = import2.exposingList
+
+    // merge and sort each import's exposing clauses
+    val exposedNames = sequenceOf(
+            mergeExposedValues(exposing1, exposing2),
+            mergeExposedTypes(exposing1, exposing2)
+    ).flatten().toList().sorted()
+
+    // generate the new, merged import statement
+    val moduleName = import1.moduleQID.text
+    val modulePlusAlias = moduleName + mergeAliasClause(import1, import2)
+    return ElmPsiFactory(project).createImportExposing(modulePlusAlias, exposedNames)
+}
+
+
+private fun mergeAliasClause(import1: ElmImportClause, import2: ElmImportClause): String {
+    return (import1.asClause ?: import2.asClause)
+            ?.let { " as " + it.name }
+            ?: ""
+}
+
+
+private fun mergeExposedValues(exposing1: ElmExposingList?, exposing2: ElmExposingList?): List<String> {
+    return sequenceOf(
+            exposing1?.exposedValueList ?: emptyList(),
+            exposing2?.exposedValueList ?: emptyList()
+    )
+            .flatten()
+            .map { it.lowerCaseIdentifier.text }
+            .toList()
+            .sorted()
+}
+
+
+private fun mergeExposedTypes(exposing1: ElmExposingList?, exposing2: ElmExposingList?): List<String> {
+    val exposedUnionsByName: Map<String, List<ElmExposedType>> =
+            sequenceOf(
+                    exposing1?.exposedTypeList ?: emptyList(),
+                    exposing2?.exposedTypeList ?: emptyList()
+            ).flatten().groupBy { it.referenceName }
+
+    return exposedUnionsByName
+            .map { (typeName, types) -> mergeExposedUnionConstructors(typeName, types) }
+}
+
+
+private fun mergeExposedUnionConstructors(typeName: String, types: List<ElmExposedType>): String {
+    if (types.any { it.exposesAll })
+        return typeName + "(..)"
+
+    val body = types
+            .map { it.exposedUnionConstructors }
+            .filterNotNull()
+            .flatMap { it.exposedUnionConstructors }
+            .map { it.text }
+            .sorted()
+            .joinToString(", ")
+
+    return if (body.isEmpty()) typeName else "$typeName($body)"
+}

--- a/src/main/kotlin/org/elm/ide/navigation/ElmGoToSymbolContributor.kt
+++ b/src/main/kotlin/org/elm/ide/navigation/ElmGoToSymbolContributor.kt
@@ -4,8 +4,6 @@ import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.stubs.StubIndex
-import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.stubs.index.ElmNamedElementIndex
 
 
@@ -14,7 +12,7 @@ class ElmGoToSymbolContributor: ChooseByNameContributor {
 
     override fun getNames(project: Project?, includeNonProjectItems: Boolean): Array<out String> {
         project ?: return emptyArray()
-        return StubIndex.getInstance().getAllKeys(indexKey, project).toTypedArray()
+        return ElmNamedElementIndex.getAllNames(project).toTypedArray()
     }
 
 
@@ -22,20 +20,15 @@ class ElmGoToSymbolContributor: ChooseByNameContributor {
                                 pattern: String?,
                                 project: Project?,
                                 includeNonProjectItems: Boolean): Array<out NavigationItem> {
-
-        if (project == null || name == null) {
+        if (project == null || name == null)
             return emptyArray()
-        }
+
         val scope = if (includeNonProjectItems)
             GlobalSearchScope.allScope(project)
         else
             GlobalSearchScope.projectScope(project)
 
-        return StubIndex.getElements(indexKey, name, project, scope, ElmNamedElement::class.java)
+        return ElmNamedElementIndex.find(name, project, scope)
                 .toTypedArray<NavigationItem>()
-    }
-
-    companion object {
-        private val indexKey = ElmNamedElementIndex.KEY
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.TokenType.WHITE_SPACE
 import com.intellij.psi.tree.IElementType
 import org.elm.lang.core.ElmFileType
 import org.elm.lang.core.psi.ElmTypes.ANONYMOUS_FUNCTION
@@ -212,6 +213,24 @@ class ElmPsiFactory(private val project: Project)
     fun createOperatorIdentifier(text: String): PsiElement =
             createFromText("foo = x $text y", OPERATOR_IDENTIFIER)
                     ?: error("Failed to create operator identifier: `$text`")
+
+    fun createImport(moduleName: String) =
+            "import $moduleName"
+                    .let { createFromText<ElmImportClause>(it) }
+                    ?: error("Failed to create import of $moduleName")
+
+    fun createImportExposing(moduleName: String, exposedNames: List<String>) =
+            "import $moduleName exposing (${exposedNames.joinToString(", ")})"
+                    .let { createFromText<ElmImportClause>(it) }
+                    ?: error("Failed to create import of $moduleName exposing $exposedNames")
+
+    fun createFreshLine() =
+            // TODO [kl] make this more specific by actually find a token which contains
+            // newline, not just any whitespace
+            PsiFileFactory.getInstance(project)
+                    .createFileFromText("DUMMY.elm", ElmFileType, "\n")
+                    .descendantOfType(WHITE_SPACE)
+                    ?: error("failed to create fresh line: should never happen")
 
     private inline fun <reified T : PsiElement> createFromText(code: String): T? =
             PsiFileFactory.getInstance(project)

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -67,14 +67,14 @@ inline fun <reified T : PsiElement> PsiElement.descendantsOfType(): Collection<T
 fun PsiFile.descendantOfType(elementType: IElementType): PsiElement? {
     // TODO [kl] surely IntelliJ provides a util function for finding a Psi leaf of a specific type?
     val stack = Stack<ASTNode>()
-    stack.addAll(children.map { it.node }.toList())
+    stack.addAll(node.getChildren(null))
 
     while (stack.isNotEmpty()) {
-        val node = stack.pop()
-        if (node.elementType == elementType)
-            return node.psi
+        val candidate = stack.pop()
+        if (candidate.elementType == elementType)
+            return candidate.psi
         else
-            stack.addAll(node.getChildren(null))
+            stack.addAll(candidate.getChildren(null))
     }
     return null
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmStubbedElement
 import org.elm.lang.core.psi.ElmTypes.DOUBLE_DOT
-import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.stubs.ElmExposingListStub
 
 
@@ -30,13 +29,4 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
 
     val exposedOperatorList: List<ElmExposedOperator>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, ElmExposedOperator::class.java)
-
-    /**
-     * Returns true if [name] can be found in the list of exposed values, constructors and types
-     */
-    fun exposesName(name: String): Boolean =
-            sequenceOf<List<ElmReferenceElement>>(exposedValueList, exposedTypeList, exposedOperatorList)
-                    .flatten()
-                    .map { it.referenceName }
-                    .contains(name)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmStubbedElement
 import org.elm.lang.core.psi.ElmTypes.DOUBLE_DOT
+import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.stubs.ElmExposingListStub
 
 
@@ -29,4 +30,13 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
 
     val exposedOperatorList: List<ElmExposedOperator>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, ElmExposedOperator::class.java)
+
+    /**
+     * Returns true if [name] can be found in the list of exposed values, constructors and types
+     */
+    fun exposesName(name: String): Boolean =
+            sequenceOf<List<ElmReferenceElement>>(exposedValueList, exposedTypeList, exposedOperatorList)
+                    .flatten()
+                    .map { it.referenceName }
+                    .contains(name)
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -22,7 +22,7 @@ class ImportScope(val elmFile: ElmFile) {
          * Returns an [ImportScope] for the module which is being imported by [importDecl].
          */
         fun fromImportDecl(importDecl: ElmImportClause): ImportScope? {
-            val moduleName = importDecl.moduleQID.upperCaseIdentifierList.joinToString(".") { it.text }
+            val moduleName = importDecl.moduleQID.text
             return ElmModulesIndex.get(moduleName, importDecl.project)
                     ?.let { ImportScope(it.elmFile) }
         }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -5,7 +5,6 @@ import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.descendantsOfType
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
-import org.elm.lang.core.psi.elements.ElmUpperCaseQID
 
 
 /**
@@ -16,9 +15,6 @@ import org.elm.lang.core.psi.elements.ElmUpperCaseQID
  * @see ImportScope for the view of the module from the outside
  */
 class ModuleScope(val elmFile: ElmFile) {
-
-    private fun toName(moduleQID: ElmUpperCaseQID) =
-            moduleQID.upperCaseIdentifierList.joinToString(".") { it.text }
 
     fun getImportDecls() =
             elmFile.descendantsOfType<ElmImportClause>()
@@ -34,7 +30,7 @@ class ModuleScope(val elmFile: ElmFile) {
      */
     fun importDeclForQualifierPrefix(qualifierPrefix: String) =
             getImportDecls().find {
-                toName(it.moduleQID) == qualifierPrefix || it.asClause?.name == qualifierPrefix
+                it.moduleQID.text == qualifierPrefix || it.asClause?.name == qualifierPrefix
             }
 
 

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmNamedElementIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmNamedElementIndex.kt
@@ -1,6 +1,9 @@
 package org.elm.lang.core.stubs.index
 
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.stubs.ElmFileStub
@@ -16,5 +19,17 @@ class ElmNamedElementIndex: StringStubIndexExtension<ElmNamedElement>() {
     companion object {
         val KEY: StubIndexKey<String, ElmNamedElement> =
                 StubIndexKey.createIndexKey("org.elm.lang.core.stubs.index.ElmNamedElementIndex")
+
+        /**
+         * Find all [ElmNamedElement]s whose name matches [name] in [scope].
+         */
+        fun find(name: String, project: Project, scope: GlobalSearchScope): Collection<ElmNamedElement> =
+                StubIndex.getElements(KEY, name, project, scope, ElmNamedElement::class.java)
+
+        /**
+         * Get the name of every element stored in this index.
+         */
+        fun getAllNames(project: Project): Collection<String> =
+                StubIndex.getInstance().getAllKeys(KEY, project)
     }
 }

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -1,0 +1,110 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ *
+ * From intellij-rust
+ */
+
+package org.elm.openapiext
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.util.RecursionManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.util.io.systemIndependentPath
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+
+fun <T> Project.runWriteCommandAction(command: () -> T): T {
+    return WriteCommandAction.runWriteCommandAction(this, Computable<T> { command() })
+}
+
+val Project.modules: Collection<Module>
+    get() = ModuleManager.getInstance(this).modules.toList()
+
+
+fun <T> recursionGuard(key: Any, block: Computable<T>, memoize: Boolean = true): T? =
+        RecursionManager.doPreventingRecursion(key, memoize, block)
+
+
+fun checkWriteAccessAllowed() {
+    check(ApplicationManager.getApplication().isWriteAccessAllowed) {
+        "Needs write action"
+    }
+}
+
+fun checkReadAccessAllowed() {
+    check(ApplicationManager.getApplication().isReadAccessAllowed) {
+        "Needs read action"
+    }
+}
+
+fun checkIsBackgroundThread() {
+    check(!ApplicationManager.getApplication().isDispatchThread) {
+        "Long running operation invoked on UI thread"
+    }
+}
+
+fun fullyRefreshDirectory(directory: VirtualFile) {
+    VfsUtil.markDirtyAndRefresh(/* async = */ false, /* recursive = */ true, /* reloadChildren = */ true, directory)
+}
+
+fun VirtualFile.findFileByMaybeRelativePath(path: String): VirtualFile? =
+        if (FileUtil.isAbsolute(path))
+            fileSystem.findFileByPath(path)
+        else
+            findFileByRelativePath(path)
+
+val VirtualFile.pathAsPath: Path get() = Paths.get(path)
+
+fun VirtualFile.toPsiFile(project: Project): PsiFile? =
+        PsiManager.getInstance(project).findFile(this)
+
+fun Editor.toPsiFile(project: Project): PsiFile? =
+        PsiDocumentManager.getInstance(project).getPsiFile(document)
+
+
+@Suppress("FunctionName")
+fun GeneralCommandLine(path: Path, vararg args: String) = GeneralCommandLine(path.systemIndependentPath, *args)
+
+fun GeneralCommandLine.withWorkDirectory(path: Path?) = withWorkDirectory(path?.systemIndependentPath)
+
+
+inline fun <Key, reified Psi : PsiElement> getElements(
+        indexKey: StubIndexKey<Key, Psi>,
+        key: Key, project: Project,
+        scope: GlobalSearchScope?
+): Collection<Psi> =
+        StubIndex.getElements(indexKey, key, project, scope, Psi::class.java)
+
+
+class CachedVirtualFile(private val url: String) {
+    private val cache = AtomicReference<VirtualFile>()
+
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): VirtualFile? {
+        val cached = cache.get()
+        if (cached != null && cached.isValid) return cached
+        val file = VirtualFileManager.getInstance().findFileByUrl(url)
+        cache.set(file)
+        return file
+    }
+}

--- a/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.intentions
 
+import com.intellij.openapi.vfs.VirtualFileFilter
 import org.elm.fileTreeFromText
 import org.intellij.lang.annotations.Language
 
@@ -138,11 +139,19 @@ module Foo exposing ()
 bar = 42
 """)
 
+
     protected fun check(@Language("Elm") before: String, @Language("Elm") after: String) {
-        fileTreeFromText(before).createAndOpenFileWithCaretMarker()
+        val testProject = fileTreeFromText(before).createAndOpenFileWithCaretMarker()
+
+        // auto-adding an import must be done using stubs only
+        checkAstNotLoaded(VirtualFileFilter { file ->
+            !file.path.endsWith(testProject.fileWithCaret)
+        })
+
         myFixture.launchAction(intention)
         myFixture.checkResult(replaceCaretMarker(after).trim())
     }
+
 
     protected fun verifyUnavailable(@Language("Elm") before: String) {
         fileTreeFromText(before).createAndOpenFileWithCaretMarker()

--- a/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
@@ -1,0 +1,58 @@
+package org.elm.ide.intentions
+
+import org.elm.fileTreeFromText
+import org.intellij.lang.annotations.Language
+
+class ElmImportIntentionTest: ElmIntentionTestBase(ElmImportIntentionAction()) {
+
+
+    fun `test un-qualified value`() = check(
+"""
+--@ main.elm
+main = bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""",
+"""
+import Foo exposing (bar)
+main = bar
+""")
+
+
+    fun `test qualified value`() = check(
+"""
+--@ main.elm
+main = Foo.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""",
+"""
+import Foo
+main = Foo.bar
+""")
+
+
+    fun `test verify unavailable when value not exposed`() = verifyUnavailable(
+"""
+--@ main.elm
+main = bar{-caret-}
+--@ Foo.elm
+module Foo exposing ()
+bar = 42
+""")
+
+    protected fun check(@Language("Elm") before: String, @Language("Elm") after: String) {
+        fileTreeFromText(before).createAndOpenFileWithCaretMarker()
+        myFixture.launchAction(intention)
+        myFixture.checkResult(replaceCaretMarker(after).trim())
+    }
+
+    protected fun verifyUnavailable(@Language("Elm") before: String) {
+        fileTreeFromText(before).createAndOpenFileWithCaretMarker()
+        check(intention.familyName !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
+            "\"$intention\" intention should not be available"
+        }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
@@ -68,6 +68,21 @@ main = Foo.bar{-caret-}
 """.trimStart())
 
 
+    fun `test expose a value with existing import`() = check(
+"""
+--@ main.elm
+import Foo
+main = bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""",
+"""
+import Foo exposing (bar)
+main = bar
+""")
+
+
     fun `test merge with existing exposed values`() = check(
 """
 --@ main.elm

--- a/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
@@ -35,6 +35,20 @@ main = Foo.bar
 """)
 
 
+    fun `test binary operator`() = check(
+"""
+--@ main.elm
+main = 2 **{-caret-} 3
+--@ Foo.elm
+module Foo exposing ((**))
+(**) a b = a ^ b
+""",
+"""
+import Foo exposing ((**))
+main = 2 ** 3
+""")
+
+
     fun `test import between module decl and value-decl`() = check(
 """
 --@ main.elm

--- a/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
@@ -130,6 +130,25 @@ main = Settings
 """)
 
 
+    fun `test insert import after import`() = check(
+"""
+--@ main.elm
+import Foo exposing (bar)
+main = bar + quux{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+--@ Quux.elm
+module Quux exposing (quux)
+quux = 99
+""",
+"""
+import Foo exposing (bar)
+import Quux exposing (quux)
+main = bar + quux
+""")
+
+
     fun `test verify unavailable when value not exposed`() = verifyUnavailable(
 """
 --@ main.elm

--- a/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmImportIntentionTest.kt
@@ -34,6 +34,86 @@ main = Foo.bar
 """)
 
 
+    fun `test import between module decl and value-decl`() = check(
+"""
+--@ main.elm
+module Main exposing (..)
+main = Foo.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""".trimStart(),
+"""
+module Main exposing (..)
+import Foo
+main = Foo.bar{-caret-}
+""".trimStart())
+
+
+    fun `test import between module decl and doc-comment`() = check(
+"""
+--@ main.elm
+module Main exposing (..)
+{-| this is a doc comment. it must be above imports -}
+main = Foo.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""".trimStart(),
+"""
+module Main exposing (..)
+{-| this is a doc comment. it must be above imports -}
+import Foo
+main = Foo.bar{-caret-}
+""".trimStart())
+
+
+    fun `test merge with existing exposed values`() = check(
+"""
+--@ main.elm
+import Foo exposing (quux)
+main = quux + bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar, quux)
+bar = 42
+quux = 99
+""",
+"""
+import Foo exposing (bar, quux)
+main = quux + bar
+""")
+
+
+    fun `test merge with existing exposed union constructors`() = check(
+"""
+--@ main.elm
+import App exposing (Page(Home))
+main = Settings{-caret-}
+--@ App.elm
+module App exposing (Page(..))
+type Page = Home | Settings
+""",
+"""
+import App exposing (Page(Home, Settings))
+main = Settings
+""")
+
+
+    fun `test merge with existing exposed union type`() = check(
+"""
+--@ main.elm
+import App exposing (Page)
+main = Settings{-caret-}
+--@ App.elm
+module App exposing (Page(..))
+type Page = Home | Settings
+""",
+"""
+import App exposing (Page(Settings))
+main = Settings
+""")
+
+
     fun `test verify unavailable when value not exposed`() = verifyUnavailable(
 """
 --@ main.elm

--- a/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ *
+ * From intellij-rust
+ */
+
+package org.elm.ide.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.elm.lang.ElmTestBase
+import org.intellij.lang.annotations.Language
+
+
+abstract class ElmIntentionTestBase(val intention: IntentionAction) : ElmTestBase() {
+
+    protected fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
+        InlineFile(before).withCaret()
+        myFixture.launchAction(intention)
+        myFixture.checkResult(replaceCaretMarker(after))
+    }
+
+    protected fun doUnavailableTest(@Language("Rust") before: String) {
+        InlineFile(before).withCaret()
+        check(intention.familyName !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
+            "\"$intention\" intention should not be available"
+        }
+    }
+}


### PR DESCRIPTION
This adds a new 'import' action when you press option-enter on an unresolved reference. It generates an appropriate import statement and inserts it at the top of the file.