### PR TITLE
Add 'parameter info' support (ctrl-p/cmd-p)

### DIFF
--- a/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
+++ b/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
@@ -1,0 +1,108 @@
+package org.elm.ide.hints
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.lang.parameterInfo.*
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmOperandTag
+import org.elm.lang.core.psi.elements.ElmFunctionCall
+import org.elm.lang.core.psi.parentOfType
+
+class ElmParameterInfoHandler : ParameterInfoHandler<PsiElement, ElmParametersDescription> {
+
+    var hintText: String = ""
+
+    override fun couldShowInLookup() = true
+
+    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<Any>? {
+        println("getParametersForLookup() called for item $item")
+        val elem = item?.`object` as? PsiElement ?: return null
+        if (elem !is ElmOperandTag) {
+            println("Skipping $elem because not an ElmOperand")
+            return null
+        }
+
+        val funcCall = elem.parentOfType<ElmFunctionCall>()
+        return if (funcCall == null) {
+            println("Skipping $elem because parent is not an ElmFunctionCall")
+            emptyArray()
+        } else {
+            // TODO verify that the function call target is actually a function
+            println("FOUND $elem")
+            arrayOf(funcCall)
+        }
+    }
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
+        val element = context.file.findElementAt(context.editor.caretModel.offset)
+        println("findElementForParameterInfo() returning $element")
+        return element
+    }
+
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PsiElement? {
+        val element = context.file.findElementAt(context.editor.caretModel.offset)
+        println("findElementForUpdatingParameterInfo() returning $element")
+        return element
+    }
+
+    override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
+        println("showParameterInfo() for $element")
+        // `element` as returned by [findElementForParameterInfo]
+        context.itemsToShow = emptyArray()      // TODO implement me (should be ElmParametersDescription)
+        context.showHint(
+                element,                        // TODO re-consider this
+                element.textRange.startOffset,  // TODO re-consider this
+                this)
+    }
+
+    override fun updateParameterInfo(parameterOwner: PsiElement, context: UpdateParameterInfoContext) {
+        println("updateParameterInfo() called with parameterOwner=$parameterOwner")
+//
+//        val argIndex = findArgumentIndex(place)
+//        if (argIndex == INVALID_INDEX) {
+//            context.removeHint()
+//            return
+//        }
+        val argIndex = 0
+
+        context.setCurrentParameter(argIndex) // TODO implement me for real
+
+        // TODO intellij-rust did some stuff to context.parameterOwner that I don't understand
+//        when {
+//            context.parameterOwner == null -> context.parameterOwner = place
+//            context.parameterOwner != findElementForParameterInfo(place) -> {
+//                context.removeHint()
+//                return
+//            }
+//        }
+
+        // TODO is this needed?
+        context.objectsToView.indices.map { context.setUIComponentEnabled(it, true) }
+    }
+
+    override fun updateUI(p: ElmParametersDescription?, context: ParameterInfoUIContext) {
+        println("updateUI() called for $p")
+        if (p == null) {
+            context.isUIComponentEnabled = false
+            return
+        }
+
+        hintText = p.presentText
+
+        // update the UI to highlight the currently selected element
+//        val range = p.getArgumentRange(context.currentParameterIndex)
+//        context.setupUIComponentPresentation(
+//                hintText,
+//                range.startOffset,
+//                range.endOffset,
+//                !context.isUIComponentEnabled,
+//                false,
+//                false,
+//                context.defaultParameterColor)
+    }
+}
+
+class ElmParametersDescription(val parameters: List<String>) {
+    val presentText: String
+        get() = parameters.joinToString(", ")
+
+}

--- a/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
+++ b/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
@@ -2,6 +2,7 @@ package org.elm.ide.hints
 
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.parameterInfo.*
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ancestorsStrict
 import org.elm.lang.core.psi.elements.ElmFunctionCall
@@ -71,10 +72,12 @@ class ElmParameterInfoHandler : ParameterInfoHandler<PsiElement, ElmParametersDe
 
         hintText = p.presentText
 
