### PR TITLE
Do code completion for functions & types even when module not imported

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -10,10 +10,7 @@ import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.*
-import org.elm.lang.core.resolve.reference.QualifiedConstructorReference
-import org.elm.lang.core.resolve.reference.QualifiedTypeReference
-import org.elm.lang.core.resolve.reference.QualifiedValueReference
-import org.elm.lang.core.resolve.reference.TypeVariableReference
+import org.elm.lang.core.resolve.reference.*
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ImportScope
 import org.elm.lang.core.resolve.scope.ModuleScope
@@ -37,36 +34,39 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
     )
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        for (ref in element.references) {
-            if (ref.resolve() == null) {
-                var handled = false
-                for (handler in handlers) {
-                    if (handler(ref, element, holder)) {
-                        handled = true
-                        break
-                    }
-                }
+        var refs = element.references.asSequence()
 
-                if (!handled) {
-                    // Generic unresolved ref error
-                    //
-                    // TODO [kl] make this smarter in the case of qualified references
-                    //           so that we don't report a double error when really the problem
-                    //           is with the qualified module name reference.
+        // Pre-processing: ignore any qualified value/type refs where the module qualifier could not be resolved.
+        // This is necessary because a single Psi element like ElmValueExpr can return multiple references:
+        // one for the module name and the other for the value/type name. If the former reference cannot be resolved,
+        // then the latter is guaranteed not to resolve. And we don't want to double-report the error, so we will
+        // instead filter them out.
+        if (refs.any { it is QualifiedModuleNameReference<*> && it.resolve() == null }) {
+            refs = refs.filterNot { it is QualifiedTypeReference || it is QualifiedValueReference || it is QualifiedConstructorReference }
+        }
 
-                    // Most of the time an ElmReferenceElement is not the ancestor of any other ElmReferenceElement.
-                    // And in these cases, it's ok to treat the error as spanning the entire reference element.
-                    // However, in cases like ElmParametricTypeRef, its children can also be reference elements,
-                    // and so it is vital that we correctly mark the error only on the text range that
-                    // contributed the reference.
-                    val errorRange = when (element) {
-                        is ElmParametricTypeRef -> element.upperCaseQID.textRange
-                        else -> element.textRange
-                    }
-                    holder.createErrorAnnotation(errorRange, "Unresolved reference '${ref.canonicalText}'")
-                            .also { it.registerFix(ElmImportIntentionAction()) }
+        // Give each handler a chance to deal with the unresolved ref before falling back on an error
+        outerLoop@
+        for (ref in refs.filter { it.resolve() == null }) {
+            for (handler in handlers) {
+                if (handler(ref, element, holder)) {
+                    continue@outerLoop
                 }
             }
+
+            // Generic unresolved ref error
+            //
+            // Most of the time an ElmReferenceElement is not the ancestor of any other ElmReferenceElement.
+            // And in these cases, it's ok to treat the error as spanning the entire reference element.
+            // However, in cases like ElmParametricTypeRef, its children can also be reference elements,
+            // and so it is vital that we correctly mark the error only on the text range that
+            // contributed the reference.
+            val errorRange = when (element) {
+                is ElmParametricTypeRef -> element.upperCaseQID.textRange
+                else -> element.textRange
+            }
+            holder.createErrorAnnotation(errorRange, "Unresolved reference '${ref.canonicalText}'")
+                    .also { it.registerFix(ElmImportIntentionAction()) }
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -43,7 +43,11 @@ object ElmQualifiableRefSuggestor : Suggestor {
                         ModuleScope(file).getVisibleConstructors().all.forEach { result.add(it) }
                         GlobalScope.builtInValues.forEach { result.add(it) }
                     } else {
-                        val importScopes = ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file)
+                        /* TODO Make a distinction between completion results that are already imported
+                                and those that are not. When selecting a completion that is not yet imported,
+                                the import declaration should be automatically added.
+                        */
+                        val importScopes = ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
                         importScopes.flatMap { it.getExposedValues() }.forEach { result.add(it) }
                         importScopes.flatMap { it.getExposedConstructors() }.forEach { result.add(it) }
                     }
@@ -54,7 +58,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                                 .filter { it is ElmUnionMember }
                                 .forEach { result.add(it) }
                     } else {
-                        ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file)
+                        ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
                                 .flatMap { it.getExposedConstructors() }
                                 .filter { it is ElmUnionMember }
                                 .forEach { result.add(it) }
@@ -65,7 +69,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                         ModuleScope(file).getVisibleTypes().all.forEach { result.add(it) }
                         GlobalScope.builtInTypes.forEach { result.add(it) }
                     } else {
-                        ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file)
+                        ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
                                 .flatMap { it.getExposedTypes() }
                                 .forEach { result.add(it) }
                     }

