### PR TITLE
Parse trailing whitespace next to a func call as part of the func call

### DIFF
--- a/src/main/grammars/ElmParser.bnf
+++ b/src/main/grammars/ElmParser.bnf
@@ -6,6 +6,7 @@
     parserUtilClass="org.elm.lang.core.parser.manual.ElmManualParseRules"
     elementTypeClass="org.elm.lang.core.psi.ElmElementType"
     tokenTypeClass="org.elm.lang.core.psi.ElmTokenType"
+    parserImports=[ "static com.intellij.lang.WhitespacesBinders.*" ]
 
     elementTypeFactory("ModuleDeclaration")="org.elm.lang.core.stubs.StubImplementationsKt.factory"
     elementTypeFactory("TypeDeclaration")="org.elm.lang.core.stubs.StubImplementationsKt.factory"
@@ -308,7 +309,13 @@ NegateExpression ::= MinusWithoutTrailingWhitespace Expression
 
 FunctionCall ::=
     FunctionCallTarget Operand+
-    { pin = 2 }
+    { pin = 2
+      /* Bind trailing whitespace as part of the function call. Imagine that the user has begun
+         making a function call and the caret is on some whitespace. We want that whitespace
+         to be part of the FunctionCall parse node to support things like ParameterInfoHandler.
+      */
+      hooks = [ rightBinder="GREEDY_RIGHT_BINDER" ]
+    }
 
 private FunctionCallTarget ::=
     RecordWithAccessor

--- a/src/test/resources/org/elm/lang/core/parser/fixtures/complete/FunctionCall.txt
+++ b/src/test/resources/org/elm/lang/core/parser/fixtures/complete/FunctionCall.txt
@@ -75,7 +75,7 @@ Elm File
         PsiWhiteSpace(' ')
         ElmNumberConstant(NUMBER_CONSTANT)
           PsiElement(NUMBER_LITERAL)('1')
-      PsiWhiteSpace(' ')
+        PsiWhiteSpace(' ')
       ElmOperator(OPERATOR)
         PsiElement(OPERATOR_IDENTIFIER)('+')
       PsiWhiteSpace(' ')


### PR DESCRIPTION
Even though my recent virtual-end-decl token fix improved the situation, trailing whitespace after a function call was still being parsed as a _sibling_ of the top-level element:
<img width="907" alt="before" src="https://user-images.githubusercontent.com/84525/47885671-71c00080-ddf3-11e8-97b0-4e3b2594e338.png">

After this change, the whitespace is parsed as part of the ElmFunctionCall element:
<img width="935" alt="after" src="https://user-images.githubusercontent.com/84525/47885736-bcda1380-ddf3-11e8-9c25-e732a027b65c.png">

It turns out that GrammarKit has a [poorly documented hook](https://github.com/JetBrains/Grammar-Kit/issues/91) for controlling how leading and trailing whitespace (and comments) are parsed. As far as I can tell, this seems like a pretty safe change, and it will be helpful for #17 