### PR TITLE
Add an intention to create a function skeleton from a type annotation

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -5,7 +5,9 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import org.elm.ide.intentions.ElmImportIntentionAction
+import org.elm.ide.intentions.ElmMakeDeclarationIntentionAction
 import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
 import org.elm.lang.core.psi.elements.ElmUpperCaseQID
 import org.elm.lang.core.psi.elements.ElmValueExpr
 import org.elm.lang.core.psi.elements.ElmValueQID
@@ -15,12 +17,19 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         for (ref in element.references) {
-            if (ref.resolve() == null && !safeToIgnore(ref, element)) {
-                // TODO [kl] make this smarter in the case of qualified references
-                // so that we don't report a double error when really the problem
-                // is with the qualified module name reference.
-                holder.createErrorAnnotation(element, "Unresolved reference '${ref.canonicalText}'")
-                        .also { it.registerFix(ElmImportIntentionAction()) }
+            if (ref.resolve() == null) {
+
+                if (element is ElmTypeAnnotation) {
+                    holder.createWeakWarningAnnotation(element, "'${ref.canonicalText}' does not exist")
+                            .also { it.registerFix(ElmMakeDeclarationIntentionAction()) }
+                }
+                else if (!safeToIgnore(ref, element)) {
+                    // TODO [kl] make this smarter in the case of qualified references
+                    // so that we don't report a double error when really the problem
+                    // is with the qualified module name reference.
+                    holder.createErrorAnnotation(element, "Unresolved reference '${ref.canonicalText}'")
+                            .also { it.registerFix(ElmImportIntentionAction()) }
+                }
             }
         }
     }

--- a/src/main/kotlin/org/elm/ide/intentions/ElmImportIntentionAction.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmImportIntentionAction.kt
@@ -33,15 +33,13 @@ import java.awt.Component
 import javax.swing.DefaultListCellRenderer
 import javax.swing.JList
 