--- a/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
@@ -14,18 +14,18 @@ h = <error descr="Unresolved reference 'Quux'">Quux</error>
 
 
     fun `test unresolved qualified refs`() = checkErrors("""
-f = <error descr="Unresolved reference 'Foo'"><error descr="Unresolved reference 'foobar'">Foo.foobar</error></error>
+f = <error descr="Unresolved reference 'Foo'">Foo.foobar</error>
 
-g : <error descr="Unresolved reference 'Foo'"><error descr="Unresolved reference 'Bar'">Foo.Bar</error></error>
+g : <error descr="Unresolved reference 'Foo'">Foo.Bar</error>
 g = 42
 
-h = <error descr="Unresolved reference 'Foo'"><error descr="Unresolved reference 'Quux'">Foo.Quux</error></error>
+h = <error descr="Unresolved reference 'Foo'">Foo.Quux</error>
 """)
 
 
     fun `test unresolved parametric type ref`() = checkErrors("""
 f0 : <error descr="Unresolved reference 'Quux'">Quux</error> ()
-f1 : <error descr="Unresolved reference 'Foo'"><error descr="Unresolved reference 'Quux'">Foo.Quux</error></error> ()
+f1 : <error descr="Unresolved reference 'Foo'">Foo.Quux</error> ()
 """)
 
 

--- a/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotatorTest.kt
@@ -23,6 +23,12 @@ h = <error descr="Unresolved reference 'Foo'"><error descr="Unresolved reference
 """)
 
 
+    fun `test unresolved parametric type ref`() = checkErrors("""
+f0 : <error descr="Unresolved reference 'Quux'">Quux</error> ()
+f1 : <error descr="Unresolved reference 'Foo'"><error descr="Unresolved reference 'Quux'">Foo.Quux</error></error> ()
+""")
+
+
     fun `test built-in type refs have no errors`() = checkErrors("""
 type alias MyList = List
 """)

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -295,7 +295,7 @@ main = <error descr="Type mismatch.Required: Maybe aFound: Foo">Bar</error>
 """)
 
     fun `test invalid constructor as type annotation`() = checkByText("""
-main : <error descr="Unresolved reference 'Just'">Just a</error> -> ()
+main : <error descr="Unresolved reference 'Just'">Just</error> a -> ()
 main a = ()
 """)
 

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmCompletionTest.kt
@@ -73,6 +73,20 @@ g = User.defaultUser{-caret-}
 """)
 
 
+    fun `test qualified value completion also includes non-imported modules`() = doSingleCompletionMultiFile(
+            """
+--@ main.elm
+g = User.defa{-caret-}
+
+--@ User.elm
+module User exposing (..)
+defaultUser = "Arnold"
+""", """
+g = User.defaultUser{-caret-}
+
+""")
+
+
     fun `test qualified type completion`() = doSingleCompletionMultiFile(
             """
 --@ main.elm
@@ -84,6 +98,20 @@ module User exposing (..)
 type User = String
 """, """
 import User
