### PR TITLE
Fix references to Cmd and Sub

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import com.intellij.openapi.vfs.LocalFileSystem
+import org.elm.lang.core.moduleLookupHack
 import org.elm.workspace.ElmToolchain.Companion.ELM_LEGACY_JSON
 import java.io.InputStream
 import java.nio.file.Path
@@ -241,11 +242,11 @@ private fun JsonNode.toExposedModuleMap(): List<String> {
     //           exposed in that category. We discard the categories because they are not useful.
     return when (this.nodeType) {
         JsonNodeType.ARRAY -> {
-            this.elements().asSequence().map { it.textValue() }.toList()
+            this.elements().asSequence().map { moduleLookupHack(it.textValue()) }.toList()
         }
         JsonNodeType.OBJECT -> {
             this.fields().asSequence().flatMap { (_, nameNodes) ->
-                nameNodes.asSequence().map { it.textValue() }
+                nameNodes.asSequence().map { moduleLookupHack(it.textValue()) }
             }.toList()
         }
         else -> {


### PR DESCRIPTION
This fixes a regression in #92 that caused implicit references to `Cmd` and `Sub` not to resolve. These two values are special-cased in `moduleLookupHack` when creating the module definition, but not the dependency exposed modules, so `ElmProject.exposes` was returning false because `exposedModules` contained `Platform.Cmd`, but the module declaration name was just `Cmd`

I added the hack to the `exposedModules`, but I don't know if that's the correct fix. Maybe the hack is no longer necessary?