+class ElmImportIntentionAction: ElmAtCaretIntentionActionBase<ElmImportIntentionAction.Context>() {
 
-data class Context(
-        val refName: String,
-        val candidates: List<Candidate>,
-        val isQualified: Boolean
-)
-
-
-class ElmImportIntentionAction: ElmAtCaretIntentionActionBase<Context>() {
+    data class Context(
+            val refName: String,
+            val candidates: List<Candidate>,
+            val isQualified: Boolean
+    )
 
     override fun getText() = "Import"
     override fun getFamilyName() = text

--- a/src/main/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionAction.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionAction.kt
@@ -1,0 +1,95 @@
+package org.elm.ide.intentions
+
+import com.intellij.codeInsight.template.Template
+import com.intellij.codeInsight.template.TemplateManager
+import com.intellij.codeInsight.template.impl.TextExpression
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.elements.ElmParametricTypeRef
+import org.elm.lang.core.psi.elements.ElmRecordType
+import org.elm.lang.core.psi.elements.ElmTupleType
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
+import org.elm.lang.core.psi.elements.ElmTypeRef
+import org.elm.lang.core.psi.elements.ElmTypeVariableRef
+import org.elm.lang.core.psi.elements.ElmUpperPathTypeRef
+import org.elm.lang.core.psi.parentOfType
+
+class ElmMakeDeclarationIntentionAction: ElmAtCaretIntentionActionBase<ElmMakeDeclarationIntentionAction.Context>() {
+
+    data class Context(val typeAnnotation: ElmTypeAnnotation)
+
+    override fun getText() = "Create"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val typeAnnotation = element.parentOfType<ElmTypeAnnotation>()
+            ?: return null
+
+        if (typeAnnotation.reference.resolve() != null) {
+            // the target declaration already exists; nothing needs to be done
+            return null
+        }
+
+        return Context(typeAnnotation)
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        object : WriteCommandAction.Simple<Unit>(project) {
+            override fun run() {
+                generateDecl(project, editor, context)
+            }
+        }.execute()
+    }
+
+    private fun generateDecl(project: Project, editor: Editor, context: Context) {
+        val typeAnnotation = context.typeAnnotation
+        val factory = ElmPsiFactory(project)
+
+        typeAnnotation.parent.addAfter(factory.createFreshLine(), typeAnnotation)
+        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+        editor.caretModel.moveCaretRelatively(0, 1, false, false, false)
+
+        val template = generateTemplate(project, editor, context)
+        TemplateManager.getInstance(project).startTemplate(editor, template)
+    }
+
+    private fun generateTemplate(project: Project, editor: Editor, context: Context): Template {
+        val templateManager = TemplateManager.getInstance(project)
+        val template = templateManager.createTemplate("", "")
+        template.isToReformat = true
+
+        val typeAnnotation = context.typeAnnotation
+        val name = typeAnnotation.referenceName
+        template.addTextSegment("$name ")
+
+        val typeRef = typeAnnotation.typeRef
+        val args: List<String> = if (typeRef == null) {
+            emptyList()
+        } else {
+            typeRef.children.dropLast(1).map {
+                when(it) {
+                    is ElmUpperPathTypeRef -> it.upperCaseQID.text
+                    is ElmTypeVariableRef -> it.text
+                    is ElmParametricTypeRef -> it.upperCaseQID.text
+                    is ElmRecordType -> "record"
+                    is ElmTupleType -> "tuple"
+                    is ElmTypeRef -> "function" // not quite true: need to check for an ARROW child
+                    else -> "?"
+                }.toLowerCase()
+            }
+        }
+
+        for (arg in args) {
+            template.addVariable(TextExpression(arg), true)
+            template.addTextSegment(" ")
+        }
+
+        template.addTextSegment("= ")
+        template.addEndVariable()
+        return template
+    }
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -224,6 +224,15 @@ class ElmPsiFactory(private val project: Project)
                     .let { createFromText<ElmImportClause>(it) }
                     ?: error("Failed to create import of $moduleName exposing $exposedNames")
 
+    fun createValueDeclaration(name: String, argNames: List<String>): ElmValueDeclaration {
+        val s = if (argNames.isEmpty())
+            "$name = "
+        else
+            "$name ${argNames.joinToString(" ")} = "
+        return createFromText(s)
+                ?: error("Failed to create value declaration named $name")
+    }
+
     fun createFreshLine() =
             // TODO [kl] make this more specific by actually find a token which contains
             // newline, not just any whitespace

--- a/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
@@ -48,4 +48,12 @@ f = Native.Scheduler.succeed
 <error descr="Unresolved reference 'Foo.Native'">import Foo.Native</error>
 f = <error descr="Unresolved reference 'Foo.Native'"><error descr="Unresolved reference 'foobar'">Foo.Native.foobar</error></error>
 """)
+
+
+    fun `test type annotation refs have warning`() = checkWarnings("""
+<weak_warning descr="'f' does not exist">f : Int -> Bool</weak_warning>
+
+g : Int
+g = 0
+""")
 }

--- a/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
@@ -14,13 +14,13 @@ import org.intellij.lang.annotations.Language
 
 abstract class ElmIntentionTestBase(val intention: IntentionAction) : ElmTestBase() {
 
-    protected fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
+    protected fun doAvailableTest(@Language("Elm") before: String, @Language("Elm") after: String) {
         InlineFile(before).withCaret()
         myFixture.launchAction(intention)
         myFixture.checkResult(replaceCaretMarker(after))
     }
 
-    protected fun doUnavailableTest(@Language("Rust") before: String) {
+    protected fun doUnavailableTest(@Language("Elm") before: String) {
         InlineFile(before).withCaret()
         check(intention.familyName !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
             "\"$intention\" intention should not be available"

--- a/src/test/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionTest.kt
@@ -1,0 +1,39 @@
+package org.elm.ide.intentions
+
+class ElmMakeDeclarationIntentionTest: ElmIntentionTestBase(ElmMakeDeclarationIntentionAction()) {
+
+
+    fun `test make value declaration`() {
+        doAvailableTest(
+"""
+f : Int{-caret-}
+"""
+, """
+f : Int
+f = {-caret-}
+""")}
+
+
+    fun `test make basic function declaration`() {
+        doAvailableTest(
+"""
+f : Int -> Int{-caret-}
+"""
+, """
+f : Int -> Int
+f int = {-caret-}
+""")}
+
+
+    fun `test make advanced function declaration`() {
+        doAvailableTest(
+"""
+f : (Int -> Int) -> List a -> (Char, String) -> { foo : Int } -> Bool{-caret-}
+"""
+, """
+f : (Int -> Int) -> List a -> (Char, String) -> { foo : Int } -> Bool
+f function list tuple record = {-caret-}
+""")}
+
+
+}


### PR DESCRIPTION
Unresolved type annotations are no longer marked as errors. Instead
they are marked as weak warnings and provide an intention/quick-fix
to generate the function declaration skeleton.

Fixes #26 