### PR TITLE
Avoid NPE when operating on return value of `File.listFiles()`

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -92,7 +92,7 @@ sealed class ElmProject(
 
         fun parse(manifestPath: Path, toolchain: ElmToolchain, ignoreTestDeps: Boolean = false): ElmProject {
             val inputStream = LocalFileSystem.getInstance().refreshAndFindFileByPath(manifestPath.toString())?.inputStream
-                    ?: throw ProjectLoadException("Could not find file $manifestPath")
+                    ?: throw ProjectLoadException("Could not find file $manifestPath. Is the package installed?")
             return parse(inputStream, manifestPath, toolchain, ignoreTestDeps)
         }
 
@@ -237,7 +237,7 @@ private fun Map<String, Constraint>.constraintDepsToPackages(toolchain: ElmToolc
                     .filter { constraint.contains(it) }
                     .sorted()
                     .firstOrNull()
-                    ?: throw ProjectLoadException("Could not load $name ($constraint)")
+                    ?: throw ProjectLoadException("Could not load $name ($constraint). Is it installed?")
 
             loadDependency(toolchain, name, version)
         }

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -91,8 +91,9 @@ data class ElmToolchain(val binDirPath: Path) {
         // TODO [kl] stop hard-coding the compiler version
         val compilerVersion = "0.19.0"
 
-        return File("$elmHomePath/$compilerVersion/package/$name/")
-                .listFiles().mapNotNull { Version.parseOrNull(it.name) }
+        val files = File("$elmHomePath/$compilerVersion/package/$name/").listFiles()
+                ?: return emptyList()
+        return files.mapNotNull { Version.parseOrNull(it.name) }
     }
 
     fun queryCompilerVersion(): Version? {

--- a/src/main/kotlin/org/elm/workspace/VersionUtil.kt
+++ b/src/main/kotlin/org/elm/workspace/VersionUtil.kt
@@ -68,12 +68,17 @@ data class Constraint(
         LESS_THAN,
         LESS_THAN_OR_EQUAL;
 
-        fun evaluate(left: Version, right: Version): Boolean {
-            return when (this) {
-                LESS_THAN -> left < right
-                LESS_THAN_OR_EQUAL -> left <= right
-            }
-        }
+        override fun toString(): String =
+                when (this) {
+                    LESS_THAN -> "<"
+                    LESS_THAN_OR_EQUAL -> "<="
+                }
+
+        fun evaluate(left: Version, right: Version): Boolean =
+                when (this) {
+                    LESS_THAN -> left < right
+                    LESS_THAN_OR_EQUAL -> left <= right
+                }
 
         companion object {
             fun parse(text: String): Op =
@@ -85,9 +90,11 @@ data class Constraint(
         }
     }
 
-    fun contains(version: Version): Boolean {
-        return (lowOp.evaluate(low, version) && highOp.evaluate(version, high))
-    }
+    fun contains(version: Version): Boolean =
+            (lowOp.evaluate(low, version) && highOp.evaluate(version, high))
+
+    override fun toString() =
+            "$low $lowOp v $highOp $high"
 
     companion object {
         fun parse(text: String): Constraint {

--- a/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
@@ -48,6 +48,11 @@ class ConstraintTest {
     fun `parse throws on bad input`() {
         Constraint.parse("1.0.0 <= v <= bogus")
     }
+
+    @Test
+    fun `toString emits a readable string`() {
+        assertEquals("1.0.0 <= v < 2.0.0", Constraint.parse("1.0.0 <= v < 2.0.0").toString())
+    }
 }
 
 private fun v(x: Int, y: Int, z: Int) =

--- a/src/test/kotlin/org/elm/workspace/VersionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/VersionTest.kt
@@ -32,6 +32,11 @@ class VersionTest {
         Version.parse("1.2.3")
     }
 
+    @Test()
+    fun `toString emits the dotted version number without any adornment`() {
+        assertEquals("1.2.3", Version.parse("1.2.3").toString())
+    }
+
     @Test(expected = ParseException::class)
     fun `parse throws on bad input`() {
         Version.parse("bogus.version.number")


### PR DESCRIPTION
Also make the "project failed to load" messages better.