+        val range = p.getHighlightRange(context.currentParameterIndex)
+
         context.setupUIComponentPresentation(
                 hintText,
-                0,
-                3,
+                range.startOffset,
+                range.endOffset,
                 !context.isUIComponentEnabled,
                 false,
                 false,
@@ -93,9 +96,17 @@ class ElmParameterInfoHandler : ParameterInfoHandler<PsiElement, ElmParametersDe
 
 class ElmParametersDescription(val parameters: List<String>) {
     val presentText: String
-        get() = parameters.joinToString(", ")
+        get() = parameters.joinToString(separator)
+
+    fun getHighlightRange(index: Int): TextRange {
+        if (index < 0 || index >= parameters.size) return TextRange.EMPTY_RANGE
+        val start = parameters.take(index).sumBy { it.length + separator.length }
+        return TextRange(start, start + parameters[index].length)
+    }
 
     companion object {
+        private val separator = ", "
+
         fun fromFuncCall(funcDecl: ElmFunctionDeclarationLeft): ElmParametersDescription {
             // TODO handle destructured parameter names
             // TODO add type information for each parameter

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -40,6 +40,7 @@ import kotlin.reflect.KClass
 
 val PsiElement.descendants: Sequence<PsiElement> get() = directChildren.flatMap { sequenceOf(it) + it.descendants }
 val PsiElement.ancestors: Sequence<PsiElement> get() = generateSequence(this) { it.parent }
+val PsiElement.ancestorsStrict: Sequence<PsiElement> get() = ancestors.drop(1)
 val PsiElement.prevSiblings: Sequence<PsiElement> get() = generateSequence(prevSibling) { it.prevSibling }
 val PsiElement.nextSiblings: Sequence<PsiElement> get() = generateSequence(nextSibling) { it.nextSibling }
 val PsiElement.directChildren: Sequence<PsiElement> get() = generateSequence(firstChild) { it.nextSibling }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionCall.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionCall.kt
@@ -1,10 +1,8 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
-import org.elm.lang.core.psi.ElmFunctionCallTargetTag
-import org.elm.lang.core.psi.ElmOperandTag
-import org.elm.lang.core.psi.ElmPsiElementImpl
-import org.elm.lang.core.psi.directChildren
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.types.*
 
 
 /**
@@ -24,4 +22,54 @@ class ElmFunctionCall(node: ASTNode) : ElmPsiElementImpl(node), ElmOperandTag {
 
     /** The arguments to the function. This will always have at least one element */
     val arguments: Sequence<ElmOperandTag> get() = directChildren.filterIsInstance<ElmOperandTag>().drop(1)
+
+    /**
+     * Returns a description of the function call's **declared** parameters.
+     * Compare to [arguments], which is what the caller actually provided, and may differ.
+     */
+    fun resolveCallInfo(): CallInfo? {
+        // TODO handle destructured parameter names
+        // TODO generalize so that it works with other kinds of call targets (such as lambdas)
+
+        val resolved = target.reference?.resolve() ?: return null
+        if (resolved !is ElmFunctionDeclarationLeft) return null
+
+        val inference = resolved.parentOfType<ElmValueDeclaration>()?.inference()
+        val parameters: List<CallInfo.Parameter>
+        if (inference != null && inference.ty is TyFunction) {
+            parameters = resolved.namedParameters
+                    .zip(inference.ty.parameters)
+                    .map { (param, ty) -> CallInfo.Parameter(param.name ?: "?", ty) }
+        } else {
+            parameters = resolved.namedParameters
+                    .map { param -> CallInfo.Parameter(param.name ?: "?", TyUnknown) }
+        }
+
+        return CallInfo(resolved.name, parameters)
+    }
+}
+
+
+/**
+ * An externally-focused description of a function and its expected parameters.
+ *
+ * This is specifically meant for **usage at the function call site**, that is,
+ * the outside view of the function, ignoring any kind of internal destructuring that
+ * may happen within the function body.
+ *
+ * With that being said, Elm's parameter destructuring can cause a problem here because
+ * you may have, say, a single tuple argument which is destructured internally, deriving
+ * the parameter of its rightful name. In such cases, the parameter will be given
+ * an anonymous name.
+ */
+data class CallInfo(
+        val functionName: String,
+        val parameters: List<Parameter>
+) {
+
+    data class Parameter(val name: String, val ty: Ty) {
+        override fun toString(): String {
+            return "$name: ${ty.renderedText(linkify = false, withModule = false)}"
+        }
+    }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionCall.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionCall.kt
@@ -35,16 +35,13 @@ class ElmFunctionCall(node: ASTNode) : ElmPsiElementImpl(node), ElmOperandTag {
         if (resolved !is ElmFunctionDeclarationLeft) return null
 
         val inference = resolved.parentOfType<ElmValueDeclaration>()?.inference()
-        val parameters: List<CallInfo.Parameter>
-        if (inference != null && inference.ty is TyFunction) {
-            parameters = resolved.namedParameters
-                    .zip(inference.ty.parameters)
-                    .map { (param, ty) -> CallInfo.Parameter(param.name ?: "?", ty) }
+        val parameterPairs = if (inference != null && inference.ty is TyFunction) {
+            resolved.namedParameters.zip(inference.ty.parameters)
         } else {
-            parameters = resolved.namedParameters
-                    .map { param -> CallInfo.Parameter(param.name ?: "?", TyUnknown) }
+            resolved.namedParameters.map { it to TyUnknown }
         }
 
+        val parameters = parameterPairs.map { (param, ty) -> CallInfo.Parameter(param.name ?: "?", ty) }
         return CallInfo(resolved.name, parameters)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -91,6 +91,7 @@
         <importFilteringRule implementation="org.elm.ide.usages.ElmImportFilteringRule"/>
         <lang.quoteHandler language="Elm" implementationClass="org.elm.ide.typing.ElmQuoteHandler"/>
         <backspaceHandlerDelegate implementation="org.elm.ide.typing.ElmBackspaceHandler"/>
+        <codeInsight.parameterInfo language="Elm" implementationClass="org.elm.ide.hints.ElmParameterInfoHandler"/>
         <codeInsight.typeInfo language="Elm" implementationClass="org.elm.ide.hints.ElmExpressionTypeProvider"/>
 
         <localInspection language="Elm" groupName="Elm" displayName="Type checker" enabledByDefault="true" level="ERROR"

--- a/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
@@ -114,7 +114,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
     // UTILS
 
     private fun checkByText(code: String, hint: String, index: Int) {
-        myFixture.configureByText("main.elm", code)
+        myFixture.configureByText("main.elm", replaceCaretMarker(code))
         val handler = ElmParameterInfoHandler()
         val createContext = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
 

--- a/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
@@ -54,7 +54,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             f : String -> Int
             f x = 42
             main = f {-caret-}
-        """.trimIndent(), "String", 0)
+        """.trimIndent(), "x: String", 0)
     }
 
     fun `test function with one arg but caret before args`() {
@@ -72,7 +72,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             g : Char -> Int
             g x = 99
             main = f (g {-caret-})
-        """.trimIndent(), "Char", 0)
+        """.trimIndent(), "x: Char", 0)
     }
 
     // MULTIPLE ARGUMENTS
@@ -82,7 +82,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             f : String -> Char -> Int
             f x y = 42
             main = f {-caret-}
-        """.trimIndent(), "String, Char", 0)
+        """.trimIndent(), "x: String, y: Char", 0)
     }
 
     fun `test function with two args, caret on second arg`() {
@@ -90,7 +90,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             f : String -> Char -> Int
             f x y = 42
             main = f "x" {-caret-}
-        """.trimIndent(), "String, Char", 1)
+        """.trimIndent(), "x: String, y: Char", 1)
     }
 
     fun `test function with two args, fully specified, caret on first arg`() {
@@ -98,7 +98,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             f : String -> Char -> Int
             f x y = 42
             main = f "x"{-caret-} 'y'
-        """.trimIndent(), "String, Char", 0)
+        """.trimIndent(), "x: String, y: Char", 0)
     }
 
     fun `test function with two args nested in another function call`() {
@@ -108,7 +108,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             g : Char -> Bool -> Int
             g x y = 99
             main = f (g 'x' {-caret-})
-        """.trimIndent(), "Char", 1)
+        """.trimIndent(), "y: Bool", 1)
     }
 
     // UTILS

