### PR TITLE
Add code completion for accessing fields in a record

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionContributor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionContributor.kt
@@ -1,13 +1,40 @@
 package org.elm.lang.core.completion
 
 import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionInitializationContext
 import com.intellij.codeInsight.completion.CompletionType.BASIC
 import com.intellij.patterns.PlatformPatterns.psiElement
 import org.elm.lang.core.ElmLanguage
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.elementType
 
 class ElmCompletionContributor : CompletionContributor() {
 
     init {
         extend(BASIC, psiElement().withLanguage(ElmLanguage), ElmCompletionProvider())
     }
+
+    override fun beforeCompletion(context: CompletionInitializationContext) {
+        val file = context.file as? ElmFile ?: return
+
+        val pre = file.findElementAt(context.startOffset - 1) ?: return
+
+        /*
+        By default, IntelliJ injects a dummy identifier that starts with an upper-case letter
+        at the insertion caret when doing code completion. This upper-case letter is problematic
+        for languages like Elm where many parse rules require a lower-case identifier.
+        */
+
+        if (pre.elementType == ElmTypes.DOT) {
+            // Assume that after a dot, a lower-case identifier should follow.
+            // This works well for functions qualified by their module name (e.g. `String.length`)
+            // but it does NOT work for qualified types (e.g. `Task.Task`)
+
+            // TODO use additional context to determine whether it should be upper- vs lower-case.
+            context.dummyIdentifier = LOWER_DUMMY_IDENTIFIER
+        }
+    }
 }
