### PR TITLE
Improve toolchain detection on Windows.

### DIFF
--- a/src/main/kotlin/org/elm/ide/notifications/ElmNeedsConfigNotificationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/notifications/ElmNeedsConfigNotificationProvider.kt
@@ -58,7 +58,7 @@ class ElmNeedsConfigNotificationProvider(
 
         // TODO [kl] is it bad to issue a blocking call here? we're on a background thread, but still...
         val compilerVersion = toolchain.queryCompilerVersion()
-        if (compilerVersion != null && compilerVersion.isOlderThan(ElmToolchain.MIN_SUPPORTED_COMPILER_VERSION)) {
+        if (compilerVersion != null && compilerVersion < ElmToolchain.MIN_SUPPORTED_COMPILER_VERSION) {
             return createBadToolchainPanel("Elm $compilerVersion is not supported")
         }
 

--- a/src/main/kotlin/org/elm/workspace/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmBuildAction.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.ContentFactory
 import org.elm.openapiext.saveAllDocuments
-import org.elm.workspace.ElmToolchain.Companion.ELM_BINARY
 
 class ElmBuildAction : AnAction() {
 
@@ -22,7 +21,7 @@ class ElmBuildAction : AnAction() {
             guessAndSetupElmProject(project, explicitRequest = true)
         }
 
-        val compilerPath = project.elmToolchain?.pathToExecutable(ELM_BINARY)
+        val compilerPath = project.elmToolchain?.elmCompilerPath
         if (compilerPath == null) {
             Messages.showErrorDialog("No path to the Elm compiler", "Build Error")
             return

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -50,7 +50,7 @@ private val log = logger<ElmWorkspaceService>()
  * The state includes user-specific paths so it is persisted to IntelliJ's workspace file
  * (which is _not_ placed in version control).
  */
-@State(name = "ElmWorkspace", storages = arrayOf(Storage(StoragePathMacros.WORKSPACE_FILE)))
+@State(name = "ElmWorkspace", storages = [Storage(StoragePathMacros.WORKSPACE_FILE)])
 class ElmWorkspaceService(
         val intellijProject: Project
 ) : PersistentStateComponent<Element> {
@@ -58,9 +58,9 @@ class ElmWorkspaceService(
 
     init {
         with(intellijProject.messageBus.connect()) {
-            subscribe(VirtualFileManager.VFS_CHANGES, ElmProjectWatcher({
+            subscribe(VirtualFileManager.VFS_CHANGES, ElmProjectWatcher {
                 refreshAllProjects()
-            }))
+            })
         }
     }
 
@@ -77,7 +77,7 @@ class ElmWorkspaceService(
     val settings: Settings
         get() {
             val raw = rawSettingsRef.get()
-            return Settings(toolchain = raw.binDirPath?.let { ElmToolchain(Paths.get(it)) })
+            return Settings(toolchain = raw.binDirPath?.let { ElmToolchain(it) })
         }
 
 
@@ -208,7 +208,7 @@ class ElmWorkspaceService(
 
     private fun loadProject(manifestPath: Path): ElmProject {
         val file = LocalFileSystem.getInstance().refreshAndFindFileByPath(manifestPath.toString())
-                ?: throw ProjectLoadException("Could not find file ${manifestPath}")
+                ?: throw ProjectLoadException("Could not find file $manifestPath")
 
         val toolchain = settings.toolchain
                 ?: throw ProjectLoadException("Elm toolchain not configured")

--- a/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
+++ b/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
@@ -10,7 +10,6 @@ import org.elm.openapiext.UiDebouncer
 import org.elm.openapiext.pathToDirectoryTextField
 import org.elm.workspace.ElmToolchain
 import org.elm.workspace.elmWorkspace
-import org.elm.workspace.isOlderThan
 import java.nio.file.Paths
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -22,7 +21,7 @@ class ElmWorkspaceConfigurable(
     private val versionUpdateDebouncer = UiDebouncer(this)
 
     private val pathToToolchainField = pathToDirectoryTextField(this,
-            "Select directory containing the 'elm' binary", { update() })
+            "Select directory containing the 'elm' binary") { update() }
 
     private val elmVersionLabel = JLabel()
 
@@ -36,7 +35,7 @@ class ElmWorkspaceConfigurable(
         val pathToToolchain = pathToToolchainField.text
         versionUpdateDebouncer.run(
                 onPooledThread = {
-                    ElmToolchain(Paths.get(pathToToolchain)).queryCompilerVersion()
+                    ElmToolchain(pathToToolchain).queryCompilerVersion()
                 },
                 onUiThread = { elmCompilerVersion ->
                     when {
@@ -44,7 +43,7 @@ class ElmWorkspaceConfigurable(
                             elmVersionLabel.text = "not available"
                             elmVersionLabel.foreground = JBColor.RED
                         }
-                        elmCompilerVersion.isOlderThan(ElmToolchain.MIN_SUPPORTED_COMPILER_VERSION) -> {
+                        elmCompilerVersion < ElmToolchain.MIN_SUPPORTED_COMPILER_VERSION -> {
                             elmVersionLabel.text = "$elmCompilerVersion (not supported)"
                             elmVersionLabel.foreground = JBColor.RED
                         }

--- a/src/test/kotlin/org/elmSlowTests/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elmSlowTests/ElmWorkspaceServiceTest.kt
@@ -1,11 +1,13 @@
 package org.elmSlowTests
 
+import com.intellij.history.core.Paths
 import org.elm.fileTree
 import org.elm.openapiext.elementFromXmlString
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.toXmlString
 import org.elm.workspace.ElmWorkspaceTestBase
 import org.elm.workspace.elmWorkspace
+import java.io.File
 
 class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
@@ -179,10 +181,12 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         val rootPath = testProject.root.pathAsPath
 
         // The known-good, serialized state that we must be able to handle
+        val projectPath = rootPath.resolve("a").resolve("elm.json")
+        val projectPathString = projectPath.toString().replace("\\", "/") // normalize windows paths
         val xml = """
             <state>
               <elmProjects>
-                <project path="$rootPath/a/elm.json" />
+                <project path="$projectPathString" />
               </elmProjects>
               <settings binDirPath="/usr/local/bin" />
             </state>
@@ -190,8 +194,8 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         // ... must be able to load from serialized state ...
         workspace.loadState(elementFromXmlString(xml))
-        val actualProjects = workspace.allProjects.map { it.manifestPath.toString() }
-        val expectedProjects = listOf("$rootPath/a/elm.json")
+        val actualProjects = workspace.allProjects.map { it.manifestPath }
+        val expectedProjects = listOf(projectPath)
         checkEquals(expectedProjects, actualProjects)
 
         // ... and serialize the resulting state ...


### PR DESCRIPTION
Depending on how elm is installed on windows, the compiler may be named `elm.cmd` or `elm` (if installed through npm), or `elm.exe` (if installed with the installer).