--- a/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
@@ -1,0 +1,142 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elm.ide.hints
+
+import com.intellij.testFramework.utils.parameterInfo.MockCreateParameterInfoContext
+import com.intellij.testFramework.utils.parameterInfo.MockParameterInfoUIContext
+import com.intellij.testFramework.utils.parameterInfo.MockUpdateParameterInfoContext
+import junit.framework.AssertionFailedError
+import junit.framework.TestCase
+import org.elm.lang.ElmTestBase
+
+class ElmParameterInfoHandlerTest : ElmTestBase() {
+    // TODO: At some point, the type annotations on each function should no longer be necessary.
+    //       But right now the type inference system needs them.
+
+    // NO ARGS (VALUES)
+
+    fun `test function with no args`() {
+        checkByText("""
+            x : Int
+            x = 42
+            main = x{-caret-}
+        """.trimIndent(), "<no arguments>", 0)
+    }
+
+    // SOLO ARGUMENT
+
+    fun `test function with one arg`() {
+        checkByText("""
+            f : String -> Int
+            f x = 42
+            main = f {-caret-}
+        """.trimIndent(), "String", 0)
+    }
+
+    fun `test function with one arg but caret before args`() {
+        checkByText("""
+            f : String -> Int
+            f x = 42
+            main = f{-caret-}
+        """.trimIndent(), "<no arguments>", 0)
+    }
+
+    fun `test function with one arg nested in another function call`() {
+        checkByText("""
+            f : Int -> Int
+            f x = 42
+            g : Char -> Int
+            g x = 99
+            main = f (g {-caret-})
+        """.trimIndent(), "Char", 0)
+    }
+
+    // MULTIPLE ARGUMENTS
+
+    fun `test function with two args, caret on first arg`() {
+        checkByText("""
+            f : String -> Char -> Int
+            f x y = 42
+            main = f {-caret-}
+        """.trimIndent(), "String, Char", 0)
+    }
+
+    fun `test function with two args, caret on second arg`() {
+        checkByText("""
+            f : String -> Char -> Int
+            f x y = 42
+            main = f "x" {-caret-}
+        """.trimIndent(), "String, Char", 1)
+    }
+
+    fun `test function with two args, fully specified, caret on first arg`() {
+        checkByText("""
+            f : String -> Char -> Int
+            f x y = 42
+            main = f "x"{-caret-} 'y'
+        """.trimIndent(), "String, Char", 0)
+    }
+
+    fun `test function with two args nested in another function call`() {
+        checkByText("""
+            f : Int -> Int
+            f x = 42
+            g : Char -> Bool -> Int
+            g x y = 99
+            main = f (g 'x' {-caret-})
+        """.trimIndent(), "Char", 1)
+    }
+
+    // UTILS
+
+    private fun checkByText(code: String, hint: String, index: Int) {
+        myFixture.configureByText("main.elm", code)
+        val handler = ElmParameterInfoHandler()
+        val createContext = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
+
+        // Check hint
+        val elt = handler.findElementForParameterInfo(createContext)
+        if (hint.isNotEmpty()) {
+            elt ?: throw AssertionFailedError("Hint not found")
+            handler.showParameterInfo(elt, createContext)
+            val items = createContext.itemsToShow ?: throw AssertionFailedError("Parameters are not shown")
+            if (items.isEmpty()) throw AssertionFailedError("Parameters are empty")
+            val context = MockParameterInfoUIContext(elt)
+            handler.updateUI(items[0] as ElmParametersDescription, context)
+            TestCase.assertEquals(hint, handler.hintText)
+
+            // Check parameter index
+            val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
+            val element = handler.findElementForUpdatingParameterInfo(updateContext)
+                    ?: throw AssertionFailedError("Parameter not found")
+            handler.updateParameterInfo(element, updateContext)
+            TestCase.assertEquals(index, updateContext.currentParameter)
+        } else if (elt != null) {
+            throw AssertionFailedError("Unexpected hint found")
+        }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
@@ -44,18 +44,6 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
             ElmWithStdlibDescriptor
 
 
-    // NO ARGS (VALUES)
-
-
-    fun `test function with no args`() {
-        checkByText("""
-x : Int
-x = 42
-main = x{-caret-}
-""", "<no arguments>")
-    }
-
-
     // SOLO ARGUMENT
 
 
@@ -65,14 +53,6 @@ f : String -> Int
 f x = 42
 main = f "foo"{-caret-}
 """, "f : String → Int")
-    }
-
-    fun `test function with one arg but caret before args`() {
-        checkByText("""
-f : String -> Int
-f x = 42
-main = f{-caret-}
-""", "<no arguments>")
     }
 
     fun `test function with one arg nested in another function call`() {

--- a/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/ElmParameterInfoHandlerTest.kt
@@ -52,7 +52,7 @@ class ElmParameterInfoHandlerTest : ElmTestBase() {
 x : Int
 x = 42
 main = x{-caret-}
-""", "<no arguments>", 0)
+""", "<no arguments>")
     }
 
 
@@ -63,8 +63,8 @@ main = x{-caret-}
         checkByText("""
 f : String -> Int
 f x = 42
-main = f {-caret-}
-""", "x: String", 0)
+main = f "foo"{-caret-}
+""", "f : String → Int")
     }
 
     fun `test function with one arg but caret before args`() {
@@ -72,7 +72,7 @@ main = f {-caret-}
 f : String -> Int
 f x = 42
 main = f{-caret-}
-""", "<no arguments>", 0)
+""", "<no arguments>")
     }
 
     fun `test function with one arg nested in another function call`() {
@@ -81,8 +81,8 @@ f : Int -> String
 f x = "blah"
 g : Char -> Int
 g x = 99
-main = f (g {-caret-})
-""", "x: Char", 0)
+main = f (g 'c'{-caret-})
+""", "g : Char → Int")
     }
 
 
