### PR TITLE
Add code folding

### DIFF
--- a/src/main/kotlin/org/elm/ide/folding/ElmFoldingBuilder.kt
+++ b/src/main/kotlin/org/elm/ide/folding/ElmFoldingBuilder.kt
@@ -1,0 +1,117 @@
+package org.elm.ide.folding
+
+import com.intellij.codeInsight.folding.CodeFoldingSettings
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmTypes.*
+import org.elm.lang.core.psi.directChildren
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.*
+
+class ElmFoldingBuilder : FoldingBuilderEx(), DumbAware {
+    override fun getPlaceholderText(node: ASTNode): String? {
+        return when (node.elementType) {
+            BLOCK_COMMENT -> {
+                val nl = node.text.indexOf('\n')
+                if (nl > 0) node.text.substring(0, nl) + " ...-}"
+                else "{-...-}"
+            }
+            RECORD, RECORD_TYPE -> "{...}"
+            TYPE_ALIAS_DECLARATION, TYPE_DECLARATION, VALUE_DECLARATION -> " = ..."
+            else -> "..."
+        }
+    }
+
+    override fun isCollapsedByDefault(node: ASTNode): Boolean {
+        return with(CodeFoldingSettings.getInstance()) {
+            COLLAPSE_DOC_COMMENTS && node.elementType == BLOCK_COMMENT
+            || COLLAPSE_IMPORTS && node.elementType == MODULE_DECLARATION
+        }
+    }
+
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        if (root !is ElmFile) return emptyArray()
+
+        val visitor = ElmFoldingVisitor()
+        PsiTreeUtil.processElements(root) {
+            it.accept(visitor)
+            true
+        }
+        return visitor.descriptors.toTypedArray()
+    }
+}
+
+private class ElmFoldingVisitor : PsiElementVisitor() {
+    val descriptors = ArrayList<FoldingDescriptor>()
+
+    override fun visitElement(element: PsiElement) {
+        super.visitElement(element)
+        when (element) {
+            is ElmFile -> {
+                val imports = element.directChildren.filterIsInstance<ElmImportClause>().toList()
+                if (imports.size < 2) return
+                val start = imports.first()
+                foldBetween(start, start, imports.last(), true, true)
+            }
+            is ElmModuleDeclaration -> {
+                val imports = element.elmFile.directChildren.filterIsInstance<ElmImportClause>().toList()
+                val end = imports.lastOrNull() ?: element.lastChild
+                foldBetween(element, element.upperCaseQID, end, false, true)
+            }
+            is PsiComment -> {
+                if (element.elementType == BLOCK_COMMENT) fold(element)
+            }
+            is ElmRecordType, is ElmRecord -> {
+                fold(element)
+            }
+            is ElmValueDeclaration -> {
+                foldToEnd(element) { functionDeclarationLeft ?: pattern ?: operatorDeclarationLeft }
+            }
+            is ElmTypeDeclaration -> {
+                foldToEnd(element) { lowerTypeNameList.lastOrNull() ?: nameIdentifier }
+            }
+            is ElmTypeAliasDeclaration -> {
+                foldToEnd(element) { lowerTypeNameList.lastOrNull() ?: nameIdentifier }
+            }
+            is ElmLetIn -> {
+                val letKw = element.directChildren.find { it.elementType == LET } ?: return
+                val inKw = element.directChildren.find { it.elementType == IN } ?: return
+                foldBetween(letKw, letKw, inKw, false, false)
+                fold(element.expression)
+            }
+            is ElmCaseOf -> {
+                foldToEnd(element) { directChildren.find { it.elementType == OF } }
+            }
+            is ElmCaseOfBranch -> {
+                foldToEnd(element) { directChildren.find { it.elementType == ARROW } }
+            }
+        }
+    }
+
+    private fun fold(element: PsiElement?) {
+        if (element == null) return
+        descriptors += FoldingDescriptor(element, element.textRange)
+    }
+
+    private inline fun <T : PsiElement> foldToEnd(element: T, predicate: T.() -> PsiElement?) {
+        val start = predicate(element) ?: return
+        foldBetween(element, start, element.lastChild, false, true)
+    }
+
+    private fun foldBetween(element: PsiElement, left: PsiElement?, right: PsiElement?,
+                            includeStart: Boolean, includeEnd: Boolean) {
+        if (left == null || right == null) return
+        val start = if (includeStart) left.textRange.startOffset else left.textRange.endOffset
+        val end = if (includeEnd) right.textRange.endOffset else right.textRange.startOffset
+        descriptors += FoldingDescriptor(element, TextRange(start, end))
+    }
+}

