### PR TITLE
Infer type references to List

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperPathTypeRef.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperPathTypeRef.kt
@@ -15,9 +15,7 @@ import org.elm.lang.core.resolve.reference.SimpleTypeReference
 /**
  * An upper-case path which references a type
  *
- * e.g. type Error = Network Http.Error
- *                           ^^^^^^^^^^
- *                           this
+ * e.g. `Http.Error` in `type Error = Network Http.Error`
  */
 class ElmUpperPathTypeRef(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElement,
         ElmParametricTypeRefParameterTag, ElmTypeRefParameterTag, ElmUnionMemberParameterTag {

--- a/src/main/kotlin/org/elm/lang/core/types/ElementTys.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/ElementTys.kt
@@ -29,7 +29,17 @@ fun recordTypeDeclType(record: ElmRecordType, alias: TyUnion?): TyRecord {
 }
 
 fun parametricTypeRefType(typeRef: ElmParametricTypeRef): Ty {
-    return resolvedTypeRefType(typeRef.reference.resolve())
+    val ref = typeRef.reference.resolve()
+
+    // Unlike all other built-in types, Elm core doesn't define the List type anywhere, so the
+    // reference won't resolve. So we check for reference to that type here. Note that users can
+    // create their own List types that shadow the built-in, so we only want to do this check if the
+    // reference is null.
+    if (ref == null && typeRef.upperCaseQID.text == "List") {
+        return TyList(TyVar("a"))
+    }
+
+    return resolvedTypeRefType(ref)
 }
 
 fun upperPathTypeRefType(typeRef: ElmUpperPathTypeRef): Ty {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -423,7 +423,7 @@ private class InferenceScope(
             }
         }
 
-        return TyList(expressionTys.firstOrNull() ?: TyUnknown)
+        return TyList(expressionTys.firstOrNull() ?: TyVar("a"))
     }
 
     private fun inferIfElse(ifElse: ElmIfElse): Ty {

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -79,6 +79,17 @@ main : Foo -> ()
 main a = <error descr="Type mismatch.Required: ()Found: Foo">a</error>
 """)
 
+    fun `test mismatched return type from List argument`() = checkByText("""
+main : List Int -> ()
+main a = <error descr="Type mismatch.Required: ()Found: List a">a</error>
+""")
+
+    fun `test mismatched return type from shadowed List`() = checkByText("""
+type List a = List a
+main : List ()
+main = <error descr="Type mismatch.Required: List aFound: List.List a">[]</error>
+""")
+
     fun `test mismatched return type from float literal`() = checkByText("""
 type Foo = Bar
 main : () -> Foo
@@ -262,26 +273,22 @@ recordAccessor = {b = {a = { x = () } } }.b.<error descr="Record does not have f
 """)
 
     fun `test matched value type from union case`() = checkByText("""
-type Maybe a = Just a | Nothing
 main : Maybe a
 main = Nothing
 """)
 
     fun `test mismatched value type from union case`() = checkByText("""
-type Maybe a = Just a | Nothing
 type Foo = Bar
 main : Maybe a
 main = <error descr="Type mismatch.Required: Maybe aFound: Foo">Bar</error>
 """)
 
     fun `test invalid constructor as type annotation`() = checkByText("""
-type Maybe a = Just a | Nothing
 main : <error descr="Unresolved reference 'Just'">Just a</error> -> ()
 main a = ()
 """)
 
     fun `test matched value from union constructor`() = checkByText("""
-type Maybe = Just () | Nothing
 foo : (() -> Maybe) -> () -> ()
 foo _ _ = ()
 
@@ -365,19 +372,11 @@ main = person George
 
 --@ Foo.elm
 module People.Washington exposing (People(..), person)
-import Maybe exposing (Maybe(..))
 
 type People = George
 
 person : People -> Maybe People
 person a = Just a
-
---@ Maybe.elm
-module Maybe exposing (Maybe(..))
-
-type Maybe a
-    = Just a
-    | Nothing
 """)
 
     fun `test duplicate function parameter`() = checkByText("""
@@ -730,8 +729,6 @@ main =
 
     // issue #113
     fun `test case branches with union value call`() = checkByText("""
-type Maybe a = Just a | Nothing
-
 foo : Maybe (List a)
 foo = Nothing
 
@@ -767,10 +764,6 @@ main x =
 """)
 
     fun `test case branches using union patterns with constructor argument`() = checkByText("""
-type Maybe a
-    = Just a
-    | Nothing
-
 type Foo
     = Bar ()
     | Baz ()
@@ -785,10 +778,6 @@ main arg =
 """)
 
     fun `test case branches using union patterns with tuple destructuring of var`() = checkByText("""
-type Maybe a
-    = Just a
-    | Nothing
-
 type Foo
     = Bar (Maybe ((), ()))
     | Baz ()
@@ -802,10 +791,6 @@ main arg =
 """)
 
     fun `test case branches using union patterns with tuple destructuring of record`() = checkByText("""
-type Maybe a
-    = Just a
-    | Nothing
-
 type Foo
     = Bar (Maybe {x: ()})
     | Baz ()
@@ -949,7 +934,6 @@ main a = () ~~ <error descr="Type mismatch.Required: ()Found: Foo">() ~~ ()</err
 """)
 
     fun `test apply-right into Maybe`() = checkByText("""
-type Maybe a = Just a | Nothing
 apR : a -> (a -> b) -> b
 apR x f = f x
 infix left  0 (|>) = apR


### PR DESCRIPTION
This works around an edge case in the core libraries.

In type expressions like

```elm
x = { y : List String }

foo : List String
foo = []
```

`String` resolves correctly, but `List` does not. No error is shown, but trying to perform any action that requires reference resolution (jump to definiton, infer type, view documentation, etc.) fails because `reference.resolve()` (correctly) returns `null`.

The reason is that, unlike all other built-in types, Elm core doesn't define the List type anywhere.

This PR adds a check for this specific case when resolving type references. I don't think there's anything we can do for other actions like quick documentation.