### PR TITLE
Fix regression in expression type provider.

### DIFF
--- a/src/main/kotlin/org/elm/ide/hints/ElmExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/elm/ide/hints/ElmExpressionTypeProvider.kt
@@ -22,10 +22,8 @@ class ElmExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
     }
 
     override fun getExpressionsAt(elementAt: PsiElement): List<PsiElement> {
-        val elementTypes = (elementAt as? ElmPsiElement)
-                ?.findInference()?.expressionTypes
-                ?: return emptyList()
+        val expressionTypes = elementAt.findInference()?.expressionTypes ?: return emptyList()
         return elementAt.ancestors.takeWhile { it !is ElmFile }
-                .filter { it in elementTypes }.toList()
+                .filter { it in expressionTypes }.toList()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -18,7 +18,7 @@ import java.util.*
 private val TYPE_INFERENCE_KEY: Key<CachedValue<InferenceResult>> = Key.create("TYPE_INFERENCE_KEY")
 
 /** Find the inference result that contains the given element */
-fun ElmPsiElement.findInference(): InferenceResult? {
+fun PsiElement.findInference(): InferenceResult? {
     // ancestors is non-strict here so that we can return this element
     return ancestors.takeWhile { it !is ElmFile }
             .filterIsInstance<ElmValueDeclaration>()


### PR DESCRIPTION
#131 broke the `ElmExpressionTypeProvider` by requiring an `ElmPsiElement` in order to infer values. There are many elements inside a value declaration that aren't `ElmPsiElement`s, so this PR removes that requirement.