### PR TITLE
Allow filtering annotations and module declarations from Find Usages

### DIFF
--- a/src/main/kotlin/org/elm/ide/usages/ElmImportFilteringRule.kt
+++ b/src/main/kotlin/org/elm/ide/usages/ElmImportFilteringRule.kt
@@ -6,6 +6,8 @@ import com.intellij.usages.rules.ImportFilteringRule
 import com.intellij.usages.rules.PsiElementUsage
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.psi.elements.ElmModuleDeclaration
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
 import org.elm.lang.core.psi.parentOfType
 
 /**
@@ -15,6 +17,8 @@ class ElmImportFilteringRule : ImportFilteringRule() {
     override fun isVisible(usage: Usage, targets: Array<UsageTarget>): Boolean {
         val element = (usage as? PsiElementUsage)?.element
         return element?.containingFile !is ElmFile
-                || element.parentOfType<ElmImportClause>() == null
+                || (element.parentOfType<ElmImportClause>() == null
+                && element.parentOfType<ElmModuleDeclaration>() == null
+                && element !is ElmTypeAnnotation)
     }
 }


### PR DESCRIPTION
This PR extends the import filtering rule to also exclude usages in `exposing` clauses and type annotations. The latter is semantically a bit kludgy, but this allows a user to filter the Find Usages panel to only places where a function is actually called. As before, the entire rule can be toggled on and off.

#### Filtering Off
![off](https://user-images.githubusercontent.com/1109214/48169379-f1dcdf00-e2a7-11e8-93f5-cd3126e5101d.png)

#### Filtering On
![on](https://user-images.githubusercontent.com/1109214/48169386-fb664700-e2a7-11e8-97ba-21e49a4a00e7.png)