+g : User.User{-caret-}
+
+""")
+
+
+    fun `test qualified type completion also includes non-imported modules`() = doSingleCompletionMultiFile(
+            """
+--@ main.elm
+g : User.Us{-caret-}
+
+--@ User.elm
+module User exposing (..)
+type User = String
+""", """
 g : User.User{-caret-}
 
 """)

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmCompletionTest.kt
@@ -1,6 +1,6 @@
 package org.elm.lang.core.completion
 
-class ElmCompletionTest: ElmCompletionTestBase() {
+class ElmCompletionTest : ElmCompletionTestBase() {
 
 
     fun `test value completion from function parameter`() = doSingleCompletion(
@@ -167,7 +167,23 @@ y = 4{-caret-}
 
 // TODO [kl] eventually code completion should add a 'dot' suffix when completing a module qualifier
 
-    fun `test value completion of module prefix, before dot`() = doSingleCompletionMultiFile(
+
+    fun `test module completion of module prefix, after dot`() = doSingleCompletionMultiFile(
+            """
+--@ main.elm
+import Data.User
+g = Data.{-caret-}
+
+--@ Data/User.elm
+module Data.User exposing (..)
+""", """
+import Data.User
+g = Data.User{-caret-}
+
+""")
+
+
+    fun `test module name completion with caret before dot`() = doSingleCompletionMultiFile(
             """
 --@ main.elm
 import Data.User
@@ -175,7 +191,6 @@ g = Dat{-caret-}
 
 --@ Data/User.elm
 module Data.User exposing (..)
-defaultUser = "Arnold"
 """, """
 import Data.User
 g = Data{-caret-}
@@ -183,42 +198,74 @@ g = Data{-caret-}
 """)
 
 
-/*
-TODO re-enable these tests once we figure out how to intelligently pick
-upper- vs lower-case dummy identifier immediately following a dot.
-See [ElmCompletionContributor.beforeCompletion]
-*/
-
-/*
-fun `test value completion of module prefix, after dot`() = doSingleCompletionMultiFile(
-"""
+    fun `test module name completion with caret after dot`() = doSingleCompletionMultiFile(
+            """
 --@ main.elm
 import Data.User
 g = Data.{-caret-}
 
 --@ Data/User.elm
 module Data.User exposing (..)
-defaultUser = "Arnold"
 """, """
 import Data.User
 g = Data.User{-caret-}
 
 """)
 
-    fun `test value completion of module prefix, final step`() = doSingleCompletionMultiFile(
-"""
---@ main.elm
-import Data.User
-g = Data.User.{-caret-}
 
---@ Data/User.elm
-module Data.User exposing (..)
+    fun `test qualified value completion with caret after dot`() = doSingleCompletionMultiFile(
+            """
+--@ main.elm
+import User
+g = User.{-caret-}
+
+--@ User.elm
+module User exposing (..)
 defaultUser = "Arnold"
 """, """
-import Data.User
-g = Data.User.defaultUser{-caret-}
+import User
+g = User.defaultUser{-caret-}
 
 """)
 
+
+    /*
+    TODO investigate
+
+    This test is temporarily disabled until we can figure out how to conditionally change
+    the IntelliJ dummy identifier to use an upper-case identifier in contexts such as types
+    which must start with an upper-case letter.
+
+    fun `test qualified type completion with caret after dot`() = doSingleCompletionMultiFile(
+            """
+--@ main.elm
+import Foo
+g : Foo.{-caret-}
+
+--@ Foo.elm
+module Foo exposing (Bar)
+type Bar = Baz String
+""", """
+import Foo
+g : Foo.Bar{-caret-}
+
+""")
 */
+
+
+    fun `test qualified type constructor completion with caret after dot`() = doSingleCompletionMultiFile(
+            """
+--@ main.elm
+import Foo
+g = Foo.{-caret-}
+
+--@ Foo.elm
+module Foo exposing (..)
+type Bar = Baz String
+""", """
+import Foo
+g = Foo.Baz{-caret-}
+
+""")
+
 }


### PR DESCRIPTION
Fixes #29 

Things left to do before merging:

- [x] fix auto-import intention for ParametricTypeRef: generates the wrong import
- [ ] try to make code-completion after the dot for upper-case ids work again