### PR TITLE
Added basic Elm-Live-Templates

### DIFF
--- a/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateContext.kt
+++ b/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateContext.kt
@@ -1,4 +1,4 @@
-package org.elm.ide
+package org.elm.ide.livetemplates
 
 import com.intellij.codeInsight.template.TemplateContextType
 import com.intellij.psi.PsiFile

--- a/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateProvider.kt
+++ b/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateProvider.kt
@@ -1,0 +1,9 @@
+package org.elm.ide.livetemplates
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider
+
+class ElmLiveTemplateProvider : DefaultLiveTemplatesProvider {
+    override fun getDefaultLiveTemplateFiles() = arrayOf("liveTemplates/Elm")
+
+    override fun getHiddenLiveTemplateFiles() = arrayOf<String>()
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,11 +60,14 @@
         <lang.psiStructureViewFactory language="Elm" implementationClass="org.elm.ide.structure.ElmStructureViewFactory" />
         <lang.refactoringSupport language="Elm" implementationClass="org.elm.lang.refactoring.ElmRefactoringSupportProvider" />
         <lang.syntaxHighlighterFactory language="Elm" implementationClass="org.elm.ide.highlight.ElmSyntaxHighlighterFactory"/>
-        <liveTemplateContext implementation="org.elm.ide.ElmLiveTemplateContext" />
         <spellchecker.support language="Elm" implementationClass="org.elm.ide.spelling.ElmSpellCheckingStrategy" />
         <stubElementTypeHolder class="org.elm.lang.core.psi.ElmTypes" />
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmModulesIndex" />
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmNamedElementIndex" />
+
+
+        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext" />
+        <defaultLiveTemplatesProvider implementation="org.elm.ide.livetemplates.ElmLiveTemplateProvider" />
     </extensions>
 
     <actions>

--- a/src/main/resources/liveTemplates/Elm.xml
+++ b/src/main/resources/liveTemplates/Elm.xml
@@ -1,0 +1,118 @@
+<templateSet group="Elm">
+  <template name="mod" value="module $NAME$ exposing ($EXPOSED$)&#10;&#10;$END$" description="Module Declaration" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="fileNameWithoutExtension()" defaultValue="" alwaysStopAt="false" />
+    <variable name="EXPOSED" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="fn0" value="$NAME$ : $RETURNTYPE$&#10;$NAME$ =&#10;    $END$ " description="Function with no arguments" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="camelCase(String)" defaultValue="" alwaysStopAt="true" />
+    <variable name="RETURNTYPE" expression="capitalize(String)" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="fn1" value="$NAME$ : $FIRSTTYPE$ -&gt; $RETURNTYPE$&#10;$NAME$ $FIRSTVAR$ =&#10;    $END$" description="Function with one argument" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="camelCase($NAME$)" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="RETURNTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTVAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="fn2" value="$NAME$ : $FIRSTTYPE$ -&gt; $SECONDTYPE$ -&gt; $RETURNTYPE$&#10;$NAME$ $FIRSTVAR$ $SECONDVAR$ =&#10;    $END$" description="Function with two arguments" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="camelCase($NAME$)" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="RETURNTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTVAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDVAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="fn3" value="$NAME$ : $FIRSTTYPE$ -&gt; $SECONDTYPE$ -&gt; $THIRDTYPE$ -&gt; $RETURNTYPE$&#10;$NAME$ $FIRSTVAR$ $SECONDVAR$ $THIRDVAR$ =&#10;    $END$" description="Function with three arguments" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="camelCase($NAME$)" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="THIRDTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="RETURNTYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTVAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDVAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="THIRDVAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="ty" value="type $NAME$&#10;    = $END$" description="Type Declaration" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="tya" value="type alias $NAME$&#10;    = $END$" description="Typealias Declaration on a single line" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="let1" value="let&#10;    $FIRSTNAME$ = $FIRSTEXP$&#10;in&#10;    $END$" description="Let expression with a single binding" toReformat="false" toShortenFQNames="true">
+    <variable name="FIRSTNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTEXP" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="let2" value="let&#10;    $FIRSTNAME$ = $FIRSTEXP$&#10;    $SECONDNAME$ = $SECONDEXP$&#10;in&#10;    $END$" description="Let expression with two bindings" toReformat="false" toShortenFQNames="true">
+    <variable name="FIRSTNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTEXP" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDEXP" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="let3" value="let&#10;    $FIRSTNAME$ = $FIRSTEXP$&#10;    $SECONDNAME$ = $SECONDEXP$&#10;    $THIRDNAME$ = $THIRDEXP$&#10;in&#10;    $END$" description="Let expression with three bindings" toReformat="false" toShortenFQNames="true">
+    <variable name="FIRSTNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTEXP" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDEXP" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="THIRDNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="THIRDEXP" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="case1" value="case $VAR$ of&#10;    $FIRSTCOND$ -&gt; &#10;        $FIRSTBRANCH$" description="Case Expression with one Branch" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTCOND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="case2" value="case $VAR$ of&#10;    $FIRSTCOND$ -&gt; &#10;        $FIRSTBRANCH$&#10;        &#10;    $SECONDCOND$ -&gt; &#10;        $SECONDBRANCH$&#10;" description="Case Expression with two Branches" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTCOND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDCOND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+  <template name="case3" value="case $VAR$ of&#10;    $FIRSTCOND$ -&gt; &#10;        $FIRSTBRANCH$&#10;        &#10;    $SECONDCOND$ -&gt; &#10;        $SECONDBRANCH$&#10;        &#10;    $THIRDCOND$ -&gt; &#10;        $THIRDBRANCH$" description="Case Expression with three Branches" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTCOND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIRSTBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDCOND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SECONDBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="THIRDCOND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="THIRDBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="ELM" value="true" />
+    </context>
+  </template>
+</templateSet>


### PR DESCRIPTION
This PR adds a couple of Live-Templates:

-  "fn0/1/2/3" to create a Function with 0, 1, 2 or 3 arguments
- "mod" to create a Module Declaration Line
- "ty" to create a Type
- "tya" to create a Type Alias
- "let1/2/3" to create a Let-Expression with 1, 2 or 3 variables
- "case1/2/3" to create a case expression with 1, 2 or 3 branches

All of those comply with the current elm-style-guide.