@@ -93,8 +93,8 @@ main = f (g {-caret-})
         checkByText("""
 f : String -> Char -> Int
 f x y = 42
-main = f {-caret-}
-""", "x: String, y: Char", 0)
+main = f "hi"{-caret-}
+""", "f : String → Char → Int")
     }
 
     fun `test function with two args, caret on second arg`() {
@@ -102,15 +102,7 @@ main = f {-caret-}
 f : String -> Char -> Int
 f x y = 42
 main = f "x" {-caret-}
-""", "x: String, y: Char", 1)
-    }
-
-    fun `test function with two args, fully specified, caret on first arg`() {
-        checkByText("""
-f : String -> Char -> Int
-f x y = 42
-main = f "x"{-caret-} 'y'
-""", "x: String, y: Char", 0)
+""", "f : String → Char → Int")
     }
 
     fun `test function with two args nested in another function call`() {
@@ -120,14 +112,14 @@ f x = 42
 g : Char -> Bool -> Int
 g x y = 99
 main = f (g 'x' {-caret-})
-""", "x: Char, y: Bool", 1)
+""", "g : Char → Bool → Int")
     }
 
 
     // UTILS
 
 
-    private fun checkByText(@Language("Elm") code: String, hint: String, index: Int) {
+    private fun checkByText(@Language("Elm") code: String, hint: String) {
         myFixture.configureByText("main.elm", replaceCaretMarker(code))
         val handler = ElmParameterInfoHandler()
         val createContext = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
@@ -147,8 +139,7 @@ main = f (g 'x' {-caret-})
             val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
             val element = handler.findElementForUpdatingParameterInfo(updateContext)
                     ?: throw AssertionFailedError("Parameter not found")
-            handler.updateParameterInfo(element, updateContext)
-            TestCase.assertEquals(index, updateContext.currentParameter)
+            TestCase.assertNotNull(element)
         } else if (elt != null) {
             throw AssertionFailedError("Unexpected hint found")
         }


### PR DESCRIPTION
Fixes #17 

I decided not to implement this the usual IntelliJ way where the current parameter is highlighted based on the caret position. It would be difficult to do for a variety of reasons, and even if you did get it to work, things like function pipelines would still be strange.

So instead it will just show the type annotation of the function-being-called.