### PR TITLE
Load `elm.json` files async

### DIFF
--- a/src/main/kotlin/org/elm/ide/notifications/ElmNeedsConfigNotificationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/notifications/ElmNeedsConfigNotificationProvider.kt
@@ -8,9 +8,10 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.EditorNotifications
 import org.elm.lang.core.psi.isElmFile
-import org.elm.workspace.*
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
+import org.elm.workspace.ElmToolchain
+import org.elm.workspace.ElmWorkspaceService
+import org.elm.workspace.elmToolchain
+import org.elm.workspace.elmWorkspace
 
 
 /**
@@ -38,18 +39,9 @@ class ElmNeedsConfigNotificationProvider(
     override fun getKey(): Key<EditorNotificationPanel> = PROVIDER_KEY
 
 
-    override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor)
-            : EditorNotificationPanel? {
+    override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor): EditorNotificationPanel? {
         if (!file.isElmFile || isNotificationDisabled())
             return null
-
-        try {
-            asyncAutoDiscoverWorkspace(project).get(1, TimeUnit.SECONDS)
-        } catch (e: TimeoutException) {
-            // Auto-discover took too long. Do not show any errors: it may finish later with a good setup,
-            // and if it doesn't we'll get another chance the next time a `.elm` file is opened.
-            return null
-        }
 
         val toolchain = project.elmToolchain
         if (toolchain == null || !toolchain.looksLikeValidToolchain()) {

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -119,6 +120,10 @@ class CachedVirtualFile(private val url: String?) {
         cache.set(file)
         return file
     }
+}
+
+fun LocalFileSystem.findFileByPath(path: Path): VirtualFile? {
+    return findFileByPath(path.toString())
 }
 
 val isUnitTestMode: Boolean get() = ApplicationManager.getApplication().isUnitTestMode

--- a/src/main/kotlin/org/elm/utils/future.kt
+++ b/src/main/kotlin/org/elm/utils/future.kt
@@ -53,3 +53,10 @@ fun <T> runAsyncTask(project: Project, progressTitle: String, fn: () -> T): Comp
  */
 fun <T> List<CompletableFuture<T>>.joinAll(): CompletableFuture<List<T>> =
         CompletableFuture.allOf(*this.toTypedArray()).thenApply { map { it.join() } }
+
+
+/**
+ * Handle an error, ignoring successful result.
+ */
+fun <T> CompletableFuture<T>.handleError(fn: (error: Throwable) -> Unit): CompletableFuture<Unit> =
+        handle { _, error -> fn(error) }

--- a/src/main/kotlin/org/elm/utils/future.kt
+++ b/src/main/kotlin/org/elm/utils/future.kt
@@ -1,0 +1,55 @@
+package org.elm.utils
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Run [fn] on a pooled background thread and show IntelliJ's indeterminate progress bar while it's running.
+ *
+ * @param project The IntelliJ project
+ * @param progressTitle The text to be shown with the progress bar
+ * @param fn The work to be performed in the background
+ * @return A future providing the result of [fn]
+ */
+fun <T> runAsyncTask(project: Project, progressTitle: String, fn: () -> T): CompletableFuture<T> {
+    val fut = CompletableFuture<T>()
+
+    ProgressManager.getInstance().run(
+            object : Task.Backgroundable(project, progressTitle) {
+
+                // NOTE: At first I thought that you should override [onThrowable] to make the future complete
+                // exceptionally, but when I did that, the exceptions were still escaping to the top-level.
+                // So now I just catch the exceptions myself within `run`.
+
+                override fun run(indicator: ProgressIndicator) {
+                    try {
+                        fut.complete(fn())
+                    } catch (e: ProcessCanceledException) {
+                        throw e // ProgressManager needs to be able to see these
+                    } catch (e: Throwable) {
+                        fut.completeExceptionally(e)
+                    }
+
+                }
+
+                override fun onCancel() {
+                    // TODO [kl] make sure that this is working correctly with IntelliJ cancellation
+                    fut.completeExceptionally(CancellationException())
+                    super.onCancel()
+                }
+            })
+
+    return fut
+}
+
+
+/**
+ * Join on the completion of all futures in the list.
+ */
+fun <T> List<CompletableFuture<T>>.joinAll(): CompletableFuture<List<T>> =
+        CompletableFuture.allOf(*this.toTypedArray()).thenApply { map { it.join() } }

