### PR TITLE
Work around unresolved type aliases when inferring type expressions

### DIFF
--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -64,6 +64,19 @@ foo bar baz = bar
 <b>foo</b> bar baz</pre></div>
 """)
 
+    fun `test function with type annotation to alias with unresolved ref`() = doTest(
+            """
+type alias Html msg = VirtualDom.Node msg
+foo : Html () -> ()
+foo = ()
+--^
+""",
+            """
+<div class='definition'><pre><b>foo</b> : <a href="psi_element://Html">Html</a> msg → ()
+<b>foo</b></pre></div>
+""")
+
+
     fun `test function with type annotation with nested types`() = doTest(
             """
 foo : List (List a) -> ()


### PR DESCRIPTION
The Elm core code has a lot of type aliases the reference synthetic classes:

```
type alias Html msg = VirtualDom.Node msg
```

The `VirtualDom` package is JS code, so the reference doesn't resolve. We currently treat the type alias as unknown in these cases. This PR changes to behavior to treat the alias as a union declaration when the reference in unresolved.