+
+private const val LOWER_DUMMY_IDENTIFIER = "elm_code_completion_dummy"

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionProvider.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionProvider.kt
@@ -18,7 +18,7 @@ interface Suggestor {
  */
 class ElmCompletionProvider : CompletionProvider<CompletionParameters>() {
 
-    val suggestors = listOf(ElmQualifiableRefSuggestor, ElmKeywordSuggestor)
+    val suggestors = listOf(ElmQualifiableRefSuggestor, ElmRecordFieldSuggestor, ElmKeywordSuggestor)
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
         suggestors.forEach { it.addCompletions(parameters, result) }

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordFieldSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordFieldSuggestor.kt
@@ -1,0 +1,34 @@
+package org.elm.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.elements.ElmFieldAccessExpr
+import org.elm.lang.core.types.*
+
+object ElmRecordFieldSuggestor : Suggestor {
+
+    override fun addCompletions(parameters: CompletionParameters, result: CompletionResultSet) {
+        val pos = parameters.position
+        val parent = pos.parent
+        val file = pos.containingFile as ElmFile
+
+        if (pos.elementType in ELM_IDENTIFIERS && parent is ElmFieldAccessExpr) {
+            // Infer the type of the record whose fields are being accessed
+            // and suggest that record's fields as completion results.
+
+            val ty = parent.targetExpr.findTy() as? TyRecord ?: return
+
+            // provide each field as a completion result
+            ty.fields.forEach { fieldName, fieldTy ->
+                result.add(fieldName, fieldTy)
+            }
+        }
+    }
+}
+
+private fun CompletionResultSet.add(str: String, field: Ty) {
+    addElement(LookupElementBuilder.create(str)
+            .withTypeText(field.renderedText(false, false)))
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -28,6 +28,7 @@ package org.elm.lang.core.psi
 
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
@@ -43,9 +44,11 @@ val PsiElement.ancestors: Sequence<PsiElement> get() = generateSequence(this) { 
 val PsiElement.ancestorsStrict: Sequence<PsiElement> get() = ancestors.drop(1)
 val PsiElement.prevSiblings: Sequence<PsiElement> get() = generateSequence(prevSibling) { it.prevSibling }
 val PsiElement.nextSiblings: Sequence<PsiElement> get() = generateSequence(nextSibling) { it.nextSibling }
+val PsiElement.prevLeaves: Sequence<PsiElement> get() = generateSequence(PsiTreeUtil.prevLeaf(this)) { PsiTreeUtil.prevLeaf(it) }
 val PsiElement.directChildren: Sequence<PsiElement> get() = generateSequence(firstChild) { it.nextSibling }
 val Sequence<PsiElement>.withoutWs get() = filter { it !is PsiWhiteSpace && it.elementType != VIRTUAL_END_DECL }
 val Sequence<PsiElement>.withoutWsOrComments get() = withoutWs.filter { it !is PsiComment }
+val Sequence<PsiElement>.withoutErrors get() = filter { it !is PsiErrorElement }
 
 
 /**

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmCompletionTest.kt
@@ -4,7 +4,7 @@ class ElmCompletionTest: ElmCompletionTestBase() {
 
 
     fun `test value completion from function parameter`() = doSingleCompletion(
-"""
+            """
 view model = text mo{-caret-}
 """, """
 view model = text model{-caret-}
@@ -12,7 +12,7 @@ view model = text model{-caret-}
 
 
     fun `test value completion from let-in decl`() = doSingleCompletion(
-"""
+            """
 f = let name = "Arnold" in na{-caret-}
 """, """
 f = let name = "Arnold" in name{-caret-}
@@ -20,7 +20,7 @@ f = let name = "Arnold" in name{-caret-}
 
 
     fun `test value completion from case-of pattern destructuring`() = doSingleCompletion(
-"""
+            """
 f = case user of { name, age } -> nam{-caret-}
 """, """
 f = case user of { name, age } -> name{-caret-}
@@ -28,7 +28,7 @@ f = case user of { name, age } -> name{-caret-}
 
 
     fun `test union constructor completion from pattern destructuring`() = doSingleCompletion(
-"""
+            """
 type MyState = State Int
 f (Sta{-caret-} n) = n
 """, """
@@ -38,7 +38,7 @@ f (State{-caret-} n) = n
 
 
     fun `test union type completion in a type annotation`() = doSingleCompletion(
-"""
+            """
 type Page = Home
 defaultPage : Pa{-caret-}
 """, """
@@ -48,7 +48,7 @@ defaultPage : Page{-caret-}
 
 
     fun `test type alias completion in a type annotation`() = doSingleCompletion(
-"""
+            """
 type alias User = { name : String, age : Int }
 viewUser : Us{-caret-}
 """, """
@@ -57,11 +57,8 @@ viewUser : User{-caret-}
 """)
 
 
-
-
-
     fun `test qualified value completion`() = doSingleCompletionMultiFile(
-"""
+            """
 --@ main.elm
 import User
 g = User.defa{-caret-}
@@ -77,7 +74,7 @@ g = User.defaultUser{-caret-}
 
 
     fun `test qualified type completion`() = doSingleCompletionMultiFile(
-"""
+            """
 --@ main.elm
 import User
 g : User.Us{-caret-}
@@ -93,7 +90,7 @@ g : User.User{-caret-}
 
 
     fun `test qualified union constructor completion in expr`() = doSingleCompletionMultiFile(
-"""
+            """
 --@ main.elm
 import Page
 defaultPage = Page.Ho{-caret-}
@@ -109,7 +106,7 @@ defaultPage = Page.Home{-caret-}
 
 
     fun `test qualified union constructor completion in pattern`() = doSingleCompletionMultiFile(
-"""
+            """
 --@ main.elm
 import Page
 defaultPage p = case p of
@@ -126,17 +123,15 @@ defaultPage p = case p of
 """)
 
 
-
-
     fun `test does not complete union constructors in type namespace`() = checkNoCompletion(
-"""
+            """
 type Page = NotFound
 f : NotF{-caret-}
 """)
 
 
     fun `test does not complete number literals`() = checkNoCompletion(
-"""
+            """
 x = 42
 y = 4{-caret-}
 """)
@@ -145,7 +140,7 @@ y = 4{-caret-}
 // TODO [kl] eventually code completion should add a 'dot' suffix when completing a module qualifier
 
     fun `test value completion of module prefix, before dot`() = doSingleCompletionMultiFile(
-"""
+            """
 --@ main.elm
 import Data.User
 g = Dat{-caret-}
@@ -160,7 +155,14 @@ g = Data{-caret-}
 """)
 
 
-    fun `test value completion of module prefix, after dot`() = doSingleCompletionMultiFile(
+/*
+TODO re-enable these tests once we figure out how to intelligently pick
+upper- vs lower-case dummy identifier immediately following a dot.
+See [ElmCompletionContributor.beforeCompletion]
+*/
+
+/*
+fun `test value completion of module prefix, after dot`() = doSingleCompletionMultiFile(
 """
 --@ main.elm
 import Data.User
@@ -190,4 +192,5 @@ g = Data.User.defaultUser{-caret-}
 
 """)
 
+*/
 }

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmKeywordCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmKeywordCompletionTest.kt
@@ -141,4 +141,48 @@ x = let
         in{-caret-}
 """)
 
+
+    // keywords like 'if', 'case' and 'let' should be suggested in any context that begins a new expression
+
+
+    fun `test keywords that can begin an expression after a left paren`() = doSingleCompletion(
+            """
+x =
+    (i{-caret-}, 0)
+""", """
+x =
+    (if {-caret-}, 0)
+""")
+
+    fun `test keywords that can begin an expression after a left square bracket`() = doSingleCompletion(
+            """
+x =
+    [i{-caret-}, 0]
+""", """
+x =
+    [if {-caret-}, 0]
+""")
+
+    fun `test keywords that can begin an expression after 'in'`() = doSingleCompletion(
+            """
+x =
+    let y = 0
+    in
+    i{-caret-}
+""", """
+x =
+    let y = 0
+    in
+    if {-caret-}
+""")
+
+    fun `test keywords that can begin an expression after case branch arrow`() = doSingleCompletion(
+            """
+x = case () of
+        () -> i{-caret-}
+""", """
+x = case () of
+        () -> if {-caret-}
+""")
+
 }

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordCompletionTest.kt
@@ -3,41 +3,47 @@ package org.elm.lang.core.completion
 class ElmRecordCompletionTest : ElmCompletionTestBase() {
 
 
-    fun `test getName from one letter`() = checkContainsCompletion("name",
+    fun `test access name field from one letter`() = doSingleCompletion(
             """
-type alias Foo =
-    { name : String
-    , age : Int
-    }
-
-getName : Foo -> String
-getName foo =
+type alias Foo = { name : String }
+f : Foo -> String
+f foo =
     foo.n{-caret-}
+""", """
+type alias Foo = { name : String }
+f : Foo -> String
+f foo =
+    foo.name{-caret-}
 """)
 
 
-    fun `test getName from blank`() = checkContainsCompletion("name",
+    fun `test access name field from blank`() = doSingleCompletion(
             """
-type alias Foo =
-    { name : String
-    , age : Int
-    }
-
-getName : Foo -> String
-getName foo =
+type alias Foo = { name : String }
+f : Foo -> String
+f foo =
     foo.{-caret-}
+""", """
+type alias Foo = { name : String }
+f : Foo -> String
+f foo =
+    foo.name{-caret-}
 """)
 
 
-    fun `test chained field access is not currently supported`() = checkNoCompletion(
+    fun `test chained field access`() = doSingleCompletion(
             """
-type alias Foo =
-    { name : { first: String, last: String }
-    , age : Int
-    }
+type alias Foo = { name : { first: String } }
 
-getName : Foo -> String
-getName foo =
+f : Foo -> String
+f foo =
     foo.name.fir{-caret-}
+""", """
+type alias Foo = { name : { first: String } }
+
+f : Foo -> String
+f foo =
+    foo.name.first{-caret-}
 """)
+
 }

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordCompletionTest.kt
@@ -1,0 +1,43 @@
+package org.elm.lang.core.completion
+
+class ElmRecordCompletionTest : ElmCompletionTestBase() {
+
+
+    fun `test getName from one letter`() = checkContainsCompletion("name",
+            """
+type alias Foo =
+    { name : String
+    , age : Int
+    }
+
+getName : Foo -> String
+getName foo =
+    foo.n{-caret-}
+""")
+
+
+    fun `test getName from blank`() = checkContainsCompletion("name",
+            """
+type alias Foo =
+    { name : String
+    , age : Int
+    }
+
+getName : Foo -> String
+getName foo =
+    foo.{-caret-}
+""")
+
+
+    fun `test chained field access is not currently supported`() = checkNoCompletion(
+            """
+type alias Foo =
+    { name : { first: String, last: String }
+    , age : Int
+    }
+
+getName : Foo -> String
+getName foo =
+    foo.name.fir{-caret-}
+""")
+}


### PR DESCRIPTION
Now you can do code completion after typing `.` following a record value:
<img width="538" alt="screen shot 2018-11-26 at 4 35 35 pm" src="https://user-images.githubusercontent.com/84525/49050685-61eccf80-f199-11e8-8b3b-be5815d0d9df.png">

This PR does __not__ provide completions for the record literal update syntax (e.g. `{ user | name = "" }`). Implementing that is a bit tricky, so it will have to wait until later.