### PR TITLE
Various performance fixes (and some bug fixes and cleanup along the way)

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -43,7 +43,7 @@ class ElmDocumentationProvider : AbstractDocumentationProvider() {
         val lastDot = link.indexOfLast { it == '.' }
         return if (lastDot <= 0) {
             with(ModuleScope(context.elmFile)) {
-                getVisibleTypes().find { it.name == link } ?: getDeclaredValues().find { it.name == link }
+                getVisibleTypes().all.find { it.name == link } ?: getDeclaredValues().find { it.name == link }
             }
         } else {
             val qualifierPrefix = link.substring(0, lastDot)

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -9,7 +9,7 @@ import org.elm.lang.core.resolve.scope.ExpressionScope
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ImportScope
 import org.elm.lang.core.resolve.scope.ModuleScope
-import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 
 /**
@@ -75,7 +75,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
     }
 
     private fun suggestQualifiers(qualifierPrefix: String, file: ElmFile, result: CompletionResultSet) {
-        ElmModules.getAll(file.project, file.elmProject)
+        ElmModulesIndex.getAll(file.project, file.elmProject)
                 .filter { it.name.startsWith(qualifierPrefix) && it.name != qualifierPrefix }
                 .map { it.name.removePrefix("$qualifierPrefix.").substringBefore('.') }
                 .forEach { result.add(it) }

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -40,7 +40,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 is ElmValueExpr -> {
                     if (qualifierPrefix.isEmpty()) {
                         ExpressionScope(parent).getVisibleValues().forEach { result.add(it) }
-                        ModuleScope(file).getVisibleConstructors().forEach { result.add(it) }
+                        ModuleScope(file).getVisibleConstructors().all.forEach { result.add(it) }
                         GlobalScope.builtInValues.forEach { result.add(it) }
                     } else {
                         val importScopes = ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file)
@@ -50,7 +50,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 }
                 is ElmUnionPattern -> {
                     if (qualifierPrefix.isEmpty()) {
-                        ModuleScope(file).getVisibleConstructors()
+                        ModuleScope(file).getVisibleConstructors().all
                                 .filter { it is ElmUnionMember }
                                 .forEach { result.add(it) }
                     } else {
@@ -62,7 +62,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 }
                 is ElmUpperPathTypeRef, is ElmParametricTypeRef -> {
                     if (qualifierPrefix.isEmpty()) {
-                        ModuleScope(file).getVisibleTypes().forEach { result.add(it) }
+                        ModuleScope(file).getVisibleTypes().all.forEach { result.add(it) }
                         GlobalScope.builtInTypes.forEach { result.add(it) }
                     } else {
                         ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
@@ -7,7 +7,7 @@ import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
-import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 private val log = logger<ElmImportClause>()
 
@@ -50,6 +50,6 @@ class ElmImportClause(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElem
                         getVariants().find { it.name == element.referenceName }
 
                 override fun getVariants(): Array<ElmNamedElement> =
-                        ElmModules.getAll(project, element.elmProject).toTypedArray()
+                        ElmModulesIndex.getAll(project, element.elmProject).toTypedArray()
             }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
@@ -12,7 +12,6 @@ import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ModuleScope
 import org.elm.lang.core.stubs.index.ElmModules
-import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 /**
  * Qualified module-name reference from the value or type namespaces.
@@ -34,14 +33,16 @@ class QualifiedModuleNameReference<T : ElmReferenceElement>(
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
+        val intellijProject = element.project
+        val elmProject = element.elmProject
         val moduleDecls =
                 ModuleScope(element.elmFile)
                         .getImportDecls()
                         .map { it.moduleQID.text }
-                        .let { ElmModulesIndex.getAll(it, element.project) }
+                        .let { ElmModules.getAll(it, intellijProject, elmProject) }
 
         val implicitDecls =
-                ElmModules.getAll(GlobalScope.defaultImports, element.project, element.elmProject)
+                ElmModules.getAll(GlobalScope.defaultImports, intellijProject, elmProject)
                         .filter { it.elmFile.isCore() }
 
         val aliasDecls = ModuleScope(element.elmFile).getAliasDecls() as List<ElmNamedElement>

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
@@ -11,7 +11,7 @@ import org.elm.lang.core.psi.offsetIn
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ModuleScope
-import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 /**
  * Qualified module-name reference from the value or type namespaces.
@@ -39,10 +39,10 @@ class QualifiedModuleNameReference<T : ElmReferenceElement>(
                 ModuleScope(element.elmFile)
                         .getImportDecls()
                         .map { it.moduleQID.text }
-                        .let { ElmModules.getAll(it, intellijProject, elmProject) }
+                        .let { ElmModulesIndex.getAll(it, intellijProject, elmProject) }
 
         val implicitDecls =
-                ElmModules.getAll(GlobalScope.defaultImports, intellijProject, elmProject)
+                ElmModulesIndex.getAll(GlobalScope.defaultImports, intellijProject, elmProject)
                         .filter { it.elmFile.isCore() }
 
         val aliasDecls = ModuleScope(element.elmFile).getAliasDecls() as List<ElmNamedElement>

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedModuleNameReference.kt
@@ -35,17 +35,14 @@ class QualifiedModuleNameReference<T : ElmReferenceElement>(
     override fun getVariants(): Array<ElmNamedElement> {
         val intellijProject = element.project
         val elmProject = element.elmProject
-        val moduleDecls =
-                ModuleScope(element.elmFile)
-                        .getImportDecls()
-                        .map { it.moduleQID.text }
+        val importDecls = ModuleScope(element.elmFile).getImportDecls()
+        val moduleDecls = importDecls.map { it.moduleQID.text }
                         .let { ElmModulesIndex.getAll(it, intellijProject, elmProject) }
 
-        val implicitDecls =
-                ElmModulesIndex.getAll(GlobalScope.defaultImports, intellijProject, elmProject)
+        val implicitDecls = ElmModulesIndex.getAll(GlobalScope.defaultImports, intellijProject, elmProject)
                         .filter { it.elmFile.isCore() }
 
-        val aliasDecls = ModuleScope(element.elmFile).getAliasDecls() as List<ElmNamedElement>
+        val aliasDecls = importDecls.mapNotNull { it.asClause } as List<ElmNamedElement>
 
         return listOf(moduleDecls, implicitDecls, aliasDecls).flatten().toTypedArray()
     }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
@@ -17,6 +17,6 @@ class SimpleTypeReference(element: ElmReferenceElement)
             getCandidates().find { it.name == element.referenceName }
 
     private fun getCandidates(): Array<ElmNamedElement> {
-        return ModuleScope(element.elmFile).getVisibleTypes().toTypedArray()
+        return ModuleScope(element.elmFile).getVisibleTypes().all.toTypedArray()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
@@ -18,7 +18,7 @@ class SimpleUnionConstructorReference(element: ElmReferenceElement)
             getCandidates().find { it.name == element.referenceName }
 
     private fun getCandidates(): Array<ElmNamedElement> =
-            ModuleScope(element.elmFile).getVisibleConstructors()
+            ModuleScope(element.elmFile).getVisibleConstructors().all
                     .filter { it is ElmUnionMember }
                     .toTypedArray()
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
@@ -15,7 +15,7 @@ class SimpleUnionOrRecordConstructorReference(element: ElmReferenceElement)
             getCandidates().find { it.name == element.referenceName }
 
     private fun getCandidates(): Array<ElmNamedElement> {
-        return ModuleScope(element.elmFile).getVisibleConstructors().toTypedArray()
+        return ModuleScope(element.elmFile).getVisibleConstructors().all.toTypedArray()
     }
 
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -12,12 +12,20 @@ import org.elm.workspace.ElmProject
  * The subset of implicitly exposed values, types and constructors provided by Elm's
  * standard library ("Core").
  */
-// TODO [kl] eventually ElmProject should be non-null, but we need to straighten out
-//           some things with the integration tests and legacy Elm 0.18 projects before
-//           we can be more restrictive here.
-class GlobalScope(val project: Project, val elmProject: ElmProject?) {
+class GlobalScope private constructor(val project: Project, val elmProject: ElmProject) {
 
     companion object {
+
+        fun forElmFile(elmFile: ElmFile): GlobalScope? {
+            val elmProject = elmFile.elmProject ?: return null
+            if (elmFile.isCore()) {
+                // The `elm/core` standard library does not have an implicit global scope. It must explicitly
+                // import modules like `List`, `String`, etc.
+                return null
+            }
+            return GlobalScope(elmFile.project, elmProject)
+        }
+
         /**
          * Modules that the Elm compiler treats as being implicitly imported.
          */

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.project.Project
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
-import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.lang.core.stubs.index.ElmModulesIndex
 import org.elm.workspace.ElmProject
 
 
@@ -59,7 +59,7 @@ class GlobalScope(val project: Project, val elmProject: ElmProject?) {
                 else -> null
             } ?: return emptyList()
 
-            return ElmModules.getAll(listOf(implicitModuleName), elmFile.project, elmFile.elmProject)
+            return ElmModulesIndex.getAll(listOf(implicitModuleName), elmFile.project, elmFile.elmProject)
                     .filter { it.elmFile.isCore() }
         }
     }
@@ -68,7 +68,7 @@ class GlobalScope(val project: Project, val elmProject: ElmProject?) {
         // ModuleScope.getDeclaredValues is cached, so there's no need to cache the results of this
         // function.
         fun helper(moduleName: String) =
-                ElmModules.get(moduleName, project, elmProject)
+                ElmModulesIndex.get(moduleName, project, elmProject)
                         ?.let { ModuleScope(it.elmFile).getDeclaredValues() }
                         ?: emptyList()
 
@@ -85,7 +85,7 @@ class GlobalScope(val project: Project, val elmProject: ElmProject?) {
 
     fun getVisibleTypes(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
-                ElmModules.get(moduleName, project, elmProject)
+                ElmModulesIndex.get(moduleName, project, elmProject)
                         ?.let { ModuleScope(it.elmFile).getDeclaredTypes() }
                         ?: emptyList()
 
@@ -104,7 +104,7 @@ class GlobalScope(val project: Project, val elmProject: ElmProject?) {
 
     fun getVisibleConstructors(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
-                ElmModules.get(moduleName, project, elmProject)
+                ElmModulesIndex.get(moduleName, project, elmProject)
                         ?.let { ModuleScope(it.elmFile).getDeclaredConstructors() }
                         ?: emptyList()
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -5,7 +5,7 @@ import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
-import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 
 /**
@@ -23,7 +23,7 @@ class ImportScope(val elmFile: ElmFile) {
          */
         fun fromImportDecl(importDecl: ElmImportClause): ImportScope? {
             val moduleName = importDecl.moduleQID.text
-            return ElmModules.get(moduleName, importDecl.project, importDecl.elmProject)
+            return ElmModulesIndex.get(moduleName, importDecl.project, importDecl.elmProject)
                     ?.let { ImportScope(it.elmFile) }
         }
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.util.CachedValueProvider.Result
 import com.intellij.psi.util.CachedValuesManager
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.descendantsOfType
+import org.elm.lang.core.psi.directChildren
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.psi.modificationTracker
@@ -36,7 +36,7 @@ data class VisibleNames(
 class ModuleScope(val elmFile: ElmFile) {
 
     fun getImportDecls() =
-            elmFile.descendantsOfType<ElmImportClause>()
+            elmFile.directChildren.filterIsInstance<ElmImportClause>().toList()
 
     fun getAliasDecls() =
             getImportDecls().mapNotNull { it.asClause }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -80,7 +80,7 @@ class ModuleScope(val elmFile: ElmFile) {
 
     fun getVisibleValues(): VisibleNames {
         return CachedValuesManager.getCachedValue(elmFile, VISIBLE_VALUES_KEY) {
-            val fromGlobal = elmFile.implicitGlobalScope()?.getVisibleValues() ?: emptyList()
+            val fromGlobal = GlobalScope.forElmFile(elmFile)?.getVisibleValues() ?: emptyList()
             val fromTopLevel = getDeclaredValues()
             val fromImports = elmFile.findChildrenByClass(ElmImportClause::class.java)
                     .flatMap { getVisibleImportNames(it) }
@@ -130,7 +130,7 @@ class ModuleScope(val elmFile: ElmFile) {
 
     fun getVisibleTypes(): VisibleNames {
         return CachedValuesManager.getCachedValue(elmFile, VISIBLE_TYPES_KEY) {
-            val fromGlobal = elmFile.implicitGlobalScope()?.getVisibleTypes() ?: emptyList()
+            val fromGlobal = GlobalScope.forElmFile(elmFile)?.getVisibleTypes() ?: emptyList()
             val fromTopLevel = getDeclaredTypes()
             val fromImports = elmFile.findChildrenByClass(ElmImportClause::class.java)
                     .flatMap { getVisibleImportTypes(it) }
@@ -173,7 +173,7 @@ class ModuleScope(val elmFile: ElmFile) {
 
     fun getVisibleConstructors(): VisibleNames {
         return CachedValuesManager.getCachedValue(elmFile, VISIBLE_CONSTRUCTORS_KEY) {
-            val fromGlobal = elmFile.implicitGlobalScope()?.getVisibleConstructors() ?: emptyList()
+            val fromGlobal = GlobalScope.forElmFile(elmFile)?.getVisibleConstructors() ?: emptyList()
             val fromTopLevel = getDeclaredConstructors()
             val fromImports = elmFile.findChildrenByClass(ElmImportClause::class.java)
                     .flatMap { getVisibleImportConstructors(it) }
@@ -225,13 +225,4 @@ class ModuleScope(val elmFile: ElmFile) {
         val allExposedNames = locallyExposedUnionConstructorNames.union(locallyExposedRecordConstructorNames)
         return allExposedConstructors.filter { allExposedNames.contains(it.name) }
     }
-}
-
-private fun ElmFile.implicitGlobalScope(): GlobalScope? {
-    if (isCore()) {
-        // The `elm/core` standard library does not have an implicit global scope. It must explicitly
-        // import modules like `List`, `String`, etc.
-        return null
-    }
-    return GlobalScope(project, elmProject)
 }

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModules.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModules.kt
@@ -1,6 +1,5 @@
 package org.elm.lang.core.stubs.index
 
-import com.intellij.openapi.project.Project
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
 import org.elm.openapiext.findFileByMaybeRelativePath
 import org.elm.openapiext.findFileByPathTestAware
@@ -8,47 +7,6 @@ import org.elm.workspace.ElmProject
 
 
 // TODO [kl] figure out a better name for this. Maybe it should be part of the 'Scope' system?
-
-/**
- * Find Elm modules within an Elm project.
- */
-class ElmModules {
-    companion object {
-
-        /**
-         * Returns all Elm modules which are visible to [elmProject]
-         */
-        fun getAll(intellijProject: Project, elmProject: ElmProject?): List<ElmModuleDeclaration> {
-            if (elmProject == null) {
-                return emptyList()
-            }
-            val allModules = ElmModulesIndex.getAll(intellijProject)
-            return allModules.filter { elmProject.exposes(it) }
-        }
-
-        /**
-         * Returns all Elm modules whose names match an element in [moduleNames] and which are visible to [elmProject]
-         */
-        fun getAll(moduleNames: Collection<String>, intellijProject: Project, elmProject: ElmProject?): List<ElmModuleDeclaration> {
-            if (elmProject == null) {
-                return emptyList()
-            }
-            val allModules = ElmModulesIndex.getAll(moduleNames, intellijProject)
-            return allModules.filter { elmProject.exposes(it) }
-        }
-
-        /**
-         * Returns an Elm module named [moduleName] which is visible to [elmProject], if any
-         */
-        fun get(moduleName: String, intellijProject: Project, elmProject: ElmProject?): ElmModuleDeclaration? {
-            if (elmProject == null) {
-                return null
-            }
-            val elmModules = ElmModulesIndex.get(moduleName, intellijProject)
-            return elmModules.firstOrNull { elmProject.exposes(it) }
-        }
-    }
-}
 
 
 /**

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
@@ -52,8 +52,7 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
             val key = makeKey(moduleName)
             return StubIndex.getElements(KEY, key, project,
                     GlobalSearchScope.allScope(project),
-                    ElmModuleDeclaration::class.java)
-                    .sortedWith(elmAppVsLibraryComparator)
+                    ElmModuleDeclaration::class.java).toList()
         }
 
         /**
@@ -70,7 +69,7 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
                     results.add(it)
                 }
             }
-            return results.sortedWith(elmAppVsLibraryComparator)
+            return results
         }
 
         /**
@@ -81,16 +80,3 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
         }
     }
 }
-
-/*
-There should be only a single file in project scope for a given module name,
-but until we start loading the `elm-package.json` manifest file to determine
-source roots and library roots, we will need to deal with indexed Elm files
-that do not truly belong to THIS project. To mitigate the problem, we will
-order the module declarations such that the ones that live in the `elm-stuff`
-directory are at the end of the list.
-*/
-private val elmAppVsLibraryComparator =
-        compareBy<ElmModuleDeclaration> {
-            if (it.containingFile.virtualFile.path.contains("/elm-stuff/")) 1 else 0
-        }

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
@@ -10,17 +10,17 @@ import com.intellij.psi.stubs.StubIndexKey
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
 import org.elm.lang.core.stubs.ElmFileStub
 import org.elm.lang.core.stubs.ElmModuleDeclarationStub
+import org.elm.openapiext.findFileByMaybeRelativePath
+import org.elm.openapiext.findFileByPathTestAware
+import org.elm.workspace.ElmProject
 
 private val logger = Logger.getInstance(ElmModulesIndex::class.java)
 
 /**
- * Low-level index of all known Elm modules in an IntelliJ project.
+ * Find Elm modules within an Elm project.
  *
- * **IMPORTANT:** For most application code, this is far too general. Typically you would
- * want to restrict the module name space by an Elm project, as defined by an `elm.json` file.
- * In which case you should instead use [ElmModules].
- *
- * @see ElmModules
+ * This API takes into account [ElmProject] structure to determine which modules
+ * should be visible, resolving each module to the correct version for the project.
  */
 class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
 
@@ -31,6 +31,46 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
             KEY
 
     companion object {
+
+        /**
+         * Returns an Elm module named [moduleName] which is visible to [elmProject], if any
+         */
+        fun get(moduleName: String, intellijProject: Project, elmProject: ElmProject?): ElmModuleDeclaration? {
+            if (elmProject == null) {
+                return null
+            }
+            val elmModules = rawGet(moduleName, intellijProject)
+            return elmModules.firstOrNull { elmProject.exposes(it) }
+        }
+
+
+        /**
+         * Returns all Elm modules which are visible to [elmProject]
+         */
+        fun getAll(intellijProject: Project, elmProject: ElmProject?): List<ElmModuleDeclaration> {
+            if (elmProject == null) {
+                return emptyList()
+            }
+            val allModules = rawGetAll(intellijProject)
+            return allModules.filter { elmProject.exposes(it) }
+        }
+
+
+        /**
+         * Returns all Elm modules whose names match an element in [moduleNames] and which are visible to [elmProject]
+         */
+        fun getAll(moduleNames: Collection<String>, intellijProject: Project, elmProject: ElmProject?): List<ElmModuleDeclaration> {
+            if (elmProject == null) {
+                return emptyList()
+            }
+            val allModules = rawGetAll(moduleNames, intellijProject)
+            return allModules.filter { elmProject.exposes(it) }
+        }
+
+
+        // INTERNALS
+
+
         val KEY: StubIndexKey<String, ElmModuleDeclaration> =
                 StubIndexKey.createIndexKey("org.elm.lang.core.stubs.index.ElmModulesIndex")
 
@@ -45,21 +85,23 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
         private fun makeKey(moduleName: String) =
                 moduleName
 
+
         /**
          * Returns all module declarations with name [moduleName]
          */
-        fun get(moduleName: String, project: Project): List<ElmModuleDeclaration> {
+        private fun rawGet(moduleName: String, project: Project): List<ElmModuleDeclaration> {
             val key = makeKey(moduleName)
             return StubIndex.getElements(KEY, key, project,
                     GlobalSearchScope.allScope(project),
                     ElmModuleDeclaration::class.java).toList()
         }
 
+
         /**
          * Returns all module declarations in [project] whose module name
          * matches an item in [moduleNames]
          */
-        fun getAll(moduleNames: Collection<String>, project: Project): List<ElmModuleDeclaration> {
+        private fun rawGetAll(moduleNames: Collection<String>, project: Project): List<ElmModuleDeclaration> {
             val index = StubIndex.getInstance()
             val results = mutableListOf<ElmModuleDeclaration>()
 
@@ -72,11 +114,58 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
             return results
         }
 
+
         /**
          * Returns all module declarations in [project]
          */
-        fun getAll(project: Project): List<ElmModuleDeclaration> {
-            return getAll(StubIndex.getInstance().getAllKeys(KEY, project), project)
+        private fun rawGetAll(project: Project): List<ElmModuleDeclaration> {
+            return rawGetAll(StubIndex.getInstance().getAllKeys(KEY, project), project)
         }
+
     }
+}
+
+/**
+ * Returns true if [moduleDeclaration] is visible within the receiver [ElmProject].
+ */
+private fun ElmProject.exposes(moduleDeclaration: ElmModuleDeclaration): Boolean {
+
+    // Check if the module is reachable from this project's source directories.
+    if (sourceDirectoryContains(moduleDeclaration))
+        return true
+
+
+    // Check if the module is reachable from this project's dependencies
+    return allResolvedDependencies.asSequence()
+            .filter { it.exposedModules.contains(moduleDeclaration.name) }
+            .any { it.sourceDirectoryContains(moduleDeclaration) }
+}
+
+
+/**
+ * Returns true if [moduleDeclaration] can be found in the receiver's source directories.
+ */
+private fun ElmProject.sourceDirectoryContains(moduleDeclaration: ElmModuleDeclaration): Boolean {
+
+    val moduleDeclProject = moduleDeclaration.elmProject
+            ?: return false
+
+    val candidateSrcDirs = if (moduleDeclProject.manifestPath == manifestPath) {
+        // They belong to the same Elm project, all source dirs are candidates
+        absoluteSourceDirectories
+    } else {
+        // The module declaration does not belong to this Elm project.
+        //
+        // Normally this means that there's no match, but it is possible
+        // to have 2 Elm projects that share one-or-more source directories.
+        // There is no guarantee that they are mutually exclusive.
+        //
+        // The only valid candidates are those that are shared between the 2 projects.
+        sharedSourceDirs(moduleDeclProject)
+    }
+
+    val elmModuleRelativePath = moduleDeclaration.name.replace('.', '/') + ".elm"
+    return candidateSrcDirs
+            .mapNotNull { findFileByPathTestAware(it) }
+            .any { it.findFileByMaybeRelativePath(elmModuleRelativePath) != null }
 }

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -3,7 +3,7 @@ package org.elm.workspace
 import org.elm.FileTreeBuilder
 import org.elm.fileTree
 import org.elm.lang.core.psi.elements.ElmImportClause
-import org.elm.lang.core.stubs.index.ElmModules
+import org.elm.lang.core.stubs.index.ElmModulesIndex
 import org.elm.openapiext.pathAsPath
 
 class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
@@ -111,8 +111,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
         if (debug) {
             println("A is $elmProjA, ${elmProjA.manifestPath}")
             println("B is $elmProjB, ${elmProjB.manifestPath}")
-            val moduleDeclsForA = ElmModules.getAll(project, elmProjA)
-            val moduleDeclsForB = ElmModules.getAll(project, elmProjB)
+            val moduleDeclsForA = ElmModulesIndex.getAll(project, elmProjA)
+            val moduleDeclsForB = ElmModulesIndex.getAll(project, elmProjB)
             println("module decls for A")
             moduleDeclsForA.forEach { println(it.elmFile.virtualFile.path) }
             println("\n\n")
@@ -269,8 +269,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
         if (debug) {
             println("A is $elmProjA, ${elmProjA.manifestPath}")
             println("B is $elmProjB, ${elmProjB.manifestPath}")
-            val moduleDeclsForA = ElmModules.getAll(project, elmProjA)
-            val moduleDeclsForB = ElmModules.getAll(project, elmProjB)
+            val moduleDeclsForA = ElmModulesIndex.getAll(project, elmProjA)
+            val moduleDeclsForB = ElmModulesIndex.getAll(project, elmProjB)
             println("module decls for A")
             moduleDeclsForA.forEach { println(it.elmFile.virtualFile.path) }
             println("\n\n")


### PR DESCRIPTION
Profiling with YourKit showed a lot of time being spent in the various `ModuleScope` methods as well as `ElmFile.getImportDecls()`. I fixed the former by adding more caching, and the latter by changing how it walks the Psi tree.

Along the way, I fixed a bug related to module resolution and refactored the code so that it couldn't happen again. And I cleaned up some other hacks that are no longer necessary now that we model Elm projects.