--- a/src/main/kotlin/org/elm/workspace/ElmAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAdditionalLibraryRootsProvider.kt
@@ -4,8 +4,10 @@ import com.intellij.navigation.ItemPresentation
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
 import com.intellij.openapi.roots.SyntheticLibrary
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import org.elm.ide.icons.ElmIcons
+import org.elm.openapiext.findFileByPath
 import javax.swing.Icon
 
 
@@ -48,7 +50,7 @@ class ElmLibrary(
 
     companion object {
         fun fromPackage(pkg: ElmPackageRef): ElmLibrary? {
-            val root = pkg.root ?: return null
+            val root = pkg.rootPath?.let { LocalFileSystem.getInstance().findFileByPath(it) } ?: return null
             if (!root.exists()) return null
             return ElmLibrary(root = root, name = pkg.name)
         }

--- a/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
@@ -23,7 +23,7 @@ class ElmAttachProjectAction : AnAction() {
                 ?: return
 
         try {
-            project.elmWorkspace.attachElmProject(file.pathAsPath)
+            project.elmWorkspace.asyncAttachElmProject(file.pathAsPath)
         } catch (e: ProjectLoadException) {
             Messages.showErrorDialog(e.message, "Failed to attach Elm project")
         }

--- a/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
@@ -2,30 +2,42 @@ package org.elm.workspace
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.ui.Messages
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.saveAllDocuments
+import org.elm.utils.handleError
+
+private val ACCEPTABLE_FILE_NAMES = listOf(ElmToolchain.ELM_JSON, ElmToolchain.ELM_LEGACY_JSON)
 
 class ElmAttachProjectAction : AnAction() {
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project
                 ?: return
         saveAllDocuments()
-        val filename = ElmToolchain.ELM_JSON
-        val legacyFilename = ElmToolchain.ELM_LEGACY_JSON // TODO [drop 0.18] remove this legacy stuff
         val descriptor = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
-                .withFileFilter { it.name == filename || it.name == legacyFilename }
-                .withTitle("Select $filename (Elm 0.19) or $legacyFilename (Elm 0.18)")
+                .withFileFilter { it.name in ACCEPTABLE_FILE_NAMES }
+                .withTitle("Select elm.json (Elm 0.19) or elm-package.json (Elm 0.18)") // TODO [drop 0.18]
         val chooser = FileChooserFactory.getInstance().createFileChooser(descriptor, project, null)
         val file = chooser.choose(project).singleOrNull()
                 ?: return
 
-        try {
-            project.elmWorkspace.asyncAttachElmProject(file.pathAsPath)
-        } catch (e: ProjectLoadException) {
-            Messages.showErrorDialog(e.message, "Failed to attach Elm project")
+        if (file.name !in ACCEPTABLE_FILE_NAMES) {
+            // TODO [drop 0.18]
+            Messages.showErrorDialog("Expected elm.json or elm-package.json, got ${file.name}", "Invalid file type")
+            return
+        }
+
+        project.elmWorkspace.asyncAttachElmProject(file.pathAsPath)
+                .handleError { showError(it) }
+    }
+
+    private fun showError(error: Throwable) {
+        ApplicationManager.getApplication().invokeLater {
+            Messages.showErrorDialog(error.message, "Failed to attach Elm project")
         }
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmBuildAction.kt
@@ -17,10 +17,6 @@ class ElmBuildAction : AnAction() {
                 ?: return
         saveAllDocuments()
 
-        if (project.elmToolchain == null || !project.hasAnElmProject) {
-            guessAndSetupElmProject(project, explicitRequest = true)
-        }
-
         val compilerPath = project.elmToolchain?.elmCompilerPath
         if (compilerPath == null) {
             Messages.showErrorDialog("No path to the Elm compiler", "Build Error")

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeType
-import com.intellij.openapi.vfs.VirtualFile
-import org.elm.openapiext.CachedVirtualFile
 import org.elm.workspace.ElmToolchain.Companion.ELM_LEGACY_JSON
 import java.io.InputStream
 import java.nio.file.Path
@@ -27,12 +25,9 @@ sealed class ElmProject(
 ) {
 
     /**
-     * Returns the `elm.json` file which defines this project.
+     * The path to the directory containing the Elm project JSON file.
      */
-    val manifestFile: VirtualFile? by CachedVirtualFile(manifestPath.toUri().toString())
-
-
-    private val projectDirPath
+    val projectDirPath: Path
         get() =
             manifestPath.parent
 
@@ -44,12 +39,6 @@ sealed class ElmProject(
      */
     val presentableName: String
         get() = projectDirPath.fileName.toString()
-
-
-    /**
-     * The directory containing the project.
-     */
-    val projectDir: VirtualFile? by CachedVirtualFile(projectDirPath.toUri()?.toString())
 
 
     /**
@@ -162,7 +151,7 @@ class ElmPackageProject(
  * A dependency reference to an Elm package
  */
 class ElmPackageRef(
-        val root: VirtualFile?,
+        val rootPath: Path?,
         val name: String,
         val version: Version
 )
@@ -175,7 +164,7 @@ private fun ExactDependenciesDTO.toPackageRefs(toolchain: ElmToolchain) =
 private fun Map<String, Version>.depsToPackages(toolchain: ElmToolchain) =
         map { (name, version) ->
             ElmPackageRef(
-                    root = toolchain.packageVersionDir(name, version),
+                    rootPath = toolchain.packageVersionDir(name, version),
                     name = name,
                     version = version)
         }
@@ -188,7 +177,7 @@ private fun Map<String, Constraint>.constraintDepsToPackages(toolchain: ElmToolc
                     .firstOrNull()
 
             ElmPackageRef(
-                    root = useVersion?.let { toolchain.packageVersionDir(name, it) },
+                    rootPath = useVersion?.let { toolchain.packageVersionDir(name, it) },
                     name = name,
                     version = useVersion ?: Version.UNKNOWN)
         }

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeType
+import org.elm.openapiext.checkIsBackgroundThread
 import org.elm.workspace.ElmToolchain.Companion.ELM_LEGACY_JSON
 import java.io.InputStream
 import java.nio.file.Path
@@ -17,6 +18,10 @@ private val objectMapper = ObjectMapper()
 /**
  * The logical representation of an Elm project. An Elm project can be an application
  * or a package, and it specifies its dependencies.
+ *
+ * @param manifestPath The location of the manifest file (e.g. `elm.json`). Uniquely identifies a project.
+ * @param dependencies Additional Elm packages that this project depends on
+ * @param testDependencies Additional Elm packages that this project's **tests** depends on
  */
 sealed class ElmProject(
         val manifestPath: Path,
@@ -51,12 +56,13 @@ sealed class ElmProject(
 
     companion object {
         /**
-         * Attempts to parse an `elm.json` file
+         * Attempts to parse an `elm.json` file.
          *
          * @throws ProjectLoadException if the JSON cannot be parsed
          */
         @Throws(ProjectLoadException::class)
         fun parse(inputStream: InputStream, manifestPath: Path, toolchain: ElmToolchain): ElmProject {
+            checkIsBackgroundThread()
 
             if (manifestPath.endsWith(ELM_LEGACY_JSON)) {
                 // Handle legacy Elm 0.18 package. We don't need to model the dependencies

--- a/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
@@ -11,10 +11,10 @@ class ElmRefreshProjectsAction : AnAction() {
                 ?: return
         saveAllDocuments()
 
-        if (project.elmToolchain == null || !project.hasAnElmProject) {
-            guessAndSetupElmProject(project, explicitRequest = true)
+        if (project.elmToolchain == null || !project.elmWorkspace.hasAtLeastOneValidProject()) {
+            asyncAutoDiscoverWorkspace(project, explicitRequest = true)
         } else {
-            project.elmWorkspace.refreshAllProjects()
+            project.elmWorkspace.asyncRefreshAllProjects()
         }
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
@@ -2,7 +2,10 @@ package org.elm.workspace
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.Messages
 import org.elm.openapiext.saveAllDocuments
+import org.elm.utils.handleError
 
 class ElmRefreshProjectsAction : AnAction() {
 
@@ -15,6 +18,14 @@ class ElmRefreshProjectsAction : AnAction() {
             asyncAutoDiscoverWorkspace(project, explicitRequest = true)
         } else {
             project.elmWorkspace.asyncRefreshAllProjects()
+        }.handleError {
+            showError(it)
+        }
+    }
+
+    private fun showError(error: Throwable) {
+        ApplicationManager.getApplication().invokeLater {
+            Messages.showErrorDialog(error.message, "Failed to refresh Elm projects")
         }
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -8,8 +8,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.io.exists
 import com.intellij.util.io.isDirectory
 import org.elm.openapiext.GeneralCommandLine
@@ -70,14 +68,13 @@ data class ElmToolchain(val binDirPath: Path) {
     /**
      * Path to directory for a package at a specific version, containing `elm.json`
      */
-    fun packageVersionDir(name: String, version: Version): VirtualFile? {
+    fun packageVersionDir(name: String, version: Version): Path? {
         // TODO [kl] stop hard-coding the compiler version
         // it's ok to assume 19 here because this will never be called from 0.18 code,
         // but even this assumption will not be safe once future 19 releases are made.
         val compilerVersion = "0.19.0"
 
-        val path = "$elmHomePath/$compilerVersion/package/$name/$version/"
-        return LocalFileSystem.getInstance().findFileByPath(path)
+        return Paths.get("$elmHomePath/$compilerVersion/package/$name/$version/")
     }
 
     /**

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -21,13 +21,13 @@ import com.intellij.openapi.util.EmptyRunnable
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.VirtualFileWithId
 import com.intellij.util.Consumer
 import com.intellij.util.indexing.LightDirectoryIndex
 import com.intellij.util.io.exists
 import com.intellij.util.io.systemIndependentPath
 import com.intellij.util.messages.Topic
 import org.elm.ide.notifications.showBalloon
+import org.elm.openapiext.findFileByPath
 import org.elm.openapiext.modules
 import org.elm.openapiext.pathAsPath
 import org.elm.workspace.ui.ElmWorkspaceConfigurable
@@ -242,13 +242,11 @@ class ElmWorkspaceService(
                 fun put(file: VirtualFile?, elmProject: ElmProject) {
                     if (file == null || file in visited) return
                     visited += file
-                    val theId = (file as VirtualFileWithId).id
-                    println("storing $theId for $file")
                     index.putInfo(file, elmProject)
                 }
 
                 for (project in allProjects) {
-                    put(project.projectDir, project)
+                    put(LocalFileSystem.getInstance().findFileByPath(project.projectDirPath), project)
                     // TODO [kl] re-visit this when we allow projects within projects
                     // We probably will need to register additional directories based
                     // on how [LightDirectoryIndex] walks up the directory tree.

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -166,6 +166,16 @@ class ElmWorkspaceService(
                         ?: throw ProjectLoadException("Elm toolchain not configured")
 
                 ElmProject.parse(file.inputStream, manifestPath, toolchain)
+            }.whenComplete { _, error ->
+                // log the result
+                if (error == null) {
+                    log.info("Successfully loaded Elm project $manifestPath")
+                } else {
+                    when (error) {
+                        is ProjectLoadException -> log.warn("Failed to load $manifestPath: ${error.message}")
+                        else -> log.error("Unexpected error when loading $manifestPath", error)
+                    }
+                }
             }
 
 

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -270,7 +270,11 @@ class ElmWorkspaceService(
     }
 
     @VisibleForTesting
-    internal fun asyncLoadState(state: Element): CompletableFuture<Unit> {
+    // TODO [kl] make this `internal` visibility...
+    // I can't do it right now because there's something wrong with Gradle where it treats the test source set
+    // as not belonging to the same Kotlin module as the code-under-test. But according to
+    // https://kotlinlang.org/docs/reference/visibility-modifiers.html#modules it *should* work!
+    fun asyncLoadState(state: Element): CompletableFuture<Unit> {
         // Must load the Settings before the Elm Projects in order to have an ElmToolchain ready
         val settingsElement = state.getChild("settings")
         val binDirPath = settingsElement.getAttributeValue("binDirPath").takeIf { it.isNotBlank() }

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -1,11 +1,10 @@
-package org.elmSlowTests
+package org.elm.workspace
 
 import junit.framework.TestCase
 import org.elm.fileTree
 import org.elm.openapiext.elementFromXmlString
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.toXmlString
-import org.elm.workspace.*
 
 class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -36,7 +36,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val workspace = project.elmWorkspace.apply {
-            asyncAttachElmProject(rootPath.resolve("a/elm.json"))
+            asyncAttachElmProject(rootPath.resolve("a/elm.json")).get()
         }
 
         fun checkFile(relativePath: String, projectName: String?) {
@@ -88,7 +88,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val workspace = project.elmWorkspace.apply {
-            asyncAttachElmProject(rootPath.resolve("a/elm.json"))
+            asyncAttachElmProject(rootPath.resolve("a/elm.json")).get()
         }
 
         val elmProject = workspace.allProjects.firstOrNull()
@@ -143,7 +143,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val workspace = project.elmWorkspace.apply {
-            asyncAttachElmProject(rootPath.resolve("elm.json"))
+            asyncAttachElmProject(rootPath.resolve("elm.json")).get()
         }
 
         val elmProject = workspace.allProjects.firstOrNull()

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -12,6 +12,7 @@ import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
 import org.elm.FileTree
 import org.elm.TestProject
+import java.util.concurrent.CompletableFuture
 
 /**
  * Base class for "heavy" integration tests such as those that depend on the Elm toolchain
@@ -30,14 +31,9 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
         get() = myFixture.findFileInTempDir(".")
 
 
-    protected fun FileTree.createWithAutoDiscover(): TestProject =
-            create(project, elmWorkspaceDirectory).apply {
-                refreshWorkspace()
-            }
-
-
-    protected fun refreshWorkspace() {
-        project.elmWorkspace.discoverAndRefresh()
+    protected fun FileTree.asyncCreateWithAutoDiscover(): CompletableFuture<TestProject> {
+        val testProject = create(project, elmWorkspaceDirectory)
+        return project.elmWorkspace.asyncDiscoverAndRefresh().thenApply { testProject }
     }
 
 

--- a/src/test/kotlin/org/elmSlowTests/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elmSlowTests/ElmWorkspaceServiceTest.kt
@@ -37,7 +37,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val workspace = project.elmWorkspace.apply {
-            attachElmProject(rootPath.resolve("a/elm.json"))
+            asyncAttachElmProject(rootPath.resolve("a/elm.json"))
         }
 
         fun checkFile(relativePath: String, projectName: String?) {
@@ -89,7 +89,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val workspace = project.elmWorkspace.apply {
-            attachElmProject(rootPath.resolve("a/elm.json"))
+            asyncAttachElmProject(rootPath.resolve("a/elm.json"))
         }
 
         val elmProject = workspace.allProjects.firstOrNull()
@@ -144,7 +144,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val workspace = project.elmWorkspace.apply {
-            attachElmProject(rootPath.resolve("elm.json"))
+            asyncAttachElmProject(rootPath.resolve("elm.json"))
         }
 
         val elmProject = workspace.allProjects.firstOrNull()
@@ -190,7 +190,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             }
         }.create(project, elmWorkspaceDirectory)
 
-        val elmProjects = project.elmWorkspace.discoverAndRefresh()
+        val elmProjects = project.elmWorkspace.asyncDiscoverAndRefresh().get()
         check(elmProjects.size == 1) { "Should have found one Elm project but found ${elmProjects.size}" }
         val elmProject = elmProjects.first()
         check(elmProject.manifestPath == testProject.root.pathAsPath.resolve("elm.json"))
@@ -204,7 +204,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             }
         }.create(project, elmWorkspaceDirectory)
 
-        val elmProjects = project.elmWorkspace.discoverAndRefresh()
+        val elmProjects = project.elmWorkspace.asyncDiscoverAndRefresh().get()
         check(elmProjects.isEmpty()) { "Should have found zero Elm projects but found ${elmProjects.size}" }
     }
 
@@ -249,7 +249,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             """.trimIndent()
 
         // ... must be able to load from serialized state ...
-        workspace.loadState(elementFromXmlString(xml))
+        workspace.asyncLoadState(elementFromXmlString(xml)).get()
         val actualProjects = workspace.allProjects.map { it.manifestPath }
         val expectedProjects = listOf(projectPath)
         checkEquals(expectedProjects, actualProjects)


### PR DESCRIPTION
The `ElmWorkspaceService` holds the list of Elm projects known within the current IntelliJ project. Previously, the service would do its work synchronously on the event dispatch thread (EDT). The only reason it was acceptable to block the EDT was that the current implementation of loading an Elm project is very simple (just read a single json file from disk). But as we add support for crawling transitive dependencies and invoking external tools, this will not work anymore.

This PR modifies the `ElmWorkspaceService` so that it does most of its work async on IntelliJ's background thread pool (unbounded, suitable for both I/O- and CPU-bound tasks).

@ajalt I'd like to know how you feel about this. It feels a little loosey-goosey to me. I'd feel more comfortable if there were some constraints like a serial queue for writes, but maybe that's overkill?? Another concern I have is that it's so easy for the caller to ignore the `CompletableFuture` return value  and pretend that things are happening synchronously (which is why I gave all the methods an `async` prefix in the method name to emphasize the fact).