### PR TITLE
Allow multiple Elm projects to co-exist in the same IntelliJ project

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -9,7 +9,7 @@ import org.elm.lang.core.resolve.scope.ExpressionScope
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ImportScope
 import org.elm.lang.core.resolve.scope.ModuleScope
-import org.elm.lang.core.stubs.index.ElmModulesIndex
+import org.elm.lang.core.stubs.index.ElmModules
 
 
 /**
@@ -75,7 +75,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
     }
 
     private fun suggestQualifiers(qualifierPrefix: String, file: ElmFile, result: CompletionResultSet) {
-        ElmModulesIndex.getAll(file.project)
+        ElmModules.getAll(file.project, file.elmProject)
                 .filter { it.name.startsWith(qualifierPrefix) && it.name != qualifierPrefix }
                 .map { it.name.removePrefix("$qualifierPrefix.").substringBefore('.') }
                 .forEach { result.add(it) }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -11,6 +11,8 @@ import com.intellij.psi.stubs.StubElement
 import org.elm.lang.core.ElmFileType
 import org.elm.lang.core.ElmLanguage
 import org.elm.lang.core.stubs.*
+import org.elm.workspace.ElmProject
+import org.elm.workspace.elmWorkspace
 
 
 class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLanguage) {
@@ -39,6 +41,10 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
         val nameWithExtension = if (name.endsWith(".elm")) name else "$name.elm"
         return super.setName(nameWithExtension)
     }
+
+    val elmProject: ElmProject?
+        // TODO [kl] why would virtualFile be null? I'm guessing it has to do with how the light integration tests work?
+        get() = virtualFile?.let { project.elmWorkspace.findProjectForFile(it) }
 
     fun getModuleDecl() =
             getStubOrPsiChild(ElmModuleDeclarationStub.Type)

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -43,8 +43,10 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
     }
 
     val elmProject: ElmProject?
-        // TODO [kl] why would virtualFile be null? I'm guessing it has to do with how the light integration tests work?
-        get() = virtualFile?.let { project.elmWorkspace.findProjectForFile(it) }
+        // Must use [originalFile] because during code completion the direct [virtualFile] is an
+        // in-memory copy of the real file. See:
+        // https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000108704/comments/115000123710
+        get() = project.elmWorkspace.findProjectForFile(originalFile.virtualFile)
 
     fun getModuleDecl() =
             getStubOrPsiChild(ElmModuleDeclarationStub.Type)

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiElementImpl.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiElementImpl.kt
@@ -8,6 +8,8 @@ import com.intellij.psi.StubBasedPsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
 import org.elm.lang.core.resolve.reference.ElmReference
+import org.elm.workspace.ElmProject
+import org.elm.workspace.elmWorkspace
 
 
 /**
@@ -18,6 +20,14 @@ interface ElmPsiElement : PsiElement {
      * Get the file containing this element as an [ElmFile]
      */
     val elmFile: ElmFile
