### PR TITLE
Fix bug when locating a package's dependencies on disk

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -92,8 +92,7 @@ data class ElmToolchain(val binDirPath: Path) {
         val compilerVersion = "0.19.0"
 
         return File("$elmHomePath/$compilerVersion/package/$name/")
-                .walk().toList()
-                .mapNotNull { Version.parseOrNull(it.name) }
+                .listFiles().mapNotNull { Version.parseOrNull(it.name) }
     }
 
     fun queryCompilerVersion(): Version? {


### PR DESCRIPTION
The old code was terrible. It was recursively listing the entire contents
of a directory, but only the direct children should have been listed.
In addition to being very wasteful, it was also throwing a lot of
exceptions which were getting masked by `Version.parseOrNull()`