--- a/src/main/kotlin/org/elm/ide/folding/ElmFoldingBuilder.kt
+++ b/src/main/kotlin/org/elm/ide/folding/ElmFoldingBuilder.kt
@@ -60,7 +60,7 @@ private class ElmFoldingVisitor : PsiElementVisitor() {
                 val imports = element.directChildren.filterIsInstance<ElmImportClause>().toList()
                 if (imports.size < 2) return
                 val start = imports.first()
-                foldBetween(start, start, imports.last(), true, true)
+                foldBetween(start, start.moduleQID, imports.last(), true, true)
             }
             is ElmModuleDeclaration -> {
                 val imports = element.elmFile.directChildren.filterIsInstance<ElmImportClause>().toList()
@@ -86,7 +86,7 @@ private class ElmFoldingVisitor : PsiElementVisitor() {
                 val letKw = element.directChildren.find { it.elementType == LET } ?: return
                 val inKw = element.directChildren.find { it.elementType == IN } ?: return
                 foldBetween(letKw, letKw, inKw, false, false)
-                fold(element.expression)
+                foldBetween(inKw, inKw, element.lastChild, false, true)
             }
             is ElmCaseOf -> {
                 foldToEnd(element) { directChildren.find { it.elementType == OF } }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -73,6 +73,7 @@
         <lang.syntaxHighlighterFactory language="Elm" implementationClass="org.elm.ide.highlight.ElmSyntaxHighlighterFactory"/>
         <spellchecker.support language="Elm" implementationClass="org.elm.ide.spelling.ElmSpellCheckingStrategy" />
         <lang.documentationProvider language="Elm" implementationClass="org.elm.ide.docs.ElmDocumentationProvider"/>
+        <lang.foldingBuilder language="Elm" implementationClass="org.elm.ide.folding.ElmFoldingBuilder"/>
 
         <!-- ELM PROJECTS, PACKAGES AND DEPENDENCIES -->
         <projectService serviceInterface="org.elm.workspace.ElmWorkspaceService" serviceImplementation="org.elm.workspace.ElmWorkspaceService" />

--- a/src/test/kotlin/org/elm/ide/folding/ElmFoldingBuilderTest.kt
+++ b/src/test/kotlin/org/elm/ide/folding/ElmFoldingBuilderTest.kt
@@ -1,0 +1,19 @@
+package org.elm.ide.folding
+
+import org.elm.lang.ElmTestBase
+
+class ElmFoldingBuilderTest: ElmTestBase() {
+    override val dataPath = "org/elm/ide/folding/fixtures"
+    private fun doTest() = myFixture.testFolding("$testDataPath/${fileName.trimStart('_')}")
+
+    fun `test imports`() = doTest()
+    fun `test module`() = doTest()
+    fun `test doc comment`() = doTest()
+    fun `test record`() = doTest()
+    fun `test record_type`() = doTest()
+    fun `test value declaration`() = doTest()
+    fun `test type declaration`() = doTest()
+    fun `test type alias`() = doTest()
+    fun `test let in`() = doTest()
+    fun `test case of`() = doTest()
+}

--- a/src/test/resources/org/elm/ide/folding/fixtures/case_of.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/case_of.elm
@@ -1,0 +1,7 @@
+main<fold text=' = ...'> =
+    case a of<fold text='...'>
+        () -><fold text='...'>
+            ()</fold>
+
+        () -><fold text='...'>
+            ()</fold></fold></fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/doc_comment.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/doc_comment.elm
@@ -1,0 +1,3 @@
+<fold text='{-| first line ...-}'>{-| first line
+second line
+-}</fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/imports.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/imports.elm
@@ -1,0 +1,2 @@
+import <fold text='...'>Foo
+import Bar</fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/let_in.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/let_in.elm
@@ -1,0 +1,5 @@
+main<fold text=' = ...'> =
+    let<fold text='...'>
+        foo<fold text=' = ...'> = ()</fold>
+    </fold>in<fold text='...'>
+        foo</fold></fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/module.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/module.elm
@@ -1,0 +1,11 @@
+module Mod<fold text='...'> exposing
+  ( foo
+  , bar
+  )
+
+-- some comments
+
+import <fold text='...'>Basics exposing (..)
+import Maybe
+import Maybe exposing ( Maybe(Just,Nothing) )
+import Native.List</fold></fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/record.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/record.elm
@@ -1,0 +1,4 @@
+foo<fold text=' = ...'>=
+    <fold text='{...}'>{ bar = "bar"
+    , baz = "baz"
+    }</fold></fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/record_type.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/record_type.elm
@@ -1,0 +1,3 @@
+{ foo : Foo
+, bar : Bar Int
+}

--- a/src/test/resources/org/elm/ide/folding/fixtures/type_alias.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/type_alias.elm
@@ -1,0 +1,2 @@
+type alias Foo a b<fold text=' = ...'> =
+    Int -> Int -> Int</fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/type_declaration.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/type_declaration.elm
@@ -1,0 +1,4 @@
+type Foo a<fold text=' = ...'>
+    = Bar
+    | Baz a
+    | Qux Foo a</fold>

--- a/src/test/resources/org/elm/ide/folding/fixtures/value_declaration.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/value_declaration.elm
@@ -1,0 +1,8 @@
+foo<fold text=' = ...'> =
+    ()</fold>
+
+(x, y)<fold text=' = ...'> =
+    (x, y)</fold>
+
+(||) a b<fold text=' = ...'> =
+    a ++ b</fold>


### PR DESCRIPTION
This PR adds code folding to all regions that I thought made sense. It follows the global settings for default collapse, so depending on your settings, module declarations, imports, and doc comments might be collapsed when you open a file.

![capture](https://user-images.githubusercontent.com/1109214/44685652-d67c6a80-aa00-11e8-8764-e3f0d0251a00.PNG)