+
+    /**
+     * Get the Elm project which this element's file belongs to.
+     *
+     * Returns null if the containing Elm project's manifest (`elm.json`) has not
+     * yet been attached to the workspace.
+     */
+    val elmProject: ElmProject?
 }
 
 /**
@@ -27,6 +37,9 @@ abstract class ElmPsiElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), El
 
     override val elmFile: ElmFile
         get() = containingFile as ElmFile
+
+    override val elmProject: ElmProject?
+        get() = project.elmWorkspace.findProjectForFile(elmFile.virtualFile)
 
     // Make the type-system happy by using our reference interface instead of PsiReference
     override fun getReferences(): Array<ElmReference> {
@@ -51,6 +64,8 @@ abstract class ElmStubbedElement<StubT : StubElement<*>>
     override val elmFile: ElmFile
         get() = containingFile as ElmFile
 
+    override val elmProject: ElmProject?
+        get() = project.elmWorkspace.findProjectForFile(elmFile.virtualFile)
 
     // Make the type-system happy by using our reference interface instead of PsiReference
     override fun getReferences(): Array<ElmReference> {

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiElementImpl.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiElementImpl.kt
@@ -39,7 +39,7 @@ abstract class ElmPsiElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), El
         get() = containingFile as ElmFile
 
     override val elmProject: ElmProject?
-        get() = project.elmWorkspace.findProjectForFile(elmFile.virtualFile)
+        get() = elmFile.elmProject
 
     // Make the type-system happy by using our reference interface instead of PsiReference
     override fun getReferences(): Array<ElmReference> {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
@@ -2,19 +2,12 @@ package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
-import org.elm.lang.core.stubs.index.ElmModulesIndex
-import org.elm.openapiext.findFileByMaybeRelativePath
-import org.elm.openapiext.findFileByPath
-import org.elm.workspace.ElmApplicationProject
-import org.elm.workspace.ElmPackageProject
-import org.elm.workspace.ElmProject
-import org.elm.workspace.Version
+import org.elm.lang.core.stubs.index.ElmModules
 
 private val log = logger<ElmImportClause>()
 
@@ -53,58 +46,10 @@ class ElmImportClause(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElem
     override fun getReference() =
             object : ElmReferenceCached<ElmImportClause>(this) {
 
-                override fun resolveInner(): ElmNamedElement? {
-                    return getVariants().find { it.name == element.referenceName }
-                }
+                override fun resolveInner(): ElmNamedElement? =
+                        getVariants().find { it.name == element.referenceName }
 
-                override fun getVariants(): Array<ElmNamedElement> {
-                    val elmProject = element.elmProject
-
-                    // The lightweight integration tests do not have an associated Elm Project,
-                    // so we will just treat them as if all Elm files were in scope.
-                    // TODO [kl] re-visit this as it could mask a real bug.
-                    val allowAllProjects = if (elmProject == null) {
-                        log.warn("Could not find Elm project containing ${elmFile.virtualFile.path}")
-                        true
-                    } else {
-                        false
-                    }
-
-                    return ElmModulesIndex.getAll(element.project)
-                            .filter { allowAllProjects || elmProject!!.exposes(it) }
-                            .toTypedArray()
-                }
+                override fun getVariants(): Array<ElmNamedElement> =
+                        ElmModules.getAll(project, element.elmProject).toTypedArray()
             }
-}
-
-/**
- * Returns true if [moduleDeclaration] is visible within the receiver [ElmProject].
- */
-private fun ElmProject.exposes(moduleDeclaration: ElmModuleDeclaration): Boolean {
-    // Since we do not fully support project-scope name resolution for Elm 0.18 projects,
-    // we will treat all Elm modules as visible.
-    when (this) {
-        is ElmApplicationProject ->
-            if (elmVersion == Version(0, 18, 0))
-                return true
-
-        is ElmPackageProject ->
-            if (elmVersion.low == Version(0, 18, 0))
-                return true
-    }
-
-    val elmModuleRelativePath = moduleDeclaration.name.replace('.', '/') + ".elm"
-
-    // check if the module is reachable from the top-level of the containing Elm project
-    val virtualDirs = sourceDirectories.map { projectDirPath.resolve(it) }
-            .mapNotNull { LocalFileSystem.getInstance().findFileByPath(it) }
-    if (virtualDirs.any { it.findFileByMaybeRelativePath(elmModuleRelativePath) != null })
-        return true
-
-    // check if the module is reachable from a direct dependency
-    if (dependencies.any { it.exposedModules.contains(moduleDeclaration.name) })
-        return true
-
-
-    return false
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
@@ -1,13 +1,19 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
 import org.elm.lang.core.stubs.index.ElmModulesIndex
+import org.elm.openapiext.findFileByMaybeRelativePath
+import org.elm.openapiext.findFileByPath
+import org.elm.workspace.*
 
+private val log = logger<ElmImportClause>()
 
 /**
  * An import declaration at the top of the module.
@@ -48,7 +54,52 @@ class ElmImportClause(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElem
                     return getVariants().find { it.name == element.referenceName }
                 }
 
-                override fun getVariants(): Array<ElmNamedElement> =
-                        ElmModulesIndex.getAll(element.project).toTypedArray()
+                override fun getVariants(): Array<ElmNamedElement> {
+                    val virtualFile = element.elmFile.virtualFile
+                    val elmProject = element.project.elmWorkspace.findProjectForFile(virtualFile)
+
+                    // The lightweight integration tests do not have an associated Elm Project,
+                    // so we will just treat it as if all Elm files were in scope.
+                    val allowAllProjects = if (elmProject == null) {
+                        log.warn("Could not find Elm project containing ${virtualFile.path}")
+                        true
+                    } else {
+                        false
+                    }
+
+                    return ElmModulesIndex.getAll(element.project)
+                            .filter { allowAllProjects || elmProject!!.exposes(it) }
+                            .toTypedArray()
+                }
             }
+}
+
+/**
+ * Returns true if [moduleDeclaration] is visible within the receiver [ElmProject].
+ */
+private fun ElmProject.exposes(moduleDeclaration: ElmModuleDeclaration): Boolean {
+    // Since we do not fully support project-scope name resolution for Elm 0.18 projects,
+    // we will treat all Elm modules as visible.
+    when (this) {
+        is ElmApplicationProject ->
+            if (elmVersion == Version(0, 18, 0))
+                return true
+
+        is ElmPackageProject ->
+            if (elmVersion.low == Version(0, 18, 0))
+                return true
+    }
+
+    val elmModuleRelativePath = moduleDeclaration.name.replace('.', '/') + ".elm"
+
+    // check if the module is reachable from the top-level of the containing Elm project
+    val virtualDirs = sourceDirectories.map { projectDirPath.resolve(it) }
+            .mapNotNull { LocalFileSystem.getInstance().findFileByPath(it) }
+    if (virtualDirs.none { it.findFileByMaybeRelativePath(elmModuleRelativePath) != null })
+        return false
+
+    // TODO [kl] check if the module is reachable from a DIRECT dependency
+
+
+    return true
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
@@ -11,6 +11,7 @@ import org.elm.lang.core.psi.offsetIn
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.stubs.index.ElmModules
 import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 /**
@@ -38,7 +39,7 @@ class QualifiedModuleNameReference<T : ElmReferenceElement>(
                         .let { ElmModulesIndex.getAll(it, element.project) }
 
         val implicitDecls =
-                ElmModulesIndex.getAll(GlobalScope.defaultImports, element.project)
+                ElmModules.getAll(GlobalScope.defaultImports, element.project, element.elmProject)
                         .filter { it.elmFile.isCore() }
 
         val aliasDecls = ModuleScope(element.elmFile).getAliasDecls() as List<ElmNamedElement>

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -2,14 +2,18 @@ package org.elm.lang.core.resolve.scope
 
 import com.intellij.openapi.project.Project
 import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.stubs.index.ElmModulesIndex
+import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.workspace.ElmProject
 
 
 /**
  * The subset of implicitly exposed values, types and constructors provided by Elm's
  * standard library ("Core").
  */
-class GlobalScope(val project: Project) {
+// TODO [kl] eventually ElmProject should be non-null, but we need to straighten out
+//           some things with the integration tests and legacy Elm 0.18 projects before
+//           we can be more restrictive here.
+class GlobalScope(val project: Project, val elmProject: ElmProject?) {
 
     companion object {
         /**
@@ -47,7 +51,7 @@ class GlobalScope(val project: Project) {
 
     fun getVisibleValues(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
-                ElmModulesIndex.get(moduleName, project)
+                ElmModules.get(moduleName, project, elmProject)
                         ?.let { ModuleScope(it.elmFile).getDeclaredValues() }
                         ?: emptyList()
 
@@ -64,7 +68,7 @@ class GlobalScope(val project: Project) {
 
     fun getVisibleTypes(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
-                ElmModulesIndex.get(moduleName, project)
+                ElmModules.get(moduleName, project, elmProject)
                         ?.let { ModuleScope(it.elmFile).getDeclaredTypes() }
                         ?: emptyList()
 
@@ -83,7 +87,7 @@ class GlobalScope(val project: Project) {
 
     fun getVisibleConstructors(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
-                ElmModulesIndex.get(moduleName, project)
+                ElmModules.get(moduleName, project, elmProject)
                         ?.let { ModuleScope(it.elmFile).getDeclaredConstructors() }
                         ?: emptyList()
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -5,7 +5,7 @@ import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
-import org.elm.lang.core.stubs.index.ElmModulesIndex
+import org.elm.lang.core.stubs.index.ElmModules
 
 
 /**
@@ -23,7 +23,7 @@ class ImportScope(val elmFile: ElmFile) {
          */
         fun fromImportDecl(importDecl: ElmImportClause): ImportScope? {
             val moduleName = importDecl.moduleQID.text
-            return ElmModulesIndex.get(moduleName, importDecl.project)
+            return ElmModules.get(moduleName, importDecl.project, importDecl.elmProject)
                     ?.let { ImportScope(it.elmFile) }
         }
 
@@ -34,7 +34,7 @@ class ImportScope(val elmFile: ElmFile) {
          */
         fun fromQualifierPrefixInModule(qualifierPrefix: String, elmFile: ElmFile): List<ImportScope> {
             // handle implicit imports from Core
-            val implicitScopes = ElmModulesIndex.getAll(listOf(qualifierPrefix), elmFile.project)
+            val implicitScopes = ElmModules.getAll(listOf(qualifierPrefix), elmFile.project, elmFile.elmProject)
                     .filter { it.elmFile.isCore() && qualifierPrefix in GlobalScope.defaultImports }
                     .map { ImportScope(it.elmFile) }
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -63,7 +63,7 @@ class ModuleScope(val elmFile: ElmFile) {
                 if (elmFile.isCore())
                     emptyList()
                 else
-                    GlobalScope(elmFile.project).getVisibleValues()
+                    GlobalScope(elmFile.project, elmFile.elmProject).getVisibleValues()
         val topLevelValues = getDeclaredValues()
         val importedValues = elmFile.findChildrenByClass(ElmImportClause::class.java)
                 .flatMap { getVisibleImportNames(it) }
@@ -111,7 +111,7 @@ class ModuleScope(val elmFile: ElmFile) {
                 if (elmFile.isCore())
                     emptyList()
                 else
-                    GlobalScope(elmFile.project).getVisibleTypes()
+                    GlobalScope(elmFile.project, elmFile.elmProject).getVisibleTypes()
         val topLevelTypes = getDeclaredTypes()
         val importedTypes = elmFile.findChildrenByClass(ElmImportClause::class.java)
                 .flatMap { getVisibleImportTypes(it) }
@@ -153,7 +153,7 @@ class ModuleScope(val elmFile: ElmFile) {
                 if (elmFile.isCore())
                     emptyList()
                 else
-                    GlobalScope(elmFile.project).getVisibleConstructors()
+                    GlobalScope(elmFile.project, elmFile.elmProject).getVisibleConstructors()
         val topLevelConstructors = getDeclaredConstructors()
         val importedConstructors = elmFile.findChildrenByClass(ElmImportClause::class.java)
                 .flatMap { getVisibleImportConstructors(it) }

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModules.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModules.kt
@@ -1,0 +1,87 @@
+package org.elm.lang.core.stubs.index
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import org.elm.lang.core.psi.elements.ElmModuleDeclaration
+import org.elm.openapiext.findFileByMaybeRelativePath
+import org.elm.openapiext.findFileByPath
+import org.elm.workspace.ElmApplicationProject
+import org.elm.workspace.ElmPackageProject
+import org.elm.workspace.ElmProject
+import org.elm.workspace.Version
+
+
+// TODO [kl] figure out a better name for this. Maybe it should be part of the 'Scope' system?
+
+/**
+ * Find Elm modules within an Elm project.
+ */
+class ElmModules {
+    companion object {
+
+        /**
+         * Returns all Elm modules which are visible to [elmProject]
+         */
+        fun getAll(intellijProject: Project, elmProject: ElmProject?) =
+                ElmModulesIndex.getAll(intellijProject)
+                        .filter { elmProject.exposes(it) }
+
+        /**
+         * Returns all Elm modules whose names match an element in [moduleNames] and which are visible to [elmProject]
+         */
+        fun getAll(moduleNames: Collection<String>, intellijProject: Project, elmProject: ElmProject?) =
+                ElmModulesIndex.getAll(moduleNames, intellijProject)
+                        .filter { elmProject.exposes(it) }
+
+        /**
+         * Returns an Elm module named [moduleName] which is visible to [elmProject], if any
+         */
+        fun get(moduleName: String, intellijProject: Project, elmProject: ElmProject?) =
+                ElmModulesIndex.get(moduleName, intellijProject)
+                        ?.takeIf { elmProject.exposes(it) }
+    }
+}
+
+
+/**
+ * Returns true if [moduleDeclaration] is visible within the receiver [ElmProject].
+ */
+private fun ElmProject?.exposes(moduleDeclaration: ElmModuleDeclaration): Boolean {
+    if (this == null) {
+        // The lightweight integration tests do not have an associated Elm Project,
+        // so we will just treat them as if all Elm files were in scope.
+        //
+        // Depending on how we handle legacy (Elm 0.18) projects, this hack may be
+        // necessary independent of integration test concerns. Specifically, whether
+        // we resolve 0.18 dependencies (as of 2018-09-29, we do not).
+        //
+        // TODO [kl] re-visit this as it could mask a real bug.
+        return true
+    }
+
+    // Since we do not fully support project-scope name resolution for Elm 0.18 projects,
+    // we will treat all Elm modules as visible.
+    when (this) {
+        is ElmApplicationProject ->
+            if (elmVersion == Version(0, 18, 0))
+                return true
+
+        is ElmPackageProject ->
+            if (elmVersion.low == Version(0, 18, 0))
+                return true
+    }
+
+    val elmModuleRelativePath = moduleDeclaration.name.replace('.', '/') + ".elm"
+
+    // check if the module is reachable from the top-level of the containing Elm project
+    val virtualDirs = sourceDirectories.map { projectDirPath.resolve(it) }
+            .mapNotNull { LocalFileSystem.getInstance().findFileByPath(it) }
+    if (virtualDirs.any { it.findFileByMaybeRelativePath(elmModuleRelativePath) != null })
+        return true
+
+    // check if the module is reachable from a direct dependency
+    if (dependencies.any { it.exposedModules.contains(moduleDeclaration.name) })
+        return true
+
+    return false
+}

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
@@ -14,7 +14,15 @@ import org.elm.lang.core.stubs.ElmModuleDeclarationStub
 
 private val logger = Logger.getInstance(ElmModulesIndex::class.java)
 
-
+/**
+ * Low-level index of all known Elm modules in an IntelliJ project.
+ *
+ * **IMPORTANT:** For most application code, this is far too general. Typically you would
+ * want to restrict the module name space by an Elm project, as defined by an `elm.json` file.
+ * In which case you should instead use [ElmModules].
+ *
+ * @see ElmModules
+ */
 class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
 
     override fun getVersion() =

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -35,6 +35,7 @@ import org.jdom.Element
 import org.jdom.input.SAXBuilder
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KProperty
 
@@ -84,6 +85,21 @@ fun VirtualFile.findFileByMaybeRelativePath(path: String): VirtualFile? =
             fileSystem.findFileByPath(path)
         else
             findFileByRelativePath(path)
+
+fun VirtualFile.findFileBreadthFirst(predicate: (VirtualFile) -> Boolean): VirtualFile? {
+    val queue = LinkedList<VirtualFile>().also { it.push(this) }
+    while (queue.isNotEmpty()) {
+        val candidate = queue.pop()
+        if (predicate(candidate)) {
+            return candidate
+        } else {
+            for (child in candidate.children) {
+                queue.add(child)
+            }
+        }
+    }
+    return null
+}
 
 val VirtualFile.pathAsPath: Path get() = Paths.get(path)
 

--- a/src/main/kotlin/org/elm/workspace/ElmAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAdditionalLibraryRootsProvider.kt
@@ -49,8 +49,8 @@ class ElmLibrary(
             name
 
     companion object {
-        fun fromPackage(pkg: ElmPackageRef): ElmLibrary? {
-            val root = pkg.rootPath?.let { LocalFileSystem.getInstance().findFileByPath(it) } ?: return null
+        fun fromPackage(pkg: ElmPackageProject): ElmLibrary? {
+            val root = LocalFileSystem.getInstance().findFileByPath(pkg.projectDirPath) ?: return null
             if (!root.exists()) return null
             return ElmLibrary(root = root, name = pkg.name)
         }

--- a/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
@@ -9,8 +9,8 @@ import com.intellij.openapi.ui.Messages
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.saveAllDocuments
 import org.elm.utils.handleError
+import org.elm.workspace.ElmToolchain.Companion.ELM_MANIFEST_FILE_NAMES
 
-private val ACCEPTABLE_FILE_NAMES = listOf(ElmToolchain.ELM_JSON, ElmToolchain.ELM_LEGACY_JSON)
 
 class ElmAttachProjectAction : AnAction() {
 
@@ -20,14 +20,14 @@ class ElmAttachProjectAction : AnAction() {
         saveAllDocuments()
 
         val descriptor = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
-                .withFileFilter { it.name in ACCEPTABLE_FILE_NAMES }
+                .withFileFilter { it.name in ELM_MANIFEST_FILE_NAMES }
                 .withTitle("Select elm.json (Elm 0.19) or elm-package.json (Elm 0.18)") // TODO [drop 0.18]
         descriptor.isForcedToUseIdeaFileChooser = true
 
         val file = FileChooser.chooseFile(descriptor, project, null)
                 ?: return
 
-        if (file.name !in ACCEPTABLE_FILE_NAMES) {
+        if (file.name !in ELM_MANIFEST_FILE_NAMES) {
             // TODO [drop 0.18]
             Messages.showErrorDialog("Expected elm.json or elm-package.json, got ${file.name}", "Invalid file type")
             return

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -21,11 +21,13 @@ private val objectMapper = ObjectMapper()
  * @param manifestPath The location of the manifest file (e.g. `elm.json`). Uniquely identifies a project.
  * @param dependencies Additional Elm packages that this project depends on
  * @param testDependencies Additional Elm packages that this project's **tests** depends on
+ * @param sourceDirectories The paths to one-or-more directories containing Elm source files belonging to this project.
  */
 sealed class ElmProject(
         val manifestPath: Path,
         val dependencies: List<ElmPackageRef>,
-        val testDependencies: List<ElmPackageRef>
+        val testDependencies: List<ElmPackageRef>,
+        val sourceDirectories: List<Path>
 ) {
 
     /**
@@ -111,6 +113,7 @@ sealed class ElmProject(
                             elmVersion = dto.elmVersion,
                             dependencies = dto.dependencies.constraintDepsToPackages(toolchain),
                             testDependencies = dto.testDependencies.constraintDepsToPackages(toolchain),
+                            sourceDirectories = listOf(Paths.get("src")),
                             name = dto.name,
                             version = dto.version,
                             exposedModules = dto.exposedModulesNode.toExposedModuleMap())
@@ -131,8 +134,8 @@ class ElmApplicationProject(
         val elmVersion: Version,
         dependencies: List<ElmPackageRef>,
         testDependencies: List<ElmPackageRef>,
-        val sourceDirectories: List<String>
-) : ElmProject(manifestPath, dependencies, testDependencies)
+        sourceDirectories: List<Path>
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
 
 
 /**
@@ -143,10 +146,11 @@ class ElmPackageProject(
         val elmVersion: Constraint,
         dependencies: List<ElmPackageRef>,
         testDependencies: List<ElmPackageRef>,
+        sourceDirectories: List<Path>,
         val name: String,
         val version: Version,
         val exposedModules: List<String>
-) : ElmProject(manifestPath, dependencies, testDependencies)
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
 
 
 /**
@@ -206,7 +210,7 @@ private interface ElmProjectDTO
 
 private class ElmApplicationProjectDTO(
         @JsonProperty("elm-version") val elmVersion: Version,
-        @JsonProperty("source-directories") val sourceDirectories: List<String>,
+        @JsonProperty("source-directories") val sourceDirectories: List<Path>,
         @JsonProperty("dependencies") val dependencies: ExactDependenciesDTO,
         @JsonProperty("test-dependencies") val testDependencies: ExactDependenciesDTO
 ) : ElmProjectDTO

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -77,6 +77,14 @@ data class ElmToolchain(val binDirPath: Path) {
     }
 
     /**
+     * Path to the manifest file for the Elm package [name] at version [version]
+     */
+    fun findPackageManifest(name: String, version: Version): Path? {
+        // TODO [kl] use compiler version to determine whether to use elm.json vs elm-package.json
+        return packageVersionDir(name, version)?.resolve(ELM_JSON)
+    }
+
+    /**
      * Path to directory for a package, containing one or more versions
      */
     fun availableVersionsForPackage(name: String): List<Version> {

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -110,6 +110,10 @@ data class ElmToolchain(val binDirPath: Path) {
         const val ELM_JSON = "elm.json"
         const val ELM_LEGACY_JSON = "elm-package.json" // TODO [drop 0.18]
 
+        // TODO [drop 0.18] this list will no longer be necessary once the migration to 0.19 is complete
+        val ELM_MANIFEST_FILE_NAMES = listOf(ElmToolchain.ELM_JSON, ElmToolchain.ELM_LEGACY_JSON)
+
+        // TODO [drop 0.18] set the min compiler version to 0.19
         val MIN_SUPPORTED_COMPILER_VERSION = Version(0, 18, 0)
 
         /** Suggest a toolchain that exists in in any standard location */

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -159,13 +159,10 @@ class ElmWorkspaceService(
      */
     private fun asyncLoadProject(manifestPath: Path): CompletableFuture<ElmProject> =
             runAsyncTask(intellijProject, "Loading Elm project '$manifestPath'") {
-                val file = LocalFileSystem.getInstance().refreshAndFindFileByPath(manifestPath.toString())
-                        ?: throw ProjectLoadException("Could not find file $manifestPath")
-
                 val toolchain = settings.toolchain
                         ?: throw ProjectLoadException("Elm toolchain not configured")
 
-                ElmProject.parse(file.inputStream, manifestPath, toolchain)
+                ElmProject.parse(manifestPath, toolchain)
             }.whenComplete { _, error ->
                 // log the result
                 if (error == null) {

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -151,7 +151,7 @@ class ElmWorkspaceService(
      */
     private fun upsertProject(elmProject: ElmProject): List<ElmProject> =
             modifyProjects { projects ->
-                val otherProjects = projects.filter { it.manifestPath == elmProject.manifestPath }
+                val otherProjects = projects.filter { it.manifestPath != elmProject.manifestPath }
                 otherProjects + elmProject
             }
 
@@ -181,19 +181,11 @@ class ElmWorkspaceService(
     // WORKSPACE ACTIONS
 
 
-    fun asyncAttachElmProject(manifestPath: Path): CompletableFuture<List<ElmProject>> {
-        if (allProjects.count() != 0) {
-            return CompletableFuture.supplyAsync {
-                throw ProjectLoadException("Multiple Elm projects are not yet supported. "
-                        + "You must remove the existing project before adding this one.")
-            }
-        }
-
-        return asyncLoadProject(manifestPath)
-                .thenApply {
-                    upsertProject(it)
-                }
-    }
+    fun asyncAttachElmProject(manifestPath: Path): CompletableFuture<List<ElmProject>> =
+            asyncLoadProject(manifestPath)
+                    .thenApply {
+                        upsertProject(it)
+                    }
 
 
     fun detachElmProject(manifestPath: Path) {

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -28,11 +28,13 @@ import com.intellij.util.io.exists
 import com.intellij.util.io.systemIndependentPath
 import com.intellij.util.messages.Topic
 import org.elm.ide.notifications.showBalloon
+import org.elm.openapiext.findFileBreadthFirst
 import org.elm.openapiext.findFileByPath
 import org.elm.openapiext.modules
 import org.elm.openapiext.pathAsPath
 import org.elm.utils.joinAll
 import org.elm.utils.runAsyncTask
+import org.elm.workspace.ElmToolchain.Companion.ELM_MANIFEST_FILE_NAMES
 import org.elm.workspace.ui.ElmWorkspaceConfigurable
 import org.jdom.Element
 import java.nio.file.Path
@@ -220,11 +222,10 @@ class ElmWorkspaceService(
     fun asyncDiscoverAndRefresh(): CompletableFuture<List<ElmProject>> {
         if (hasAtLeastOneValidProject())
             return CompletableFuture.completedFuture(allProjects)
-
         val guessManifest = intellijProject.modules
                 .asSequence()
                 .flatMap { ModuleRootManager.getInstance(it).contentRoots.asSequence() }
-                .mapNotNull { it.findChild(ElmToolchain.ELM_JSON) }
+                .mapNotNull { dir -> dir.findFileBreadthFirst { it.name in ELM_MANIFEST_FILE_NAMES } }
                 .firstOrNull()
                 ?: return CompletableFuture.completedFuture(allProjects)
 

--- a/src/test/kotlin/org/elm/FileTree.kt
+++ b/src/test/kotlin/org/elm/FileTree.kt
@@ -35,6 +35,7 @@ import com.intellij.psi.*
 import org.elm.lang.core.psi.parentOfType
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.openapiext.fullyRefreshDirectory
+import org.elm.workspace.ElmPackageProject
 import org.intellij.lang.annotations.Language
 
 
@@ -156,7 +157,8 @@ class TestProject(
 
     inline fun <reified T : ElmReferenceElement> checkReferenceIsResolved(
             path: String,
-            shouldNotResolve: Boolean = false
+            shouldNotResolve: Boolean = false,
+            toPackage: String? = null
     ) {
         val ref = findElementInFile<T>(path)
         val res = ref.reference.resolve()
@@ -167,6 +169,13 @@ class TestProject(
         } else {
             check(res != null) {
                 "Failed to resolve the reference `${ref.text}` in `$path`."
+            }
+            if (toPackage != null && res != null) {
+                val pkgProject = res.elmProject as? ElmPackageProject
+                val pkg = pkgProject?.let { "${it.name} ${it.version}" } ?: "<package not found>"
+                check(pkg == toPackage) {
+                    "Expected to be resolved to $toPackage but actually resolved to $pkg"
+                }
             }
         }
     }

--- a/src/test/kotlin/org/elm/FileTree.kt
+++ b/src/test/kotlin/org/elm/FileTree.kt
@@ -175,7 +175,7 @@ class TestProject(
         val vFile = root.findFileByRelativePath(path)
                 ?: error("No `$path` file in test project")
         val file = PsiManager.getInstance(project).findFile(vFile)!!
-        return findElementInFile(file, "^")
+        return findElementInFile(file, "--^")
     }
 
     fun psiFile(path: String): PsiFileSystemItem {

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -1,0 +1,44 @@
+package org.elm.workspace
+
+import org.elm.FileTreeBuilder
+import org.elm.fileTree
+import org.elm.lang.core.psi.elements.ElmImportClause
+
+class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
+
+    fun `test resolves modules found within source-directories`() {
+        buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", """
+                    import Foo
+                           --^
+                """.trimIndent())
+
+                elm("Foo.elm", """
+                    module Foo exposing (..)
+                """.trimIndent())
+
+            }
+        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm")
+    }
+
+    fun buildProject(builder: FileTreeBuilder.() -> Unit) =
+            fileTree(builder).asyncCreateWithAutoDiscover().get()
+}

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -112,6 +112,67 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
         }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", shouldNotResolve = true)
     }
 
+    fun `test resolves modules provided by packages which are direct dependencies`() {
+        buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {
+                        "elm/time": "1.0.0"
+                    },
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", """
+                    import Time
+                           --^
+                """.trimIndent())
+            }
+        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", toPackage = "elm/time 1.0.0")
+    }
+
+    // TODO [kl] re-enable once a distinction is made between direct and indirect deps
+//    fun `test does not resolve modules which are not direct dependencies`() {
+//        buildProject {
+//            project("elm.json", """
+//            {
+//                "type": "application",
+//                "source-directories": [
+//                    "src"
+//                ],
+//                "elm-version": "0.19.0",
+//                "dependencies": {
+//                    "direct": {},
+//                    "indirect": {
+//                        "elm/time": "1.0.0"
+//                    }
+//                },
+//                "test-dependencies": {
+//                    "direct": {},
+//                    "indirect": {}
+//                }
+//            }
+//            """.trimIndent())
+//            dir("src") {
+//                elm("Main.elm", """
+//                    import Time
+//                           --^
+//                """.trimIndent())
+//            }
+//        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", shouldNotResolve = true)
+//    }
+
 
     fun buildProject(builder: FileTreeBuilder.() -> Unit) =
             fileTree(builder).asyncCreateWithAutoDiscover().get()

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -6,6 +6,7 @@ import org.elm.lang.core.psi.elements.ElmImportClause
 
 class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
+
     fun `test resolves modules found within source-directories`() {
         buildProject {
             project("elm.json", """
@@ -38,6 +39,79 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             }
         }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm")
     }
+
+    fun `test resolves modules found within source-directories in parent`() {
+        // this test ensures that we properly handle source-dirs like "../vendor"
+        buildProject {
+            dir("app") {
+                project("elm.json", """
+                    {
+                        "type": "application",
+                        "source-directories": [
+                            "src",
+                            "../vendor"
+                        ],
+                        "elm-version": "0.19.0",
+                        "dependencies": {
+                            "direct": {},
+                            "indirect": {}
+                        },
+                        "test-dependencies": {
+                            "direct": {},
+                            "indirect": {}
+                        }
+                    }
+                    """.trimIndent())
+                dir("src") {
+                    elm("Main.elm", """
+                    import Foo
+                           --^
+                    """.trimIndent())
+                }
+            }
+            dir("vendor") {
+                elm("Foo.elm", """
+                    module Foo exposing (..)
+                    """.trimIndent())
+            }
+        }.checkReferenceIsResolved<ElmImportClause>("app/src/Main.elm")
+    }
+
+
+    fun `test does not resolve modules outside of source-directories`() {
+        buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", """
+                    import Foo
+                           --^
+                """.trimIndent())
+            }
+            dir("other") {
+                elm("Foo.elm", """
+                    module Foo exposing (..)
+                """.trimIndent())
+
+            }
+        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", shouldNotResolve = true)
+    }
+
 
     fun buildProject(builder: FileTreeBuilder.() -> Unit) =
             fileTree(builder).asyncCreateWithAutoDiscover().get()

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -5,6 +5,7 @@ import org.elm.fileTree
 import org.elm.openapiext.elementFromXmlString
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.toXmlString
+import java.nio.file.Paths
 
 class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
@@ -58,7 +59,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                 project("elm.json", """
                     {
                         "type": "application",
-                        "source-directories": [ "src" ],
+                        "source-directories": [ "src", "vendor" ],
                         "elm-version": "0.19.0",
                         "dependencies": {
                             "direct": {
@@ -82,6 +83,9 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                 dir("src") {
                     elm("Main.elm", "")
                 }
+                dir("vendor") {
+                    elm("VendoredPackage.elm", "")
+                }
             }
         }.create(project, elmWorkspaceDirectory)
 
@@ -102,6 +106,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         }
 
         checkEquals(Version(0, 19, 0), elmProject.elmVersion)
+        checkEquals(setOf(Paths.get("src"), Paths.get("vendor")), elmProject.sourceDirectories.toSet())
 
         checkEquals(setOf(
                 "elm/core" to Version(1, 0, 0),
@@ -157,6 +162,9 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         checkEquals(makeConstraint(Version(0, 19, 0), Version(0, 20, 0))
                 , elmProject.elmVersion)
+
+        // The source directory for Elm 0.19 packages is implicitly "src". It cannot be changed.
+        checkEquals(setOf(Paths.get("src")), elmProject.sourceDirectories.toSet())
 
         checkEquals(setOf("elm/core" to Version(1, 0, 0)),
                 elmProject.dependencies.map { it.name to it.version }.toSet())

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -30,7 +30,6 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
     protected val elmWorkspaceDirectory: VirtualFile
         get() = myFixture.findFileInTempDir(".")
 
-
     protected fun FileTree.asyncCreateWithAutoDiscover(): CompletableFuture<TestProject> {
         val testProject = create(project, elmWorkspaceDirectory)
         return project.elmWorkspace.asyncDiscoverAndRefresh().thenApply { testProject }


### PR DESCRIPTION
Fixes #15 

Sometimes you have multiple Elm projects in the same IntelliJ project:
- a library package and its corresponding example app project
- a web-app comprised of several, separate Elm apps

This PR adds proper support for those situations. This means that when you do code completion, the plugin will only provide names that are visible to the current Elm project. All you have to do is attach each project's `elm.json` file to the workspace (either using the Elm tool window, or selecting `Tools -> Elm -> Attach Elm JSON project file` from the main IntelliJ menu bar).

Notable changes:
- the package manifests for each dependency are now loaded recursively
- `source-directories` are now used to restrict the visibility of Elm modules
- package `dependencies` are now used to restrict the visibility of  Elm modules