### PR TITLE
Revert "Work around unresolved type aliases when inferring type expressions"

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -141,15 +141,7 @@ class TypeExpression private constructor(
             val aliasTy = TyUnion(decl.moduleName, decl.upperCaseIdentifier.text, replaceParamsWithArgs(params, caller))
             return childScope.recordTypeDeclType(record, aliasTy)
         }
-        val aliasedTy = decl.typeRef?.let { childScope.typeRefType(it) } ?: TyUnknown
-
-        // It's common for Elm core code to define aliases for types defined in JS code, which don't
-        // resolve in elm. For these cases, just return the alias as a union
-        if (aliasedTy == TyUnknown) {
-            return TyUnion(decl.moduleName, decl.name, params)
-        }
-
-        return aliasedTy
+        return decl.typeRef?.let { childScope.typeRefType(it) } ?: return TyUnknown
     }
 
     private fun typeDeclarationType(declaration: ElmTypeDeclaration, caller: Caller?): Ty {

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -64,19 +64,6 @@ foo bar baz = bar
 <b>foo</b> bar baz</pre></div>
 """)
 
-    fun `test function with type annotation to alias with unresolved ref`() = doTest(
-            """
-type alias Html msg = VirtualDom.Node msg
-foo : Html () -> ()
-foo = ()
---^
-""",
-            """
-<div class='definition'><pre><b>foo</b> : <a href="psi_element://Html">Html</a> msg → ()
-<b>foo</b></pre></div>
-""")
-
-
     fun `test function with type annotation with nested types`() = doTest(
             """
 foo : List (List a) -> ()


### PR DESCRIPTION
Reverts klazuka/intellij-elm#132

It turns out that this can lead to false positives in the case where two aliases both reference the same unresolved type. 