### PR TITLE
Fix ref resolve for case-of branches and anonymous functions

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmAnonymousFunction.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmAnonymousFunction.kt
@@ -24,5 +24,8 @@ class ElmAnonymousFunction(node: ASTNode) : ElmPsiElementImpl(node), ElmOperandT
 
     /** Named elements introduced by pattern destructuring in the parameter list */
     val namedParameters: List<ElmNameDeclarationPatternTag>
-        get() = PsiTreeUtil.collectElementsOfType(this, ElmNameDeclarationPatternTag::class.java).toList()
+        get() = patternList.flatMap {
+            PsiTreeUtil.collectElementsOfType(it, ElmNameDeclarationPatternTag::class.java)
+        }
+
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmCaseOfBranch.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmCaseOfBranch.kt
@@ -32,5 +32,5 @@ class ElmCaseOfBranch(node: ASTNode) : ElmPsiElementImpl(node) {
      * Named elements introduced by pattern destructuring on the left-hand side of the branch.
      */
     val destructuredNames: List<ElmNameDeclarationPatternTag>
-        get() = PsiTreeUtil.collectElementsOfType(this, ElmNameDeclarationPatternTag::class.java).toList()
+        get() = PsiTreeUtil.collectElementsOfType(pattern, ElmNameDeclarationPatternTag::class.java).toList()
 }

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmMiscResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmMiscResolveTest.kt
@@ -4,11 +4,11 @@ package org.elm.lang.core.resolve
 /**
  * Miscellaneous tests related to the reference-resolve system
  */
-class ElmMiscResolveTest: ElmResolveTestBase() {
+class ElmMiscResolveTest : ElmResolveTestBase() {
 
 
     fun `test top-level value ref`() = checkByCode(
-"""
+            """
 magicNumber = 42
 --X
 
@@ -17,8 +17,11 @@ f = magicNumber + 1
 """)
 
 
+    // LET-IN EXPRESSIONS
+
+
     fun `test simple value declared by let-in`() = checkByCode(
-"""
+            """
 f x =
     let y = 42
       --X
@@ -28,7 +31,7 @@ f x =
 
 
     fun `test let-in should honor lexical scope in body expr`() = checkByCode(
-"""
+            """
 foo =
     let
         bar y = 0
@@ -38,7 +41,7 @@ foo =
 
 
     fun `test let-in should honor lexical scope in sibling decl`() = checkByCode(
-"""
+            """
 foo =
     let
         bar y = 0
@@ -49,35 +52,54 @@ foo =
 """)
 
 
+    // LAMBDAS (ANONYMOUS FUNCTIONS)
+
+
     fun `test lambda parameter ref`() = checkByCode(
-"""
+            """
 f = \x -> x
    --X  --^
 """)
 
+    fun `test lambda parameter nested`() = checkByCode(
+            """
+f = \x -> (\() -> x)
+   --X          --^
+""")
+
+
+    fun `test lambda parameter nested and should not resolve`() = checkByCode(
+            """
+f = \() -> x (\x -> ())
+         --^unresolved
+""")
+
 
     fun `test lambda parameter destructured record field ref`() = checkByCode(
-"""
+            """
 f = \{x} -> x
     --X   --^
 """)
 
 
     fun `test lambda parameter destructured tuple ref`() = checkByCode(
-"""
+            """
 f = \(x,y) -> x
     --X     --^
 """)
 
     fun `test lambda parameter destructured with alias`() = checkByCode(
-"""
+            """
 f = \((x,y) as point) -> point
                --X       --^
 """)
 
 
+    // PORTS
+
+
     fun `test port ref`() = checkByCode(
-"""
+            """
 port module Ports exposing (..)
 port foo : String -> Cmd msg
      --X

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmPatternResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmPatternResolveTest.kt
@@ -4,11 +4,14 @@ package org.elm.lang.core.resolve
 /**
  * Tests related to pattern matching and destructuring
  */
-class ElmPatternResolveTest: ElmResolveTestBase() {
+class ElmPatternResolveTest : ElmResolveTestBase() {
+
+
+    // CASE-OF EXPRESSIONS AND PATTERNS
 
 
     fun `test case-of pattern wildcard`() = checkByCode(
-"""
+            """
 f x =
     case x of
         0 -> 0
@@ -19,7 +22,7 @@ f x =
 
 
     fun `test case-of pattern union type constructor`() = checkByCode(
-"""
+            """
 f x =
     case x of
         Nothing -> 0
@@ -29,22 +32,64 @@ f x =
     )
 
 
-    fun `test function parameter record destructuring`() = checkByCode(
+    fun `test case-of that should not resolve`() = checkByCode(
+            """
+f x =
+    case () of
+        Just foo -> ()
+        _ -> foo
+             --^unresolved
 """
+    )
+
+
+    fun `test nested case-of`() = checkByCode(
+            """
+f x =
+    case () of
+        _ ->
+            case () of
+                _ -> ()
+                Just foo -> foo
+                     --X    --^
+"""
+    )
+
+
+    // see bug https://github.com/klazuka/intellij-elm/issues/106
+    fun `test nested case-of that should not resolve`() = checkByCode(
+            """
+f x =
+    case () of
+        _ ->
+            case () of
+                Just foo -> ()
+                _ -> foo
+                     --^unresolved
+"""
+    )
+
+
+    // PARAMETER DESTRUCTURING
+
+
+    fun `test function parameter record destructuring`() = checkByCode(
+            """
 foo { name } = name
       --X      --^
 """)
 
 
     fun `test function parameter tuple destructuring`() = checkByCode(
-"""
+            """
 foo ( x, y ) = x + y
        --X       --^
 """)
 
 
+    // TODO [drop 0.18] this becomes invalid at the top-level in 0.19
     fun `test top-level value destructuring`() = checkByCode(
-"""
+            """
 ( x, y ) = (0, 0)
    --X
 
@@ -54,7 +99,7 @@ f = y + 20
 
 
     fun `test nested function parameter destructuring`() = checkByCode(
-"""
+            """
 f =
     let
         g ( x, y ) = x + y
@@ -64,15 +109,18 @@ f =
 """)
 
 
+    // PATTERN ALIASES
+
+
     fun `test pattern alias in function decl parameter`() = checkByCode(
-"""
+            """
 foo ((x, y) as point) = point
                --X      --^
 """)
 
 
     fun `test pattern alias in let-in decl`() = checkByCode(
-"""
+            """
 f =
     let
         g ((x, y) as point) = point
@@ -83,7 +131,7 @@ f =
 
 
     fun `test pattern alias in case-of branch`() = checkByCode(
-"""
+            """
 f x =
     case x of
         ((x, y) as point) -> point


### PR DESCRIPTION
Fixes #106 

Both `ElmCaseOfBranch` and `ElmAnonymousFunction` were being too lenient when providing the names which it introduces into the lexical scope.