### PR TITLE
 Aliased imports now hide the original module name from qualified refs

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -6,24 +6,52 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import org.elm.ide.intentions.ElmImportIntentionAction
 import org.elm.ide.intentions.ElmMakeDeclarationIntentionAction
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.resolve.reference.QualifiedConstructorReference
+import org.elm.lang.core.resolve.reference.QualifiedTypeReference
+import org.elm.lang.core.resolve.reference.QualifiedValueReference
 import org.elm.lang.core.resolve.reference.TypeVariableReference
 import org.elm.lang.core.resolve.scope.GlobalScope
+import org.elm.lang.core.resolve.scope.ImportScope
+import org.elm.lang.core.resolve.scope.ModuleScope
+
+
+/**
+ * A handler should return `true` if it handled the error and no further processing needs to be done.
+ */
+typealias BadRefHandler =
+        (ref: PsiReference, element: PsiElement, holder: AnnotationHolder) -> Boolean
+
 
 class ElmUnresolvedReferenceAnnotator : Annotator {
+
+    // A chain of handlers to be executed sequentially when a reference cannot be resolved.
+    // Order matters! Handlers earlier in the chain can short-circuit further evaluation.
+    private val handlers = listOf<BadRefHandler>(
+            ::handleTypeAnnotation,
+            ::handleSafeToIgnore,
+            ::handleModuleHiddenByAlias
+    )
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         for (ref in element.references) {
             if (ref.resolve() == null) {
+                var handled = false
+                for (handler in handlers) {
+                    if (handler(ref, element, holder)) {
+                        handled = true
+                        break
+                    }
+                }
 
-                if (element is ElmTypeAnnotation) {
-                    holder.createWeakWarningAnnotation(element, "'${ref.canonicalText}' does not exist")
-                            .also { it.registerFix(ElmMakeDeclarationIntentionAction()) }
-                } else if (!safeToIgnore(ref, element)) {
+                if (!handled) {
+                    // Generic unresolved ref error
                     // TODO [kl] make this smarter in the case of qualified references
-                    // so that we don't report a double error when really the problem
-                    // is with the qualified module name reference.
+                    //           so that we don't report a double error when really the problem
+                    //           is with the qualified module name reference.
                     holder.createErrorAnnotation(element, "Unresolved reference '${ref.canonicalText}'")
                             .also { it.registerFix(ElmImportIntentionAction()) }
                 }
@@ -31,7 +59,16 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
         }
     }
 
-    private fun safeToIgnore(ref: PsiReference, element: PsiElement): Boolean {
+    private fun handleTypeAnnotation(ref: PsiReference, element: PsiElement, holder: AnnotationHolder): Boolean {
+        if (element !is ElmTypeAnnotation) return false
+
+        holder.createWeakWarningAnnotation(element, "'${ref.canonicalText}' does not exist")
+                .also { it.registerFix(ElmMakeDeclarationIntentionAction()) }
+
+        return true
+    }
+
+    private fun handleSafeToIgnore(ref: PsiReference, element: PsiElement, @Suppress("UNUSED_PARAMETER") holder: AnnotationHolder): Boolean {
         // Ignore refs to built-in types and values
         if (GlobalScope.allBuiltInSymbols.contains(ref.canonicalText))
             return true
@@ -50,6 +87,44 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
         }
 
         return false
+    }
+
+    // When a module is imported using an alias (e.g. `import Json.Decode as D`),
+    // Elm prohibits the use of the original module name in qualified references.
+    // So we will try to detect this condition and present a helpful error.
+    private fun handleModuleHiddenByAlias(ref: PsiReference, element: PsiElement, holder: AnnotationHolder): Boolean {
+        if (element !is ElmValueExpr && element !is ElmUpperPathTypeRef) return false
+        val elmFile = element.containingFile as? ElmFile ?: return false
+
+        val qid: ElmQID = when (ref) {
+            is QualifiedValueReference -> ref.valueQID
+            is QualifiedConstructorReference -> ref.upperCaseQID
+            is QualifiedTypeReference -> ref.upperCaseQID
+            else -> return false
+        }
+
+        if (qid.qualifierPrefix.isEmpty()) return false
+
+        val moduleName = qid.qualifierPrefix
+        val importDecl = ModuleScope(elmFile).getImportDecls().find { it.moduleQID.text == moduleName } ?: return false
+        val aliasName = importDecl.asClause?.upperCaseIdentifier?.text ?: return false
+
+        val importScope = ImportScope.fromImportDecl(importDecl) ?: return false
+
+        val exposedNames = when (ref) {
+            is QualifiedValueReference -> importScope.getExposedValues()
+            is QualifiedConstructorReference -> importScope.getExposedConstructors()
+            is QualifiedTypeReference -> importScope.getExposedTypes()
+            else -> return false
+        }
+
+        if (exposedNames.none { it.name == ref.canonicalText })
+            return false
+
+        // Success! The reference would have succeeded were it not for the alias.
+        holder.createErrorAnnotation(element, "Unresolved reference '${ref.canonicalText}'. " +
+                "Module '$moduleName' is imported as '$aliasName' and so you must use the alias here.")
+        return true
     }
 }
 

--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -93,7 +93,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
     // Elm prohibits the use of the original module name in qualified references.
     // So we will try to detect this condition and present a helpful error.
     private fun handleModuleHiddenByAlias(ref: PsiReference, element: PsiElement, holder: AnnotationHolder): Boolean {
-        if (element !is ElmValueExpr && element !is ElmUpperPathTypeRef) return false
+        if (element !is ElmValueExpr && element !is ElmUpperPathTypeRef && element !is ElmParametricTypeRef) return false
         val elmFile = element.containingFile as? ElmFile ?: return false
 
         val qid: ElmQID = when (ref) {

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -60,7 +60,8 @@ class ModuleScope(val elmFile: ElmFile) {
      */
     fun importDeclsForQualifierPrefix(qualifierPrefix: String) =
             getImportDecls().filter {
-                it.moduleQID.text == qualifierPrefix || it.asClause?.name == qualifierPrefix
+                // If a module has an alias, then the alias hides the original module name. (issue #93)
+                qualifierPrefix == it.asClause?.name ?: it.moduleQID.text
             }
 
 

--- a/src/test/kotlin/org/elm/ide/annotator/ElmAnnotatorTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/annotator/ElmAnnotatorTestBase.kt
@@ -30,6 +30,10 @@ import org.elm.lang.ElmTestBase
 import org.intellij.lang.annotations.Language
 
 abstract class ElmAnnotatorTestBase : ElmTestBase() {
+
+    override val dataPath: String
+        get() = "org/elm/ide/annotator/fixtures"
+
     protected fun doTest(vararg additionalFilenames: String) {
         myFixture.testHighlighting(fileName, *additionalFilenames)
     }

--- a/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
@@ -61,6 +61,10 @@ g = 0
 """)
 
 
+    fun testIssue93() = doTest("Issue93Module.elm")
+
+
+
     // LEGACY Elm 0.18 TESTS
 
     // TODO [drop 0.18] remove this test

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmAliasedImportResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmAliasedImportResolveTest.kt
@@ -67,4 +67,29 @@ module App exposing (Person)
 type alias Person = { name : String, age: Int }
 """)
 
+
+    // issue #93
+    fun `test introducing an alias hides the original module name from qualified refs`() = stubOnlyResolve(
+            """
+--@ main.elm
+import Foo as F
+main = Foo.bar
+           --^unresolved
+
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""")
+
+
+    fun `test an import with an alias still provides a ref for the original module name`() = stubOnlyResolve(
+            """
+--@ main.elm
+import Foo as F
+       --^Foo.elm
+
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""")
 }

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmResolveTestBase.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmResolveTestBase.kt
@@ -69,7 +69,9 @@ abstract class ElmResolveTestBase : ElmTestBase() {
         if (resolveFile == "unresolved") {
             val element = ref?.resolve()
             if (element != null) {
-                error("Should not resolve ${ref.element.text} to ${element.text}")
+                // Note: we cannot log the element text here because it may force a stub to load ASTNode
+                // causing the `checkAstNotLoaded` filter above to throw an exception.
+                error("Should not resolve ${ref.element.text} to $element")
             }
             return
         }

--- a/src/test/resources/org/elm/ide/annotator/fixtures/Issue93Module.elm
+++ b/src/test/resources/org/elm/ide/annotator/fixtures/Issue93Module.elm
@@ -1,0 +1,7 @@
+module Issue93Module exposing (..)
+
+type A = ConstructorA
+type B c = ConstructorB c
+
+x : A
+x = ConstructorA

--- a/src/test/resources/org/elm/ide/annotator/fixtures/issue93.elm
+++ b/src/test/resources/org/elm/ide/annotator/fixtures/issue93.elm
@@ -14,3 +14,7 @@ type alias Foo =
 f a b = <error descr="Unresolved reference 'x'. Module 'Issue93Module' is imported as 'I' and so you must use the alias here.">Issue93Module.x</error>
 
 g = <error descr="Unresolved reference 'ConstructorA'. Module 'Issue93Module' is imported as 'I' and so you must use the alias here.">Issue93Module.ConstructorA</error>
+
+ok = I.x
+
+badRefRegardlessOfAlias = <error descr="Unresolved reference 'bogus'">Issue93Module.bogus</error>

--- a/src/test/resources/org/elm/ide/annotator/fixtures/issue93.elm
+++ b/src/test/resources/org/elm/ide/annotator/fixtures/issue93.elm
@@ -1,0 +1,16 @@
+import Issue93Module as I
+
+{-
+When importing a module using an alias, as we do here, the original module
+name can no longer be used. And since this might otherwise be confusing
+to the user, we show a nice error message.
+-}
+
+type alias Foo =
+    { a : <error descr="Unresolved reference 'A'. Module 'Issue93Module' is imported as 'I' and so you must use the alias here.">Issue93Module.A</error>
+    , b : <error descr="Unresolved reference 'B'. Module 'Issue93Module' is imported as 'I' and so you must use the alias here.">Issue93Module.B ()</error>
+    }
+
+f a b = <error descr="Unresolved reference 'x'. Module 'Issue93Module' is imported as 'I' and so you must use the alias here.">Issue93Module.x</error>
+
+g = <error descr="Unresolved reference 'ConstructorA'. Module 'Issue93Module' is imported as 'I' and so you must use the alias here.">Issue93Module.ConstructorA</error>


### PR DESCRIPTION
Fixes #93 

When a module is imported using an alias (e.g. `import Json.Decode as D`), Elm prohibits the use of the original module name in qualified references. We now mark these as unresolved references along with a special error message that describes the problem and its solution.