### PR TITLE
Setup an ElmProject when running tests; plug the "null ElmProject" hole

### DIFF
--- a/src/main/kotlin/org/elm/utils/MyDirectoryIndex.kt
+++ b/src/main/kotlin/org/elm/utils/MyDirectoryIndex.kt
@@ -125,14 +125,20 @@ class MyDirectoryIndex<T>(parentDisposable: Disposable,
 
     private fun cacheInfo(file: VirtualFile, info: T) {
         val id = (file as VirtualFileWithId).id
-//        log.debug("Putting $info for $file using id $id")
+        if (log.isDebugEnabled) {
+            val thing = if (info == myDefValue) "sentinel" else info.toString()
+            log.debug("Putting $thing for $file using id $id")
+        }
         myInfoCache.put(id, info)
     }
 
     private fun getCachedInfo(file: VirtualFile): T? {
         val id = (file as VirtualFileWithId).id
         val info = myInfoCache.get(id)
-//        log.debug("Got $info for $file using id $id")
+        if (log.isDebugEnabled) {
+            val thing = if (info == myDefValue) "sentinel" else info.toString()
+            log.debug("Got $thing for $file using id $id")
+        }
         return info
     }
 

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -370,7 +370,7 @@ main : Maybe People
 main = person George
 --^
 
---@ Foo.elm
+--@ People/Washington.elm
 module People.Washington exposing (People(..), person)
 
 type People = George

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -284,6 +284,39 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
         }
     }
 
+    fun `test resolves modules provided by packages which are direct test dependencies`() {
+
+        ensureElmStdlibInstalled(FullElmStdlibVariant)
+
+        buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {
+                        "elm-explorations/test": "1.0.0"
+                    },
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("tests") {
+                elm("MyTests.elm", """
+                    import Test
+                           --^
+                """.trimIndent())
+            }
+        }.checkReferenceIsResolved<ElmImportClause>("tests/MyTests.elm", toPackage = "elm-explorations/test 1.0.0")
+    }
+
 
     // TODO [kl] re-enable once a distinction is made between direct and indirect deps
 //    fun `test does not resolve modules which are not direct dependencies`() {

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -36,6 +36,8 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
     }
 
     protected fun ensureElmStdlibInstalled(variant: ElmStdlibVariant) {
+        // IMPORTANT: do not use the returned `ElmProject` from [ensureElmStdlibInstalled] as it
+        // uses paths designed for IntelliJ's "light" tests (in-memory VFS).
         variant.ensureElmStdlibInstalled(project, toolchain!!)
     }
 


### PR DESCRIPTION
Fixes #119 

In typical usage, every Elm file should have an associated Elm project (`elm.json`). But one big exception was our integration tests, which did not setup any Elm projects in the ElmWorkspace. And because of this hole, I had a fallback that would provide extremely liberal module resolution when the Elm project could not be determined. This fallback masked a lot of problems (including the underlying bug in #119).

This PR makes it so that all of the integration tests run in a workspace where an `ElmProject` exists. This makes the integration test code behave similarly to the real production code. And it allowed me to remove the loosey-goosey fallback in the module resolution code.

I also fixed the underlying bug in #119, which was that `test-dependencies` were not being included during module resolution.

Even after this PR, the module resolution system is still too liberal, but that will have to wait for a future PR.