### PR TITLE
Add more module information to rendered docs

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -6,8 +6,11 @@ import com.intellij.lang.documentation.DocumentationMarkup
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
-import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ElmDocTarget
+import org.elm.lang.core.psi.ElmPsiElement
 import org.elm.lang.core.psi.ElmTypes.BLOCK_COMMENT
+import org.elm.lang.core.psi.ancestors
+import org.elm.lang.core.psi.elementType
 import org.elm.lang.core.psi.elements.*
 import org.elm.lang.core.resolve.scope.ImportScope
 import org.elm.lang.core.resolve.scope.ModuleScope
@@ -157,7 +160,7 @@ private fun documentationFor(decl: ElmModuleDeclaration): String? = buildString 
     }
 
     renderDocContent(decl) { html ->
-        val declarations = ModuleScope(decl.elmFile).getDeclaredValues()
+        val declarations = ModuleScope(decl.elmFile).run { getDeclaredValues() + getDeclaredTypes() }
 
         // Render @docs commands
         html.replace(Regex("<p>@docs (.+?)</p>", RegexOption.DOT_MATCHES_ALL)) { match ->

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmModuleDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmModuleDeclaration.kt
@@ -1,14 +1,13 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.presentation.getPresentation
 import org.elm.lang.core.moduleLookupHack
-import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.ElmPsiFactory
-import org.elm.lang.core.psi.ElmStubbedElement
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.stubs.ElmModuleDeclarationStub
 import org.elm.lang.core.stubs.ElmNamedStub
 
@@ -22,7 +21,7 @@ import org.elm.lang.core.stubs.ElmNamedStub
  * - give the module a name
  * - expose values and types
  */
-class ElmModuleDeclaration : ElmStubbedElement<ElmModuleDeclarationStub>, ElmNamedElement {
+class ElmModuleDeclaration : ElmStubbedElement<ElmModuleDeclarationStub>, ElmNamedElement, ElmDocTarget {
 
     constructor(node: ASTNode) :
             super(node)
@@ -54,13 +53,13 @@ class ElmModuleDeclaration : ElmStubbedElement<ElmModuleDeclarationStub>, ElmNam
 
 
     val exposesAll: Boolean
-        get() = getStub()?.exposesAll
+        get() = stub?.exposesAll
                 ?: (exposingList?.doubleDot != null)
 
 
     override fun getName(): String {
-        val stub = getStub() as? ElmNamedStub
-        val fullName = if (stub != null) stub.name else upperCaseQID.text
+        val stub = stub as? ElmNamedStub
+        val fullName = stub?.name ?: upperCaseQID.text
         return moduleLookupHack(fullName)
     }
 
@@ -75,4 +74,7 @@ class ElmModuleDeclaration : ElmStubbedElement<ElmModuleDeclarationStub>, ElmNam
 
     override fun getPresentation() =
             getPresentation(this)
+
+    override val docComment: PsiComment?
+        get() = (nextSiblings.withoutWs.firstOrNull() as? PsiComment)?.takeIf { it.text.startsWith("{-|") }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -90,10 +90,7 @@ class ModuleScope(val elmFile: ElmFile) {
 
 
     fun getDeclaredTypes(): List<ElmNamedElement> {
-        return listOf<List<ElmNamedElement>>(
-                elmFile.getTypeDeclarations(),
-                elmFile.getTypeAliasDeclarations()
-        ).flatten()
+        return elmFile.getTypeDeclarations() + elmFile.getTypeAliasDeclarations()
     }
 
 

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -77,6 +77,18 @@ foo bar baz = bar baz
 <div class='content'><p>foo some ints together</p></div>
 """)
 
+    fun `test function in module`() = doTest(
+            """
+module Foo.Bar exposing (foo)
+
+foo bar = bar
+--^
+""",
+            """
+<div class='definition'><pre><b>foo</b> bar<i> defined in </i>Foo.Bar</pre></div>
+""")
+
+
     fun `test doc comments with markdown`() = doTest(
             """
 {-| Map some `Int`s together,
@@ -121,6 +133,19 @@ type Foo = Bar
 <p><code>Bar</code></td></table>
 """)
 
+    fun `test type declaration in module`() = doTest(
+            """
+module Foo.Bar exposing (Foo)
+
+type Foo = Bar
+     --^
+""",
+            """
+<div class='definition'><pre><b>type</b> Foo<i> defined in </i>Foo.Bar</pre></div>
+<table class='sections'><tr><td valign='top' class='section'><p>Members:</td><td><p>
+<p><code>Bar</code></td></table>
+""")
+
     fun `test type declaration with docs`() = doTest(
             """
 {-| included *docs* -}
@@ -161,6 +186,17 @@ type alias Foo = Int
 """,
             """
 <div class='definition'><pre><b>type alias</b> Foo</pre></div>
+""")
+
+    fun `test type alias in module`() = doTest(
+            """
+module Foo.Bar exposing (Foo)
+
+type alias Foo = Int
+         --^
+""",
+            """
+<div class='definition'><pre><b>type alias</b> Foo<i> defined in </i>Foo.Bar</pre></div>
 """)
 
     fun `test type alias with docs`() = doTest(

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -241,6 +241,29 @@ main = ()
 <div class='definition'><pre><i>module</i> Main</pre></div>
 """)
 
+    // This test is kludgy: since a line comment before a doc comment will cause the doc comment to fail to attach to
+    // the module element, we need to put the line comment inside the doc comment.
+    fun `test module with docstring`() = doTest(
+            """
+module Main exposing (main)
+{-|  --^
+
+Module docs
+
+# Header
+@docs main
+
+@docs foo, bar
+-}
+main = ()
+foo = ()
+bar = ()
+""",
+            """
+<div class='definition'><pre><i>module</i> Main</pre></div>
+<div class='content'><p>--^</p><p>Module docs</p><h2>Header</h2><a href="psi_element://main">main</a><a href="psi_element://foo">foo</a>, <a href="psi_element://bar">bar</a></div>
+""")
+
     fun `test function parameter`() = doTest(
             """
 foo bar = ()

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -251,17 +251,20 @@ module Main exposing (main)
 Module docs
 
 # Header
-@docs main
+@docs main, foo, bar
 
-@docs foo, bar
+# Helpers
+@docs main, foo,
+      bar, baz
 -}
 main = ()
 foo = ()
 bar = ()
+baz = ()
 """,
             """
 <div class='definition'><pre><i>module</i> Main</pre></div>
-<div class='content'><p>--^</p><p>Module docs</p><h2>Header</h2><a href="psi_element://main">main</a><a href="psi_element://foo">foo</a>, <a href="psi_element://bar">bar</a></div>
+<div class='content'><p>--^</p><p>Module docs</p><h2>Header</h2><a href="psi_element://main">main</a>, <a href="psi_element://foo">foo</a>, <a href="psi_element://bar">bar</a><h2>Helpers</h2><a href="psi_element://main">main</a>, <a href="psi_element://foo">foo</a>, <a href="psi_element://bar">bar</a>, <a href="psi_element://baz">baz</a></div>
 """)
 
     fun `test function parameter`() = doTest(

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -251,20 +251,20 @@ module Main exposing (main)
 Module docs
 
 # Header
-@docs main, foo, bar
+@docs main, foo, Bar
 
 # Helpers
 @docs main, foo,
-      bar, baz
+      Bar, Baz
 -}
 main = ()
 foo = ()
-bar = ()
-baz = ()
+type alias Bar = ()
+type Baz = Baz
 """,
             """
 <div class='definition'><pre><i>module</i> Main</pre></div>
-<div class='content'><p>--^</p><p>Module docs</p><h2>Header</h2><a href="psi_element://main">main</a>, <a href="psi_element://foo">foo</a>, <a href="psi_element://bar">bar</a><h2>Helpers</h2><a href="psi_element://main">main</a>, <a href="psi_element://foo">foo</a>, <a href="psi_element://bar">bar</a>, <a href="psi_element://baz">baz</a></div>
+<div class='content'><p>--^</p><p>Module docs</p><h2>Header</h2><a href="psi_element://main">main</a>, <a href="psi_element://foo">foo</a>, <a href="psi_element://Bar">Bar</a><h2>Helpers</h2><a href="psi_element://main">main</a>, <a href="psi_element://foo">foo</a>, <a href="psi_element://Bar">Bar</a>, <a href="psi_element://Baz">Baz</a></div>
 """)
 
     fun `test function parameter`() = doTest(


### PR DESCRIPTION
This PR addresses a comment in #55 by adding the module that elements are defined in to their docs.

![defined](https://user-images.githubusercontent.com/1109214/43667368-74ff9fb6-972c-11e8-9f6f-181bd41ea541.png)


It also adds rendered doc comments for modules. Modules can have `@doc` directives that are defined to inline the named elements into the rendered docs. I decided to just render links to the elements rather than inlining the docs, in order to make the result more manageable.

![module](https://user-images.githubusercontent.com/1109214/43667370-784c452a-972c-11e8-9aec-dd4e8227fee0.png)