### PR TITLE
Improve parameter name generation from a type annotation

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionAction.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionAction.kt
@@ -54,7 +54,7 @@ class ElmMakeDeclarationIntentionAction : ElmAtCaretIntentionActionBase<ElmMakeD
     private fun generateTemplate(project: Project, context: Context): Template {
         val templateManager = TemplateManager.getInstance(project)
         val template = templateManager.createTemplate("", "")
-        template.isToReformat = true
+        template.isToReformat = false
 
         val typeAnnotation = context.typeAnnotation
         val name = typeAnnotation.referenceName
@@ -73,7 +73,7 @@ class ElmMakeDeclarationIntentionAction : ElmAtCaretIntentionActionBase<ElmMakeD
                     is ElmTupleType -> "tuple"
                     is ElmTypeRef -> "function" // not quite true: need to check for an ARROW child
                     else -> "?"
-                }.toLowerCase()
+                }.toLowerCamelCase()
             }
         }
 
@@ -87,3 +87,12 @@ class ElmMakeDeclarationIntentionAction : ElmAtCaretIntentionActionBase<ElmMakeD
         return template
     }
 }
+
+/// NOTE: Assumes that the receiver is already InterCapped.
+private fun String.toLowerCamelCase(): String =
+        this.mapIndexed { idx, c ->
+            if (idx == 0)
+                c.toLowerCase()
+            else
+                c
+        }.joinToString("")

--- a/src/test/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionTest.kt
@@ -1,39 +1,54 @@
 package org.elm.ide.intentions
 
-class ElmMakeDeclarationIntentionTest: ElmIntentionTestBase(ElmMakeDeclarationIntentionAction()) {
+class ElmMakeDeclarationIntentionTest : ElmIntentionTestBase(ElmMakeDeclarationIntentionAction()) {
 
 
     fun `test make value declaration`() {
         doAvailableTest(
-"""
+                """
 f : Int{-caret-}
 """
-, """
+                , """
 f : Int
 f = {-caret-}
-""")}
+""")
+    }
 
 
     fun `test make basic function declaration`() {
         doAvailableTest(
-"""
+                """
 f : Int -> Int{-caret-}
 """
-, """
+                , """
 f : Int -> Int
 f int = {-caret-}
-""")}
+""")
+    }
 
 
     fun `test make advanced function declaration`() {
         doAvailableTest(
-"""
+                """
 f : (Int -> Int) -> List a -> (Char, String) -> { foo : Int } -> Bool{-caret-}
 """
-, """
+                , """
 f : (Int -> Int) -> List a -> (Char, String) -> { foo : Int } -> Bool
 f function list tuple record = {-caret-}
-""")}
+""")
+    }
+
+
+    fun `test function parameters should be camelCased`() {
+        doAvailableTest(
+                """
+f : FooBar -> QuuxQuuxQuux -> Int{-caret-}
+"""
+                , """
+f : FooBar -> QuuxQuuxQuux -> Int
+f fooBar quuxQuuxQuux = {-caret-}
+""")
+    }
 
 
 }


### PR DESCRIPTION
Type names like `MyList` were populating the function parameter
as `MyList`, but Elm requires function parameters to have an initial
lower-case letter (e.g. `myList`).