### PR TITLE
Enable filtering out imports in the Find Usages panel.

### DIFF
--- a/src/main/kotlin/org/elm/ide/usages/ElmImportFilteringRule.kt
+++ b/src/main/kotlin/org/elm/ide/usages/ElmImportFilteringRule.kt
@@ -1,0 +1,20 @@
+package org.elm.ide.usages
+
+import com.intellij.usages.Usage
+import com.intellij.usages.UsageTarget
+import com.intellij.usages.rules.ImportFilteringRule
+import com.intellij.usages.rules.PsiElementUsage
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.psi.parentOfType
+
+/**
+ * A filtering rule that allows you exclude imports from actions such as "find usages"
+ */
+class ElmImportFilteringRule : ImportFilteringRule() {
+    override fun isVisible(usage: Usage, targets: Array<UsageTarget>): Boolean {
+        val element = (usage as? PsiElementUsage)?.element
+        return element?.containingFile !is ElmFile
+                || element.parentOfType<ElmImportClause>() == null
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,6 +74,7 @@
         <spellchecker.support language="Elm" implementationClass="org.elm.ide.spelling.ElmSpellCheckingStrategy" />
         <lang.documentationProvider language="Elm" implementationClass="org.elm.ide.docs.ElmDocumentationProvider"/>
         <lang.foldingBuilder language="Elm" implementationClass="org.elm.ide.folding.ElmFoldingBuilder"/>
+        <importFilteringRule implementation="org.elm.ide.usages.ElmImportFilteringRule"/>
 
         <!-- ELM PROJECTS, PACKAGES AND DEPENDENCIES -->
         <projectService serviceInterface="org.elm.workspace.ElmWorkspaceService" serviceImplementation="org.elm.workspace.ElmWorkspaceService" />


### PR DESCRIPTION
I'd also like to be able to filter out type annotations when finding usages of a function, but there's no button for that. Maybe we could use the "show write access" or "show read access" button? It would be kind of gross, but they aren't currently hooked up, and they aren't really meaningful in a pure language.

![filtered](https://user-images.githubusercontent.com/1109214/44740324-097d3780-aaaf-11e8-8d6a-74cbb9f4bb5a.png)
![filtered2](https://user-images.githubusercontent.com/1109214/44740333-0f731880-aaaf-11e8-9008-2502f9a6aa95.png)

