### PR TITLE
Add clickable links to generated documentation

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -61,7 +61,7 @@ private fun documentationFor(decl: ElmFunctionDeclarationLeft): String? = buildS
                 append("\n")
                 b { append(decl.lowerCaseIdentifier.text) }
                 for (pat in decl.patternList) {
-                    append(" ").append(pat.text)
+                    append(" ", pat.text)
                 }
             }
             prev.skipWsAndVirtDeclsBackwards()?.let {
@@ -83,9 +83,9 @@ private fun documentationFor(decl: ElmTypeDeclaration): String? = buildString {
 
     definition {
         b { append("type") }
-        append(" ").append(name.text)
+        append(" ", name.text)
         for (type in types) {
-            append(" ").append(type.name)
+            append(" ", type.name)
         }
     }
 
@@ -93,9 +93,8 @@ private fun documentationFor(decl: ElmTypeDeclaration): String? = buildString {
 
     sections {
         section("Members") {
-            append("<p>")
             for (member in decl.unionMemberList) {
-                append("<p><code>${member.upperCaseIdentifier.text}</code>")
+                append("\n<p><code>${member.upperCaseIdentifier.text}</code>")
                 renderParameters(member.allParameters, " ", false, true)
             }
         }
@@ -122,9 +121,8 @@ private fun documentationFor(decl: ElmTypeAliasDeclaration): String? = buildStri
         if (recordTypes.isNotEmpty()) {
             sections {
                 section("Fields") {
-                    append("<p>")
                     for (type in recordTypes) {
-                        append("<p><code>${type.lowerCaseIdentifier.text}</code> : ")
+                        append("\n<p><code>${type.lowerCaseIdentifier.text}</code> : ")
                         appendDefinition(type.typeRef)
                     }
                 }
@@ -244,8 +242,7 @@ private inline fun StringBuilder.definition(block: () -> Unit) {
 }
 
 private inline fun StringBuilder.content(block: () -> Unit) {
-    append("\n") // just for html readability
-    append(DocumentationMarkup.CONTENT_START)
+    append("\n", DocumentationMarkup.CONTENT_START)
     block()
     append(DocumentationMarkup.CONTENT_END)
 }
@@ -257,13 +254,13 @@ private inline fun StringBuilder.b(block: () -> Unit) {
 }
 
 private inline fun StringBuilder.sections(block: StringBuilder.() -> Unit) {
-    append(DocumentationMarkup.SECTIONS_START)
+    append("\n", DocumentationMarkup.SECTIONS_START)
     block()
     append(DocumentationMarkup.SECTIONS_END)
 }
 
 private inline fun StringBuilder.section(title: String, block: StringBuilder.() -> Unit) {
-    append(DocumentationMarkup.SECTION_HEADER_START, title, ":", DocumentationMarkup.SECTION_SEPARATOR)
+    append(DocumentationMarkup.SECTION_HEADER_START, title, ":", DocumentationMarkup.SECTION_SEPARATOR, "<p>")
     block()
     append(DocumentationMarkup.SECTION_END)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmNamedElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmNamedElement.kt
@@ -1,10 +1,7 @@
 package org.elm.lang.core.psi
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.NavigatablePsiElement
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiNameIdentifierOwner
-import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.*
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
 import org.elm.ide.presentation.getPresentation
@@ -23,6 +20,13 @@ interface ElmNamedElement : ElmPsiElement, PsiNamedElement, NavigatablePsiElemen
 interface ElmNameIdentifierOwner : ElmNamedElement, PsiNameIdentifierOwner {
     override fun getNameIdentifier(): PsiElement
     override fun getName(): String
+}
+
+/** An element that can have an attached documentation comment */
+interface ElmDocTarget: ElmPsiElement {
+    /** The doc comment for this element, or `null` if there isn't one. */
+    val docComment: PsiComment?
+        get() = (prevSiblings.withoutWs.firstOrNull() as? PsiComment)?.takeIf { it.text.startsWith("{-|") }
 }
 
 

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -27,8 +27,10 @@ SOFTWARE.
 package org.elm.lang.core.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiUtilCore
@@ -41,6 +43,10 @@ val PsiElement.ancestors: Sequence<PsiElement> get() = generateSequence(this) { 
 val PsiElement.prevSiblings: Sequence<PsiElement> get() = generateSequence(prevSibling) { it.prevSibling }
 val PsiElement.nextSiblings: Sequence<PsiElement> get() = generateSequence(nextSibling) { it.nextSibling }
 val PsiElement.directChildren: Sequence<PsiElement> get() = generateSequence(firstChild) { it.nextSibling }
+val Sequence<PsiElement>.withoutWs
+    get() =
+        filter { it !is PsiWhiteSpace && it.elementType != ElmTypes.VIRTUAL_END_DECL }
+val Sequence<PsiElement>.withoutWsOrComments get() = withoutWs.filter { it !is PsiComment }
 
 
 /**

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -40,6 +40,7 @@ import kotlin.reflect.KClass
 val PsiElement.ancestors: Sequence<PsiElement> get() = generateSequence(this) { it.parent }
 val PsiElement.prevSiblings: Sequence<PsiElement> get() = generateSequence(prevSibling) { it.prevSibling }
 val PsiElement.nextSiblings: Sequence<PsiElement> get() = generateSequence(nextSibling) { it.nextSibling }
+val PsiElement.directChildren: Sequence<PsiElement> get() = generateSequence(firstChild) { it.nextSibling }
 
 
 /**

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
@@ -1,13 +1,13 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
-import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
-import org.elm.lang.core.psi.IdentifierCase
 import org.elm.lang.core.stubs.ElmFunctionDeclarationLeftStub
 
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmParametricTypeRef.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmParametricTypeRef.kt
@@ -37,7 +37,7 @@ class ElmParametricTypeRef(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenc
      *
      * The elements will be in source order, and will be any of the following types:
      *
-     * [ElmTypeVariableRef], [ElmRecordType], [ElmTupleType], [ElmTypeRef]
+     * [ElmUpperPathTypeRef], [ElmTypeVariableRef], [ElmRecordType], [ElmTupleType], [ElmTypeRef]
      */
     val allParameters: Sequence<ElmPsiElement>
         get() = directChildren.filterIsInstance<ElmPsiElement>().filter {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmParametricTypeRef.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmParametricTypeRef.kt
@@ -3,7 +3,9 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.ElmPsiElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.directChildren
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReference
 import org.elm.lang.core.resolve.reference.QualifiedModuleNameReference
@@ -30,23 +32,21 @@ class ElmParametricTypeRef(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenc
     val upperCaseQID: ElmUpperCaseQID
         get() = findNotNullChildByClass(ElmUpperCaseQID::class.java)
 
-
-    // TODO [kl] cleanup the Psi tree so that this isn't such a mess
-    val upperPathTypeRefList: List<ElmUpperPathTypeRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmUpperPathTypeRef::class.java)
-
-    val typeVariableRefList: List<ElmTypeVariableRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTypeVariableRef::class.java)
-
-    val recordTypeList: List<ElmRecordType>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmRecordType::class.java)
-
-    val tupleTypeList: List<ElmTupleType>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTupleType::class.java)
-
-    val typeRefList: List<ElmTypeRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTypeRef::class.java)
-
+    /**
+     * All parameters of the type.
+     *
+     * The elements will be in source order, and will be any of the following types:
+     *
+     * [ElmTypeVariableRef], [ElmRecordType], [ElmTupleType], [ElmTypeRef]
+     */
+    val allParameters: Sequence<ElmPsiElement>
+        get() = directChildren.filterIsInstance<ElmPsiElement>().filter {
+            it is ElmUpperPathTypeRef
+                    || it is ElmTypeVariableRef
+                    || it is ElmRecordType
+                    || it is ElmTupleType
+                    || it is ElmTypeRef
+        }
 
     override val referenceNameElement: PsiElement
         get() = upperCaseQID.upperCaseIdentifierList.last()
@@ -55,13 +55,14 @@ class ElmParametricTypeRef(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenc
         get() = referenceNameElement.text
 
     override fun getReference(): ElmReference =
-            getReferences().first()
+            references.first()
 
     override fun getReferences(): Array<ElmReference> {
-        return if (upperCaseQID.upperCaseIdentifierList.size > 1)
+        return if (upperCaseQID.upperCaseIdentifierList.size > 1) {
             arrayOf(QualifiedTypeReference(this, upperCaseQID),
                     QualifiedModuleNameReference(this, upperCaseQID))
-        else
+        } else {
             arrayOf(SimpleTypeReference(this))
+        }
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
@@ -1,13 +1,13 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
-import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
-import org.elm.lang.core.psi.IdentifierCase
 import org.elm.lang.core.stubs.ElmTypeAliasDeclarationStub
 
 
@@ -17,7 +17,7 @@ import org.elm.lang.core.stubs.ElmTypeAliasDeclarationStub
  * e.g. `type alias User = { name : String, age : Int }`
  *
  */
-class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarationStub> {
+class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarationStub>, ElmDocTarget {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.UPPER)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
@@ -49,7 +49,7 @@ class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarati
 
     /** `true` if the alias is exclusively a record */
     val isRecordAlias: Boolean
-        get() = aliasedRecord != null
+        get() = stub?.isRecordAlias ?: (aliasedRecord != null)
 
     /** The aliased record type if this alias is exclusively a record, or `null` otherwise. */
     val aliasedRecord: ElmRecordType?

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
@@ -49,5 +49,9 @@ class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarati
 
     /** `true` if the alias is exclusively a record */
     val isRecordAlias: Boolean
-        get() = stub?.isRecordAlias ?: (typeRef?.firstChild is ElmRecordType)
+        get() = aliasedRecord != null
+
+    /** The aliased record type if this alias is exclusively a record, or `null` otherwise. */
+    val aliasedRecord: ElmRecordType?
+        get() = typeRef?.firstChild as? ElmRecordType
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
@@ -47,12 +47,7 @@ class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarati
         get() = findChildByClass(ElmTypeRef::class.java)
 
 
-    // TODO [kl] this will be wrong in the case of a function type ref
-    // such as `Int -> { foo: String }`. We want to know that it is exclusively a record.
-    // We should see if we can get GrammarKit to parse [ElmTypeRef] into a better data structure
-    // than what Kamil had.
+    /** `true` if the alias is exclusively a record */
     val isRecordAlias: Boolean
-        get() = getStub()?.isRecordAlias
-                ?: typeRef?.recordTypeList?.isNotEmpty()
-                ?: false
+        get() = stub?.isRecordAlias ?: (typeRef?.firstChild is ElmRecordType)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeDeclaration.kt
@@ -1,12 +1,11 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
-import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
-import org.elm.lang.core.psi.ElmTypes
-import org.elm.lang.core.psi.IdentifierCase
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.stubs.ElmTypeDeclarationStub
 
 
@@ -20,7 +19,7 @@ import org.elm.lang.core.stubs.ElmTypeDeclarationStub
  * In which case, [lowerTypeNameList] would contain a single element representing the
  * type variable `a`.
  */
-class ElmTypeDeclaration : ElmStubbedNamedElementImpl<ElmTypeDeclarationStub> {
+class ElmTypeDeclaration : ElmStubbedNamedElementImpl<ElmTypeDeclarationStub>, ElmDocTarget {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.UPPER)
@@ -44,5 +43,4 @@ class ElmTypeDeclaration : ElmStubbedNamedElementImpl<ElmTypeDeclarationStub> {
      */
     val unionMemberList: List<ElmUnionMember>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, ElmUnionMember::class.java)
-
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeRef.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeRef.kt
@@ -1,27 +1,40 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.ElmPsiElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.directChildren
 
 
+/**
+ * A type reference.
+ *
+ * e.g.
+ *
+ *  - `Float`
+ *  - `Maybe a`
+ *  - `Int -> String`
+ *  - `a -> (a -> {a: String})`
+ */
 class ElmTypeRef(node: ASTNode) : ElmPsiElementImpl(node) {
 
-    val upperPathTypeRefList: List<ElmUpperPathTypeRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmUpperPathTypeRef::class.java)
-
-    val typeVariableRefList: List<ElmTypeVariableRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTypeVariableRef::class.java)
-
-    val recordTypeList: List<ElmRecordType>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmRecordType::class.java)
-
-    val tupleTypeList: List<ElmTupleType>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTupleType::class.java)
-
-    val parametricTypeRefList: List<ElmParametricTypeRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmParametricTypeRef::class.java)
-
-    val typeRefList: List<ElmTypeRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTypeRef::class.java)
+    /**
+     * All parameters of the type annotation.
+     *
+     * The elements will be in source order, and will be any of the following types:
+     *
+     * [ElmTypeVariableRef], [ElmRecordType], [ElmTupleType], [ElmParametricTypeRef], [ElmTypeRef]
+     *
+     * If the reference is not a function, there will be one parameter in well-formed programs. For functions, there
+     * will be one parameter per function argument, plus the return type.
+     */
+    val allParameters: Sequence<ElmPsiElement>
+        get() = directChildren.filterIsInstance<ElmPsiElement>().filter {
+            it is ElmUpperPathTypeRef
+                    || it is ElmTypeVariableRef
+                    || it is ElmRecordType
+                    || it is ElmTupleType
+                    || it is ElmParametricTypeRef
+                    || it is ElmTypeRef
+        }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionMember.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionMember.kt
@@ -4,9 +4,11 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.ElmPsiElement
 import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.IdentifierCase
+import org.elm.lang.core.psi.directChildren
 import org.elm.lang.core.stubs.ElmUnionMemberStub
 
 
@@ -23,16 +25,19 @@ class ElmUnionMember : ElmStubbedNamedElementImpl<ElmUnionMemberStub> {
     val upperCaseIdentifier: PsiElement
         get() = findNotNullChildByType(UPPER_CASE_IDENTIFIER)
 
-    val typeVariableRefList: List<ElmTypeVariableRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTypeVariableRef::class.java)
-
-    val recordTypeList: List<ElmRecordType>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmRecordType::class.java)
-
-    val tupleTypeList: List<ElmTupleType>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTupleType::class.java)
-
-    val typeRefList: List<ElmTypeRef>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmTypeRef::class.java)
-
+    /**
+     * All parameters of the member, if any.
+     *
+     * The elements will be in source order, and will be any of the following types:
+     *
+     * [ElmTypeVariableRef], [ElmRecordType], [ElmTupleType], [ElmTypeRef]
+     */
+    val allParameters: Sequence<ElmPsiElement>
+        get() = directChildren.filterIsInstance<ElmPsiElement>().filter {
+            it is ElmUpperPathTypeRef
+                    || it is ElmTypeVariableRef
+                    || it is ElmRecordType
+                    || it is ElmTupleType
+                    || it is ElmTypeRef
+        }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionMember.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionMember.kt
@@ -34,8 +34,7 @@ class ElmUnionMember : ElmStubbedNamedElementImpl<ElmUnionMemberStub> {
      */
     val allParameters: Sequence<ElmPsiElement>
         get() = directChildren.filterIsInstance<ElmPsiElement>().filter {
-            it is ElmUpperPathTypeRef
-                    || it is ElmTypeVariableRef
+            it is ElmTypeVariableRef
                     || it is ElmRecordType
                     || it is ElmTupleType
                     || it is ElmTypeRef

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -1,11 +1,11 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
-import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.ElmStubbedElement
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.stubs.ElmValueDeclarationStub
 
 
@@ -20,7 +20,7 @@ import org.elm.lang.core.stubs.ElmValueDeclarationStub
  * to a pattern, possibly introducing multiple top-level names.
  * e.g. `(x,y) = (0,0)`
  */
-class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub> {
+class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub>, ElmDocTarget {
 
     constructor(node: ASTNode) :
             super(node)
@@ -81,4 +81,12 @@ class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub> {
         return functionDeclarationLeft?.namedParameters
                 ?: emptyList()
     }
+
+    /** The type annotation for this function, or `null` if there isn't one. */
+    val typeAnnotation: ElmTypeAnnotation?
+        get() = prevSiblings.withoutWsOrComments.firstOrNull() as? ElmTypeAnnotation
+
+    override val docComment: PsiComment?
+        get() = (prevSiblings.withoutWs.filter { it !is ElmTypeAnnotation }.firstOrNull() as? PsiComment)
+                ?.takeIf { it.text.startsWith("{-|") }
 }

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -9,7 +9,7 @@ foo = 0
 --^
 """,
             """
-<div class='definition'><pre>foo</pre></div>
+<div class='definition'><pre><b>foo</b></pre></div>
 """)
 
     fun `test unary function`() = doTest(
@@ -18,7 +18,7 @@ foo bar = bar
 --^
 """,
             """
-<div class='definition'><pre>foo bar</pre></div>
+<div class='definition'><pre><b>foo</b> bar</pre></div>
 """)
 
     fun `test binary function with line comment`() = doTest(
@@ -28,7 +28,7 @@ foo bar baz = bar baz
 --^
 """,
             """
-<div class='definition'><pre>foo bar baz</pre></div>
+<div class='definition'><pre><b>foo</b> bar baz</pre></div>
 """)
 
     fun `test function with doc comment`() = doTest(
@@ -38,7 +38,7 @@ foo bar baz = bar baz
 --^
 """,
             """
-<div class='definition'><pre>foo bar baz</pre></div>
+<div class='definition'><pre><b>foo</b> bar baz</pre></div>
 <div class='content'><p>this should be included.</p></div>
 """)
 

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -195,6 +195,26 @@ type alias Foo = { a: Int, b: String }
 <p><code>b</code> : <a href="psi_element://String">String</a></td></table>
 """)
 
+    fun `test module`() = doTest(
+            """
+module Main exposing (main)
+      --^
+main = ()
+""",
+            """
+<div class='definition'><pre><i>module</i> Main</pre></div>
+""")
+
+    fun `test function parameter`() = doTest(
+            """
+foo bar = ()
+  --^
+""",
+            """
+<div class='definition'><pre><i>parameter</i> bar <i>of function </i><a href="psi_element://foo">foo</a></pre></div>
+""")
+
+
     private fun doTest(@Language("Elm") code: String, @Language("Html") expected: String) =
             doTest(code, expected, ElmDocumentationProvider::generateDoc)
 }

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -49,8 +49,19 @@ foo bar baz = bar baz
 --^
 """,
             """
-<div class='definition'><pre>foo : Int -&gt; Int -&gt; Int
-foo bar baz</pre></div>
+<div class='definition'><pre><b>foo</b> : <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Int">Int</a>
+<b>foo</b> bar baz</pre></div>
+""")
+
+    fun `test function with qualified type annotation`() = doTest(
+            """
+foo : Int -> Http.Error
+foo bar = bar
+--^
+""",
+            """
+<div class='definition'><pre><b>foo</b> : <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Http.Error">Http.Error</a>
+<b>foo</b> bar</pre></div>
 """)
 
     fun `test function with type and docs`() = doTest(
@@ -61,8 +72,8 @@ foo bar baz = bar baz
 --^
 """,
             """
-<div class='definition'><pre>foo : Int -&gt; Int -&gt; Int
-foo bar baz</pre></div>
+<div class='definition'><pre><b>foo</b> : <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Int">Int</a>
+<b>foo</b> bar baz</pre></div>
 <div class='content'><p>foo some ints together</p></div>
 """)
 
@@ -88,8 +99,8 @@ foo bar baz =
   bar baz
 """,
             """
-<div class='definition'><pre>foo : Int -&gt; Int -&gt; Int
-foo bar baz</pre></div>
+<div class='definition'><pre><b>foo</b> : <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Int">Int</a> -&gt; <a href="psi_element://Int">Int</a>
+<b>foo</b> bar baz</pre></div>
 <div class='content'><p>Map some <code>Int</code>s together,
 producing another <code>Int</code></p><h2>Example</h2><pre><code>bar = 1
 baz = 2

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -117,6 +117,8 @@ type Foo = Bar
 """,
             """
 <div class='definition'><pre><b>type</b> Foo</pre></div>
+<table class='sections'><tr><td valign='top' class='section'><p>Members:</td><td><p>
+<p><code>Bar</code></td></table>
 """)
 
     fun `test type declaration with docs`() = doTest(
@@ -128,7 +130,71 @@ type Foo = Bar
             """
 <div class='definition'><pre><b>type</b> Foo</pre></div>
 <div class='content'><p>included <em>docs</em></p></div>
+<table class='sections'><tr><td valign='top' class='section'><p>Members:</td><td><p>
+<p><code>Bar</code></td></table>
 """)
+
+    fun `test type declaration with multiple members`() = doTest(
+            """
+{-| included *docs* -}
+type Foo
+     --^
+     = Bar
+     | Baz a
+     | Qux (Maybe a) a
+     | Lorem { ipsum: Dolor }
+""",
+            """
+<div class='definition'><pre><b>type</b> Foo</pre></div>
+<div class='content'><p>included <em>docs</em></p></div>
+<table class='sections'><tr><td valign='top' class='section'><p>Members:</td><td><p>
+<p><code>Bar</code>
+<p><code>Baz</code> a
+<p><code>Qux</code> (<a href="psi_element://Maybe">Maybe</a> a) a
+<p><code>Lorem</code> { ipsum : <a href="psi_element://Dolor">Dolor</a> }</td></table>
+""")
+
+    fun `test type alias`() = doTest(
+            """
+type alias Foo = Int
+         --^
+""",
+            """
+<div class='definition'><pre><b>type alias</b> Foo</pre></div>
+""")
+
+    fun `test type alias with docs`() = doTest(
+            """
+{-| included *docs* -}
+type alias Foo = Int
+         --^
+""",
+            """
+<div class='definition'><pre><b>type alias</b> Foo</pre></div>
+<div class='content'><p>included <em>docs</em></p></div>
+""")
+
+    fun `test type alias empty record`() = doTest(
+            """
+type alias Foo = { }
+         --^
+""",
+            """
+<div class='definition'><pre><b>type alias</b> Foo</pre></div>
+""")
+
+    fun `test type alias record with fields`() = doTest(
+            """
+type alias Foo = { a: Int, b: String }
+         --^
+""",
+            """
+<div class='definition'><pre><b>type alias</b> Foo</pre></div>
+<table class='sections'><tr><td valign='top' class='section'><p>Fields:</td><td><p>
+<p><code>a</code> : <a href="psi_element://Int">Int</a>
+<p><code>b</code> : <a href="psi_element://String">String</a></td></table>
+""")
+
     private fun doTest(@Language("Elm") code: String, @Language("Html") expected: String) =
             doTest(code, expected, ElmDocumentationProvider::generateDoc)
 }

--- a/src/test/kotlin/org/elm/ide/docs/ElmResolveLinkTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmResolveLinkTest.kt
@@ -1,0 +1,37 @@
+package org.elm.ide.docs
+
+import com.intellij.psi.PsiManager
+import org.elm.lang.ElmTestBase
+import org.elm.lang.core.psi.ElmNamedElement
+import org.intellij.lang.annotations.Language
+
+class ElmResolveLinkTest : ElmTestBase(){
+    fun `test type`() = doTest(
+"""
+type Foo = Bar
+   --X
+
+foo : Foo
+foo = 0
+--^
+""", "Foo")
+
+    fun `test type alias`() = doTest(
+            """
+type alias Foo = Int
+         --X
+
+foo : Foo
+foo = 0
+--^
+""", "Foo")
+
+    private fun doTest(@Language("Elm") code: String, link: String) {
+        InlineFile(code)
+        val context = findElementInEditor<ElmNamedElement>("^")
+        val expectedElement = findElementInEditor<ElmNamedElement>("X")
+        val actualElement = ElmDocumentationProvider()
+                .getDocumentationElementForLink(PsiManager.getInstance(project), link, context)
+        assertEquals(expectedElement, actualElement)
+    }
+}


### PR DESCRIPTION
![untitled](https://user-images.githubusercontent.com/1109214/43555783-1d88dc60-95b1-11e8-8470-52cc42984640.png)

This PR adds reference links to the generated documentation. Clicking one will show the documentation for the linked element.

This makes the generation a little more involved, but it's still pretty straight forward. 

For qualified names (like `Http.Status`), I decided to make the entire id a single link to the referenced element, rather than making the qualification sections link to modules.