### PR TITLE
Fix the Travis Windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];     then npm install -g elm                 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]];   then npm install -g elm                 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install --yes elm-platform   ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export JAVA_HOME="C:\Program Files\Java\jdk1.8.0_192"   ; fi
     - echo Installed elm `elm --version`
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install jdk8                 ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ls /c/Program Files/Java           ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_191/bin"   ; fi
+    - java -version
 
 install: ./gradlew assemble --no-daemon
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install --yes elm-platform   ; fi
     - echo Installed elm `elm --version`
     - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install jdk8                 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ls /c/Program Files/Java           ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ls "/c/Program Files/Java"         ; fi
     - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_191/bin"   ; fi
     - java -version
 


### PR DESCRIPTION
They stopped shipping the JDK as part of the Windows CI environment. So now you have to install it yourself.

Still no official support for `language: java`, and the Windows builds are still crazy slow. But at least it works now.