### PR TITLE
Allow attaching "package" project `elm.json` file

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -110,7 +110,7 @@ sealed class ElmProject(
                         throw ProjectLoadException("Invalid elm.json: ${e.message}")
                     }
                     // TODO [kl] resolve dependency constraints to determine package version numbers
-                    // [ ] use whichever version number is available in the Elm package cache (~/.elm)
+                    // [x] use whichever version number is available in the Elm package cache (~/.elm)
                     // [ ] include transitive dependencies
                     // [ ] resolve versions such that all constraints are satisfied
                     //     (necessary for correctness sake, but low priority)

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -22,7 +22,6 @@ private val objectMapper = ObjectMapper()
  */
 sealed class ElmProject(
         val manifestPath: Path,
-        val elmVersion: String,
         val dependencies: List<ElmPackageRef>,
         val testDependencies: List<ElmPackageRef>
 ) {
@@ -76,7 +75,7 @@ sealed class ElmProject(
                 // that the user has not excluded that directory from the project.
                 return ElmApplicationProject(
                         manifestPath = manifestPath,
-                        elmVersion = "0.18.0",
+                        elmVersion = Version(0, 18, 0),
                         dependencies = emptyList(),
                         testDependencies = emptyList(),
                         sourceDirectories = emptyList()
@@ -91,7 +90,11 @@ sealed class ElmProject(
             val type = node.get("type")?.textValue()
             return when (type) {
                 "application" -> {
-                    val dto = objectMapper.treeToValue(node, ElmApplicationProjectDTO::class.java)
+                    val dto = try {
+                        objectMapper.treeToValue(node, ElmApplicationProjectDTO::class.java)
+                    } catch (e: JsonProcessingException) {
+                        throw ProjectLoadException("Invalid elm.json: ${e.message}")
+                    }
                     ElmApplicationProject(
                             manifestPath = manifestPath,
                             elmVersion = dto.elmVersion,
@@ -101,21 +104,23 @@ sealed class ElmProject(
                     )
                 }
                 "package" -> {
-                    throw ProjectLoadException("Elm 'package' projects are not currently supported. "
-                            + "As a workaround, please add your example app project instead.")
-                    val dto = objectMapper.treeToValue(node, ElmPackageProjectDTO::class.java)
-                    // TODO [kl] fix the resolving of dependencies:
-                    //           - resolve version constraint to a specific version
-                    //           - do not use the empty list for transitiveDependencies
+                    val dto = try {
+                        objectMapper.treeToValue(node, ElmPackageProjectDTO::class.java)
+                    } catch (e: JsonProcessingException) {
+                        throw ProjectLoadException("Invalid elm.json: ${e.message}")
+                    }
+                    // TODO [kl] resolve dependency constraints to determine package version numbers
+                    // [ ] use whichever version number is available in the Elm package cache (~/.elm)
+                    // [ ] include transitive dependencies
+                    // [ ] resolve versions such that all constraints are satisfied
+                    //     (necessary for correctness sake, but low priority)
                     ElmPackageProject(
                             manifestPath = manifestPath,
                             elmVersion = dto.elmVersion,
-                            dependencies = dto.dependencies.depsToPackages(toolchain),
-                            testDependencies = dto.testDependencies.depsToPackages(toolchain),
+                            dependencies = dto.dependencies.constraintDepsToPackages(toolchain),
+                            testDependencies = dto.testDependencies.constraintDepsToPackages(toolchain),
                             name = dto.name,
-                            summary = dto.summary,
                             version = dto.version,
-                            license = dto.license,
                             exposedModules = dto.exposedModulesNode.toExposedModuleMap())
                 }
                 else -> throw ProjectLoadException("The 'type' field is '$type', "
@@ -131,11 +136,11 @@ sealed class ElmProject(
  */
 class ElmApplicationProject(
         manifestPath: Path,
-        elmVersion: String,
+        val elmVersion: Version,
         dependencies: List<ElmPackageRef>,
         testDependencies: List<ElmPackageRef>,
         val sourceDirectories: List<String>
-) : ElmProject(manifestPath, elmVersion, dependencies, testDependencies)
+) : ElmProject(manifestPath, dependencies, testDependencies)
 
 
 /**
@@ -143,16 +148,14 @@ class ElmApplicationProject(
  */
 class ElmPackageProject(
         manifestPath: Path,
-        elmVersion: String,
+        val elmVersion: Constraint,
         dependencies: List<ElmPackageRef>,
         testDependencies: List<ElmPackageRef>,
         val name: String,
-        val summary: String,
-        val license: String,
-        val version: String,
+        val version: Version,
         /** Map from label to one-or-more module names. The label can be the empty string. */
         val exposedModules: Map<String, List<String>>
-) : ElmProject(manifestPath, elmVersion, dependencies, testDependencies)
+) : ElmProject(manifestPath, dependencies, testDependencies)
 
 
 /**
@@ -161,20 +164,32 @@ class ElmPackageProject(
 class ElmPackageRef(
         val root: VirtualFile?,
         val name: String,
-        val version: String
+        val version: Version
 )
 
 
-private fun ExactDependencies.toPackageRefs(toolchain: ElmToolchain) =
+private fun ExactDependenciesDTO.toPackageRefs(toolchain: ElmToolchain) =
         direct.depsToPackages(toolchain) + indirect.depsToPackages(toolchain)
 
 
-private fun Map<String, String>.depsToPackages(toolchain: ElmToolchain) =
+private fun Map<String, Version>.depsToPackages(toolchain: ElmToolchain) =
         map { (name, version) ->
             ElmPackageRef(
-                    root = toolchain.packageRootDir(name, version),
+                    root = toolchain.packageVersionDir(name, version),
                     name = name,
                     version = version)
+        }
+
+private fun Map<String, Constraint>.constraintDepsToPackages(toolchain: ElmToolchain) =
+        map { (name, constraint) ->
+            val useVersion = toolchain.availableVersionsForPackage(name)
+                    .filter { constraint.contains(it) }
+                    .sorted()
+                    .first()
+            ElmPackageRef(
+                    root = toolchain.packageVersionDir(name, useVersion),
+                    name = name,
+                    version = useVersion)
         }
 
 
@@ -202,7 +217,7 @@ private fun JsonNode.toExposedModuleMap(): Map<String, List<String>> {
  */
 val noProjectSentinel = ElmApplicationProject(
         manifestPath = Paths.get("/elm.json"),
-        elmVersion = "",
+        elmVersion = Version(0, 0, 0),
         dependencies = emptyList(),
         testDependencies = emptyList(),
         sourceDirectories = emptyList()
@@ -217,28 +232,28 @@ private interface ElmProjectDTO
 
 
 private class ElmApplicationProjectDTO(
-        @JsonProperty("elm-version") val elmVersion: String,
+        @JsonProperty("elm-version") val elmVersion: Version,
         @JsonProperty("source-directories") val sourceDirectories: List<String>,
-        @JsonProperty("dependencies") val dependencies: ExactDependencies,
-        @JsonProperty("test-dependencies") val testDependencies: ExactDependencies
+        @JsonProperty("dependencies") val dependencies: ExactDependenciesDTO,
+        @JsonProperty("test-dependencies") val testDependencies: ExactDependenciesDTO
 ) : ElmProjectDTO
 
 
-private class ExactDependencies(
-        @JsonProperty("direct") val direct: Map<String, String>,
-        @JsonProperty("indirect") val indirect: Map<String, String>
+private class ExactDependenciesDTO(
+        @JsonProperty("direct") val direct: Map<String, Version>,
+        @JsonProperty("indirect") val indirect: Map<String, Version>
 )
 
 
 private class ElmPackageProjectDTO(
-        @JsonProperty("elm-version") val elmVersion: String,
-        @JsonProperty("dependencies") val dependencies: Map<String, String>,
-        @JsonProperty("test-dependencies") val testDependencies: Map<String, String>,
+        @JsonProperty("elm-version") val elmVersion: Constraint,
+        @JsonProperty("dependencies") val dependencies: Map<String, Constraint>,
+        @JsonProperty("test-dependencies") val testDependencies: Map<String, Constraint>,
         @JsonProperty("name") val name: String,
-        @JsonProperty("summary") val summary: String,
-        @JsonProperty("license") val license: String,
-        @JsonProperty("version") val version: String,
+        @JsonProperty("version") val version: Version,
         @JsonProperty("exposed-modules") val exposedModulesNode: JsonNode // either List<String>
         // or Map<String, List<String>>
         // where the map's keys are labels
 ) : ElmProjectDTO
+
+

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.io.exists
 import com.intellij.util.io.isDirectory
-import com.intellij.util.text.SemVer
 import org.elm.openapiext.GeneralCommandLine
 import org.elm.openapiext.checkIsBackgroundThread
 import org.elm.openapiext.modules
@@ -93,7 +92,7 @@ data class ElmToolchain(val binDirPath: Path) {
                 .mapNotNull { Version.parseOrNull(it.name) }
     }
 
-    fun queryCompilerVersion(): SemVer? {
+    fun queryCompilerVersion(): Version? {
         checkIsBackgroundThread()
         val elm = elmCompilerPath ?: return null
         // Output of `elm --version` is a single line containing the version number (e.g. `0.19.0\n`)
@@ -101,14 +100,14 @@ data class ElmToolchain(val binDirPath: Path) {
                 .withParameters("--version")
                 .runExecutable()
                 ?.firstOrNull()
-                ?.let { SemVer.parseFromText(it) }
+                ?.let { Version.parseOrNull(it) }
     }
 
     companion object {
         const val ELM_JSON = "elm.json"
         const val ELM_LEGACY_JSON = "elm-package.json" // TODO [drop 0.18]
 
-        val MIN_SUPPORTED_COMPILER_VERSION = SemVer("0.18.0", 0, 18, 0)
+        val MIN_SUPPORTED_COMPILER_VERSION = Version(0, 18, 0)
 
         /** Suggest a toolchain that exists in in any standard location */
         fun suggest(project: Project): ElmToolchain? {

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -68,14 +68,29 @@ data class ElmToolchain(val binDirPath: Path) {
 
     fun looksLikeValidToolchain(): Boolean = elmCompilerPath != null
 
-    fun packageRootDir(name: String, version: String): VirtualFile? {
-        // TODO [kl] scrape the version from the Elm compiler
+    /**
+     * Path to directory for a package at a specific version, containing `elm.json`
+     */
+    fun packageVersionDir(name: String, version: Version): VirtualFile? {
+        // TODO [kl] stop hard-coding the compiler version
         // it's ok to assume 19 here because this will never be called from 0.18 code,
         // but even this assumption will not be safe once future 19 releases are made.
         val compilerVersion = "0.19.0"
 
         val path = "$elmHomePath/$compilerVersion/package/$name/$version/"
         return LocalFileSystem.getInstance().findFileByPath(path)
+    }
+
+    /**
+     * Path to directory for a package, containing one or more versions
+     */
+    fun availableVersionsForPackage(name: String): List<Version> {
+        // TODO [kl] stop hard-coding the compiler version
+        val compilerVersion = "0.19.0"
+
+        return File("$elmHomePath/$compilerVersion/package/$name/")
+                .walk().toList()
+                .mapNotNull { Version.parseOrNull(it.name) }
     }
 
     fun queryCompilerVersion(): SemVer? {

--- a/src/main/kotlin/org/elm/workspace/VersionUtil.kt
+++ b/src/main/kotlin/org/elm/workspace/VersionUtil.kt
@@ -1,0 +1,115 @@
+package org.elm.workspace
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+
+// VERSION
+
+@JsonDeserialize(using = VersionDeserializer::class)
+data class Version(val x: Int, val y: Int, val z: Int) : Comparable<Version> {
+
+    override fun toString() =
+            "$x.$y.$z"
+
+    override fun compareTo(other: Version) =
+            when {
+                x != other.x -> x.compareTo(other.x)
+                y != other.y -> y.compareTo(other.y)
+                z != other.z -> z.compareTo(other.z)
+                else -> 0
+            }
+
+    companion object {
+        fun parse(text: String): Version {
+            val parts = text.split(".")
+            if (parts.size != 3) throw ParseException("expected a version number like '1.0.0', got '$text'")
+            try {
+                return Version(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
+            } catch (e: NumberFormatException) {
+                throw ParseException("expected a version number like '1.0.0', got '$text'")
+            }
+        }
+
+        fun parseOrNull(text: String): Version? =
+                try {
+                    parse(text)
+                } catch (e: ParseException) {
+                    null
+                }
+    }
+}
+
+private class VersionDeserializer : StdDeserializer<Version>(Version::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext) =
+            try {
+                Version.parse(p.text)
+            } catch (e: ParseException) {
+                throw ctxt.weirdStringException(p.text, Version::class.java, e.message)
+            }
+}
+
+
+// CONSTRAINT ON VERSION NUMBERS
+
+@JsonDeserialize(using = ConstraintDeserializer::class)
+data class Constraint(
+        val low: Version,
+        val high: Version,
+        val lowOp: Op,
+        val highOp: Op
+) {
+    enum class Op {
+        LESS_THAN,
+        LESS_THAN_OR_EQUAL;
+
+        fun evaluate(left: Version, right: Version): Boolean {
+            return when (this) {
+                LESS_THAN -> left < right
+                LESS_THAN_OR_EQUAL -> left <= right
+            }
+        }
+
+        companion object {
+            fun parse(text: String): Op =
+                    when (text) {
+                        "<" -> LESS_THAN
+                        "<=" -> LESS_THAN_OR_EQUAL
+                        else -> throw ParseException("expected '<' or '<=', got '$text'")
+                    }
+        }
+    }
+
+    fun contains(version: Version): Boolean {
+        return (lowOp.evaluate(low, version) && highOp.evaluate(version, high))
+    }
+
+    companion object {
+        fun parse(text: String): Constraint {
+            val parts = text.split(" ")
+            if (parts.size != 5) throw ParseException("expected something like '1.0.0 <= v < 2.0.0', got '$text'")
+            val low = Version.parse(parts[0])
+            val lowOp = Op.parse(parts[1])
+            if (parts[2] != "v") throw ParseException("expected 'v', got '${parts[2]}'")
+            val highOp = Op.parse(parts[3])
+            val high = Version.parse(parts[4])
+            return Constraint(low = low, lowOp = lowOp, highOp = highOp, high = high)
+        }
+    }
+}
+
+private class ConstraintDeserializer : StdDeserializer<Constraint>(Constraint::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext) =
+            try {
+                Constraint.parse(p.text)
+            } catch (e: ParseException) {
+                throw ctxt.weirdStringException(p.text, Constraint::class.java, e.message)
+            }
+}
+
+
+// MISC
+
+class ParseException(msg: String) : RuntimeException(msg)

--- a/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
@@ -1,0 +1,38 @@
+package org.elm.workspace
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ConstraintTest {
+
+    @Test
+    fun `can determine whether a version satisfies a constraint`() {
+        val c = Constraint(
+                low = v(1, 0, 0),
+                high = v(2, 0, 0),
+                lowOp = Constraint.Op.LESS_THAN_OR_EQUAL,
+                highOp = Constraint.Op.LESS_THAN
+        )
+        assertTrue(c.contains(v(1, 0, 0)))
+        assertTrue(c.contains(v(1, 1, 0)))
+        assertFalse(c.contains(v(2, 0, 0)))
+    }
+
+    @Test
+    fun `parse works on good input`() {
+        assertEquals(Constraint(
+                low = v(1, 0, 0),
+                high = v(2, 0, 0),
+                lowOp = Constraint.Op.LESS_THAN_OR_EQUAL,
+                highOp = Constraint.Op.LESS_THAN
+        ), Constraint.parse("1.0.0 <= v < 2.0.0"))
+    }
+
+    @Test(expected = ParseException::class)
+    fun `parse throws on bad input`() {
+        Constraint.parse("1.0.0 <= v <= bogus")
+    }
+}
+
+private fun v(x: Int, y: Int, z: Int) =
+        Version(x, y, z)

--- a/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
@@ -6,16 +6,32 @@ import org.junit.Test
 class ConstraintTest {
 
     @Test
-    fun `can determine whether a version satisfies a constraint`() {
+    fun `can determine whether a version satisfies a half-open constraint`() {
         val c = Constraint(
                 low = v(1, 0, 0),
                 high = v(2, 0, 0),
                 lowOp = Constraint.Op.LESS_THAN_OR_EQUAL,
                 highOp = Constraint.Op.LESS_THAN
         )
+        assertFalse(c.contains(v(0, 9, 0)))
         assertTrue(c.contains(v(1, 0, 0)))
         assertTrue(c.contains(v(1, 1, 0)))
         assertFalse(c.contains(v(2, 0, 0)))
+    }
+
+    @Test
+    fun `can determine whether a version satisfies an inclusive constraint`() {
+        val c = Constraint(
+                low = v(1, 0, 0),
+                high = v(2, 0, 0),
+                lowOp = Constraint.Op.LESS_THAN_OR_EQUAL,
+                highOp = Constraint.Op.LESS_THAN_OR_EQUAL
+        )
+        assertFalse(c.contains(v(0, 9, 0)))
+        assertTrue(c.contains(v(1, 0, 0)))
+        assertTrue(c.contains(v(1, 1, 0)))
+        assertTrue(c.contains(v(2, 0, 0)))
+        assertFalse(c.contains(v(2, 1, 0)))
     }
 
     @Test

--- a/src/test/kotlin/org/elm/workspace/VersionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/VersionTest.kt
@@ -1,0 +1,47 @@
+package org.elm.workspace
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class VersionTest {
+
+    @Test
+    fun `version compare`() {
+        assertTrue(v(1, 0, 0) < v(2, 0, 0))
+        assertTrue(v(2, 0, 0) > v(1, 0, 0))
+        assertTrue(v(1, 0, 0) == v(1, 0, 0))
+
+        assertTrue(v(0, 1, 0) < v(0, 2, 0))
+        assertTrue(v(0, 2, 0) > v(0, 1, 0))
+        assertTrue(v(0, 1, 0) == v(0, 1, 0))
+
+        assertTrue(v(0, 0, 1) < v(0, 0, 2))
+        assertTrue(v(0, 0, 2) > v(0, 0, 1))
+        assertTrue(v(0, 0, 1) == v(0, 0, 1))
+    }
+
+    @Test
+    fun `version toString is dotted form`() {
+        assertEquals("1.2.3", v(1, 2, 3).toString())
+    }
+
+    @Test()
+    fun `parse works on good input`() {
+        Version.parse("1.2.3")
+    }
+
+    @Test(expected = ParseException::class)
+    fun `parse throws on bad input`() {
+        Version.parse("bogus.version.number")
+    }
+
+    @Test()
+    fun `parseOrNull does not throw on bad input`() {
+        assertNull(Version.parseOrNull("bogus.version.number"))
+    }
+
+    private fun v(x: Int, y: Int, z: Int) =
+            Version(x, y, z)
+}


### PR DESCRIPTION
This registers the package dependencies as external library roots. Unlike "application" projects, we cannot easily obtain:
- the exact version numbers used
- the transitive dependencies

So this PR just registers the package's direct dependencies and will use an arbitrary version that it finds in `~/.elm` that satisfies its own version constraint (but the full dependency graph).

More work needs to be done to make this better. Ideally the Elm toolchain itself would be able to describe how it would resolve a package's dependency graph.