### PR TITLE
Intentions for adding/removing a function/type from the exposing list

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
@@ -1,0 +1,55 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmNameIdentifierOwner
+import org.elm.lang.core.psi.elements.*
+
+/**
+ * An intention action that adds a function/type to a module's `exposing` list.
+ */
+class AddExposureIntention : ElmAtCaretIntentionActionBase<AddExposureIntention.Context>() {
+
+    data class Context(val nameToExpose: String, val exposingList: ElmExposingList)
+
+    override fun getText() = "Add to exposing list"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val exposingList = (element.containingFile as? ElmFile)?.getModuleDecl()?.exposingList
+                ?: return null
+
+        if (exposingList.doubleDot != null) {
+            // The module already exposes everything. Nothing to do here.
+            return null
+        }
+
+        val parent = element.parent as? ElmNameIdentifierOwner ?: return null
+
+        if (parent.nameIdentifier != element) return null
+
+        return when (parent) {
+            is ElmFunctionDeclarationLeft,
+            is ElmTypeDeclaration,
+            is ElmTypeAliasDeclaration ->
+                if (exposingList.allExposedItems.none { it.reference?.isReferenceTo(parent) ?: false }) {
+                    Context(parent.name, exposingList)
+                } else {
+                    // already exposed
+                    null
+                }
+            else -> null
+        }
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        object : WriteCommandAction.Simple<Unit>(project) {
+            override fun run() {
+                context.exposingList.addItem(context.nameToExpose)
+            }
+        }.execute()
+    }
+}

--- a/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
@@ -35,12 +35,12 @@ class AddExposureIntention : ElmAtCaretIntentionActionBase<AddExposureIntention.
             is ElmFunctionDeclarationLeft,
             is ElmTypeDeclaration,
             is ElmTypeAliasDeclaration ->
-                if (exposingList.allExposedItems.none { it.reference?.isReferenceTo(parent) ?: false }) {
+                if (exposingList.findMatchingItemFor(parent) == null) {
                     Context(parent.name, exposingList)
                 } else {
-                    // already exposed
                     null
                 }
+
             else -> null
         }
     }

--- a/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
@@ -39,9 +39,7 @@ class RemoveExposureIntention : ElmAtCaretIntentionActionBase<RemoveExposureInte
             is ElmFunctionDeclarationLeft,
             is ElmTypeDeclaration,
             is ElmTypeAliasDeclaration ->
-                exposingList.allExposedItems
-                        .find { it.reference?.isReferenceTo(parent) ?: false }
-                        ?.let { Context(it, exposingList) }
+                exposingList.findMatchingItemFor(parent)?.let { Context(it, exposingList) }
             else -> null
         }
     }

--- a/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
@@ -1,0 +1,62 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmExposedItemTag
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.ElmExposedValue
+import org.elm.lang.core.psi.elements.ElmExposingList
+import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
+import org.elm.lang.core.psi.elements.removeItem
+
+/**
+ * An intention action that removes a function/type from a module's `exposing` list.
+ */
+class RemoveExposureIntention : ElmAtCaretIntentionActionBase<RemoveExposureIntention.Context>() {
+
+    data class Context(val element: ElmExposedItemTag, val exposingList: ElmExposingList)
+
+    override fun getText() = "Remove from exposing list"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val elmFile = element.containingFile as? ElmFile ?: return null
+        val moduleDecl = elmFile.getModuleDecl() ?: return null
+        val exposingList = moduleDecl.exposingList ?: return null
+
+        if (exposingList.allExposedItems.size == 1) {
+            // Elm's exposing list can never be empty. In this case, there is only one thing left
+            // in the list, and if we were to remove it, the list would become empty. So we will
+            // return null to indicate that the user cannot hide the current thing.
+            return null
+        }
+
+        val parent = element.parent ?: return null
+
+        if (element.elementType == ElmTypes.LOWER_CASE_IDENTIFIER
+                && parent is ElmFunctionDeclarationLeft
+                && parent.lowerCaseIdentifier == element) {
+            return exposingList.exposesFunction(parent)?.let { Context(it, exposingList) }
+        }
+
+        return null
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        object : WriteCommandAction.Simple<Unit>(project) {
+            override fun run() {
+                context.exposingList.removeItem(context.element)
+            }
+        }.execute()
+    }
+}
+
+
+private fun ElmExposingList.exposesFunction(decl: ElmFunctionDeclarationLeft): ElmExposedValue? {
+    if (!decl.isTopLevel) return null
+    return exposedValueList.find { it.reference.isReferenceTo(decl) }
+}

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
@@ -1,9 +1,8 @@
 package org.elm.ide.lineMarkers
 
-import com.intellij.codeHighlighting.Pass
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
-import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.psi.PsiElement
 import org.elm.ide.icons.ElmIcons
 import org.elm.lang.core.psi.ElmFile
@@ -15,7 +14,6 @@ import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.psi.elements.findMatchingItemFor
-import java.awt.event.MouseEvent
 
 /**
  * Put an icon in the gutter for top-level declarations (types, functions, values)
@@ -26,17 +24,17 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
         if (element.elementType !in listOf(LOWER_CASE_IDENTIFIER, UPPER_CASE_IDENTIFIER)) return null
 
-        val parent = element.parent
-        if (parent !is ElmNameIdentifierOwner || parent.nameIdentifier != element) return null
+        val parentDecl = element.parent
+        if (parentDecl !is ElmNameIdentifierOwner || parentDecl.nameIdentifier != element) return null
 
-        return when (parent) {
+        return when (parentDecl) {
             is ElmFunctionDeclarationLeft ->
-                if (!parent.isTopLevel) null
-                else makeMarkerIfNecessary(element, parent)
+                if (!parentDecl.isTopLevel) null
+                else makeMarkerIfExposed(element, parentDecl)
 
             is ElmTypeDeclaration,
             is ElmTypeAliasDeclaration ->
-                makeMarkerIfNecessary(element, parent)
+                makeMarkerIfExposed(element, parentDecl)
 
             else ->
                 null
@@ -49,26 +47,23 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
 }
 
 
-private fun makeMarkerIfNecessary(element: PsiElement, decl: ElmNameIdentifierOwner): LineMarkerInfo<PsiElement>? {
+private fun makeMarkerIfExposed(element: PsiElement, decl: ElmNameIdentifierOwner): LineMarkerInfo<PsiElement>? {
     val elmFile = element.containingFile as? ElmFile ?: return null
     val moduleDecl = elmFile.getModuleDecl() ?: return null
     val exposingList = moduleDecl.exposingList ?: return null
     if (moduleDecl.exposesAll) {
-        return makeMarker(element) { _, _ -> Unit }
+        return makeMarker(element, exposingList.doubleDot)
     } else {
         val item = exposingList.findMatchingItemFor(decl) ?: return null
-        return makeMarker(element) { _, _ -> Unit }
+        return makeMarker(element, item)
     }
 }
 
 
-private fun makeMarker(element: PsiElement, navHandler: (MouseEvent, PsiElement) -> Unit) =
-        LineMarkerInfo(
-                element,
-                element.textRange,
-                ElmIcons.EXPOSED_GUTTER,
-                Pass.LINE_MARKERS,
-                { "Exposed" },
-                navHandler,
-                GutterIconRenderer.Alignment.RIGHT
-        )
+private fun makeMarker(element: PsiElement, target: PsiElement?) =
+        NavigationGutterIconBuilder
+                .create(ElmIcons.EXPOSED_GUTTER)
+                .setTarget(target)
+                .setPopupTitle("Go to where it is exposed")
+                .setTooltipText("Exposed")
+                .createLineMarkerInfo(element)

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
@@ -12,34 +12,35 @@ import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.elementType
 import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
-import org.elm.lang.core.psi.elements.ElmModuleDeclaration
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
+import org.elm.lang.core.psi.elements.findMatchingItemFor
+import java.awt.event.MouseEvent
 
 /**
  * Put an icon in the gutter for top-level declarations (types, functions, values)
  * that are exposed by the containing module.
  */
 class ElmExposureLineMarkerProvider : LineMarkerProvider {
+
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
         if (element.elementType !in listOf(LOWER_CASE_IDENTIFIER, UPPER_CASE_IDENTIFIER)) return null
-        val elmFile = element.containingFile as? ElmFile ?: return null
-        val moduleDecl = elmFile.getModuleDecl() ?: return null
 
         val parent = element.parent
         if (parent !is ElmNameIdentifierOwner || parent.nameIdentifier != element) return null
 
-        when (parent) {
+        return when (parent) {
             is ElmFunctionDeclarationLeft ->
-                if (moduleDecl.exposesFunction(parent))
-                    return makeMarker(element)
+                if (!parent.isTopLevel) null
+                else makeMarkerIfNecessary(element, parent)
 
             is ElmTypeDeclaration,
             is ElmTypeAliasDeclaration ->
-                if (moduleDecl.exposesType(parent))
-                    return makeMarker(element)
+                makeMarkerIfNecessary(element, parent)
+
+            else ->
+                null
         }
-        return null
     }
 
     override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<LineMarkerInfo<PsiElement>>) {
@@ -48,29 +49,26 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
 }
 
 
-private fun makeMarker(element: PsiElement): LineMarkerInfo<PsiElement> {
-    return LineMarkerInfo(
-            element,
-            element.textRange,
-            ElmIcons.EXPOSED_GUTTER,
-            Pass.LINE_MARKERS,
-            { "Exposed" },
-            { _, _ -> Unit },
-            GutterIconRenderer.Alignment.RIGHT
-    )
+private fun makeMarkerIfNecessary(element: PsiElement, decl: ElmNameIdentifierOwner): LineMarkerInfo<PsiElement>? {
+    val elmFile = element.containingFile as? ElmFile ?: return null
+    val moduleDecl = elmFile.getModuleDecl() ?: return null
+    val exposingList = moduleDecl.exposingList ?: return null
+    if (moduleDecl.exposesAll) {
+        return makeMarker(element) { _, _ -> Unit }
+    } else {
+        val item = exposingList.findMatchingItemFor(decl) ?: return null
+        return makeMarker(element) { _, _ -> Unit }
+    }
 }
 
 
-private fun ElmModuleDeclaration.exposesFunction(decl: ElmFunctionDeclarationLeft): Boolean {
-    if (!decl.isTopLevel) return false
-    if (exposesAll) return true
-    val exposedValues = exposingList?.exposedValueList ?: return false
-    return exposedValues.any { it.reference.isReferenceTo(decl) }
-}
-
-
-private fun ElmModuleDeclaration.exposesType(decl: PsiElement): Boolean {
-    if (exposesAll) return true
-    val exposedTypes = exposingList?.exposedTypeList ?: return false
-    return exposedTypes.any { it.reference.isReferenceTo(decl) }
-}
+private fun makeMarker(element: PsiElement, navHandler: (MouseEvent, PsiElement) -> Unit) =
+        LineMarkerInfo(
+                element,
+                element.textRange,
+                ElmIcons.EXPOSED_GUTTER,
+                Pass.LINE_MARKERS,
+                { "Exposed" },
+                navHandler,
+                GutterIconRenderer.Alignment.RIGHT
+        )

--- a/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
@@ -53,3 +53,6 @@ interface ElmConstantTag : ElmAtomTag, ElmFunctionParamTag, ElmPatternChildTag, 
 
 /** An element which can be the target of a field access expression. */
 interface ElmFieldAccessTargetTag : ElmPsiElement
+
+/** An element which can occur in a module or import's exposing list */
+interface ElmExposedItemTag : ElmPsiElement

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -45,6 +45,7 @@ val PsiElement.ancestorsStrict: Sequence<PsiElement> get() = ancestors.drop(1)
 val PsiElement.prevSiblings: Sequence<PsiElement> get() = generateSequence(prevSibling) { it.prevSibling }
 val PsiElement.nextSiblings: Sequence<PsiElement> get() = generateSequence(nextSibling) { it.nextSibling }
 val PsiElement.prevLeaves: Sequence<PsiElement> get() = generateSequence(PsiTreeUtil.prevLeaf(this)) { PsiTreeUtil.prevLeaf(it) }
+val PsiElement.nextLeaves: Sequence<PsiElement> get() = generateSequence(PsiTreeUtil.nextLeaf(this)) { PsiTreeUtil.nextLeaf(it) }
 val PsiElement.directChildren: Sequence<PsiElement> get() = generateSequence(firstChild) { it.nextSibling }
 val Sequence<PsiElement>.withoutWs get() = filter { it !is PsiWhiteSpace && it.elementType != VIRTUAL_END_DECL }
 val Sequence<PsiElement>.withoutWsOrComments get() = withoutWs.filter { it !is PsiComment }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
@@ -3,11 +3,8 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
-import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.ElmStubbedElement
-import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.OPERATOR_IDENTIFIER
-import org.elm.lang.core.psi.parentOfType
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
 import org.elm.lang.core.resolve.scope.ImportScope
@@ -18,7 +15,7 @@ import org.elm.lang.core.stubs.ElmExposedOperatorStub
 /**
  * Exposes a binary operator
  */
-class ElmExposedOperator : ElmStubbedElement<ElmExposedOperatorStub>, ElmReferenceElement {
+class ElmExposedOperator : ElmStubbedElement<ElmExposedOperatorStub>, ElmReferenceElement, ElmExposedItemTag {
 
     constructor(node: ASTNode) :
             super(node)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedType.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedType.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmStubbedElement
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.parentOfType
@@ -18,7 +19,7 @@ import org.elm.lang.core.stubs.ElmExposedTypeStub
  * 1) a Union Type, in which case [exposedUnionConstructors] may be non-null
  * 2) a Type Alias, in which case [exposedUnionConstructors] will be null
  */
-class ElmExposedType : ElmStubbedElement<ElmExposedTypeStub>, ElmReferenceElement {
+class ElmExposedType : ElmStubbedElement<ElmExposedTypeStub>, ElmReferenceElement, ElmExposedItemTag {
 
     constructor(node: ASTNode) :
             super(node)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedValue.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedValue.kt
@@ -3,6 +3,7 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmStubbedElement
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.parentOfType
@@ -18,7 +19,7 @@ import org.elm.lang.core.stubs.ElmExposedValueStub
  *
  * e.g. `bar` in `import Foo exposing (bar)`
  */
-class ElmExposedValue : ElmStubbedElement<ElmExposedValueStub>, ElmReferenceElement {
+class ElmExposedValue : ElmStubbedElement<ElmExposedValueStub>, ElmReferenceElement, ElmExposedItemTag {
 
     constructor(node: ASTNode) :
             super(node)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -75,6 +75,13 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
 
 
 /**
+ * Attempt to find an exposed item that refers to [decl]
+ */
+fun ElmExposingList.findMatchingItemFor(decl: ElmNameIdentifierOwner): ElmExposedItemTag? =
+        allExposedItems.find { it.reference?.isReferenceTo(decl) ?: false }
+
+
+/**
  * Add a function/type to the exposing list, while ensuring that the necessary comma and whitespace are also added.
  *
  * TODO does this function really belong here in this file? Or should it be moved closer to intention actions?

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -23,6 +23,11 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
     val doubleDot: PsiElement?
         get() = findChildByType(DOUBLE_DOT)
 
+
+    /* TODO consider getting rid of the individual [exposedValueList], [exposedTypeList],
+            and [exposedOperatorList] functions in favor of [allExposedItems]
+    */
+
     val exposedValueList: List<ElmExposedValue>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, ElmExposedValue::class.java)
 
@@ -40,6 +45,8 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
      *
      * In the case where the module/import exposes *all* names (e.g. `module Foo exposing (..)`)
      * the returned list will be empty.
+     *
+     * This is the superset of [exposedValueList], [exposedTypeList], and [exposedOperatorList]
      */
     val allExposedItems: List<ElmExposedItemTag>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, ElmExposedItemTag::class.java)
@@ -49,6 +56,8 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
 
 /**
  * Remove the item from the exposing list and make sure that whitespace and commas are correctly preserved.
+ *
+ * TODO does this function really belong here in this file? Or should it be moved closer to intention actions?
  */
 fun ElmExposingList.removeItem(item: ElmExposedItemTag) {
     val nextVisibleLeaf = PsiTreeUtil.nextVisibleLeaf(item) ?: error("incomplete exposing list")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -95,22 +95,26 @@
         <additionalTextAttributes scheme="Darcula" file="colorSchemes/ElmDarcula.xml"/>
         <annotator language="Elm" implementationClass="org.elm.ide.highlight.ElmSyntaxHighlightAnnotator"/>
         <annotator language="Elm" implementationClass="org.elm.ide.annotator.ElmUnresolvedReferenceAnnotator"/>
-        <colorSettingsPage implementation="org.elm.ide.color.ElmColorSettingsPage" />
+        <colorSettingsPage implementation="org.elm.ide.color.ElmColorSettingsPage"/>
         <enterHandlerDelegate implementation="org.elm.ide.typing.ElmOnEnterSmartIndentHandler"/>
         <fileTypeFactory implementation="org.elm.lang.core.ElmFileTypeFactory"/>
-        <gotoSymbolContributor implementation="org.elm.ide.navigation.ElmGoToSymbolContributor" />
-        <lang.braceMatcher language="Elm" implementationClass="org.elm.ide.ElmPairedBraceMatcher" />
+        <gotoSymbolContributor implementation="org.elm.ide.navigation.ElmGoToSymbolContributor"/>
+        <lang.braceMatcher language="Elm" implementationClass="org.elm.ide.ElmPairedBraceMatcher"/>
         <lang.commenter language="Elm" implementationClass="org.elm.ide.commenter.ElmCommenter"/>
-        <completion.contributor language="Elm" implementationClass="org.elm.lang.core.completion.ElmCompletionContributor" />
-        <lang.findUsagesProvider language="Elm" implementationClass="org.elm.ide.search.ElmFindUsagesProvider" />
-        <lang.namesValidator language="Elm" implementationClass="org.elm.lang.refactoring.ElmNamesValidator" />
+        <completion.contributor language="Elm"
+                                implementationClass="org.elm.lang.core.completion.ElmCompletionContributor"/>
+        <lang.findUsagesProvider language="Elm" implementationClass="org.elm.ide.search.ElmFindUsagesProvider"/>
+        <lang.namesValidator language="Elm" implementationClass="org.elm.lang.refactoring.ElmNamesValidator"/>
         <lang.parserDefinition language="Elm" implementationClass="org.elm.lang.core.parser.ElmParserDefinition"/>
-        <lang.psiStructureViewFactory language="Elm" implementationClass="org.elm.ide.structure.ElmStructureViewFactory" />
-        <lang.refactoringSupport language="Elm" implementationClass="org.elm.lang.refactoring.ElmRefactoringSupportProvider" />
-        <renamePsiElementProcessor implementation="org.elm.lang.refactoring.ElmRenamePsiFileProcessor" />
-        <renamePsiElementProcessor implementation="org.elm.lang.refactoring.ElmRenamePsiElementProcessor" />
-        <lang.syntaxHighlighterFactory language="Elm" implementationClass="org.elm.ide.highlight.ElmSyntaxHighlighterFactory"/>
-        <spellchecker.support language="Elm" implementationClass="org.elm.ide.spelling.ElmSpellCheckingStrategy" />
+        <lang.psiStructureViewFactory language="Elm"
+                                      implementationClass="org.elm.ide.structure.ElmStructureViewFactory"/>
+        <lang.refactoringSupport language="Elm"
+                                 implementationClass="org.elm.lang.refactoring.ElmRefactoringSupportProvider"/>
+        <renamePsiElementProcessor implementation="org.elm.lang.refactoring.ElmRenamePsiFileProcessor"/>
+        <renamePsiElementProcessor implementation="org.elm.lang.refactoring.ElmRenamePsiElementProcessor"/>
+        <lang.syntaxHighlighterFactory language="Elm"
+                                       implementationClass="org.elm.ide.highlight.ElmSyntaxHighlighterFactory"/>
+        <spellchecker.support language="Elm" implementationClass="org.elm.ide.spelling.ElmSpellCheckingStrategy"/>
         <lang.documentationProvider language="Elm" implementationClass="org.elm.ide.docs.ElmDocumentationProvider"/>
         <lang.foldingBuilder language="Elm" implementationClass="org.elm.ide.folding.ElmFoldingBuilder"/>
         <importFilteringRule implementation="org.elm.ide.usages.ElmImportFilteringRule"/>
@@ -118,7 +122,8 @@
         <backspaceHandlerDelegate implementation="org.elm.ide.typing.ElmBackspaceHandler"/>
         <codeInsight.parameterInfo language="Elm" implementationClass="org.elm.ide.hints.ElmParameterInfoHandler"/>
         <codeInsight.typeInfo language="Elm" implementationClass="org.elm.ide.hints.ElmExpressionTypeProvider"/>
-        <codeInsight.lineMarkerProvider language="Elm" implementationClass="org.elm.ide.lineMarkers.ElmExposureLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="Elm"
+                                        implementationClass="org.elm.ide.lineMarkers.ElmExposureLineMarkerProvider"/>
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
 
         <!-- Inspections -->
@@ -139,22 +144,32 @@
                          implementationClass="org.elm.ide.inspections.ElmIncompletePatternInspection"/>
 
 
+        <!-- Intentions -->
+
+        <intentionAction>
+            <className>org.elm.ide.intentions.RemoveExposureIntention</className>
+            <category>Elm</category>
+        </intentionAction>
+
+
         <!-- ELM PROJECTS, PACKAGES AND DEPENDENCIES -->
-        <projectService serviceInterface="org.elm.workspace.ElmWorkspaceService" serviceImplementation="org.elm.workspace.ElmWorkspaceService" />
-        <additionalLibraryRootsProvider implementation="org.elm.workspace.ElmAdditionalLibraryRootsProvider" />
-        <projectConfigurable instance="org.elm.workspace.ui.ElmWorkspaceConfigurable" displayName="Elm" groupId="language"/>
-        <editorNotificationProvider implementation="org.elm.ide.notifications.ElmNeedsConfigNotificationProvider" />
+        <projectService serviceInterface="org.elm.workspace.ElmWorkspaceService"
+                        serviceImplementation="org.elm.workspace.ElmWorkspaceService"/>
+        <additionalLibraryRootsProvider implementation="org.elm.workspace.ElmAdditionalLibraryRootsProvider"/>
+        <projectConfigurable instance="org.elm.workspace.ui.ElmWorkspaceConfigurable" displayName="Elm"
+                             groupId="language"/>
+        <editorNotificationProvider implementation="org.elm.ide.notifications.ElmNeedsConfigNotificationProvider"/>
         <toolWindow id="Elm" anchor="right" icon="/icons/elm-toolwindow.png"
                     factoryClass="org.elm.ide.toolwindow.ElmToolWindowFactory"/>
 
         <!-- STUBS -->
-        <stubElementTypeHolder class="org.elm.lang.core.psi.ElmTypes" />
-        <stubIndex implementation="org.elm.lang.core.stubs.index.ElmModulesIndex" />
-        <stubIndex implementation="org.elm.lang.core.stubs.index.ElmNamedElementIndex" />
+        <stubElementTypeHolder class="org.elm.lang.core.psi.ElmTypes"/>
+        <stubIndex implementation="org.elm.lang.core.stubs.index.ElmModulesIndex"/>
+        <stubIndex implementation="org.elm.lang.core.stubs.index.ElmNamedElementIndex"/>
 
 
-        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext" />
-        <defaultLiveTemplatesProvider implementation="org.elm.ide.livetemplates.ElmLiveTemplateProvider" />
+        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext"/>
+        <defaultLiveTemplatesProvider implementation="org.elm.ide.livetemplates.ElmLiveTemplateProvider"/>
     </extensions>
 
     <project-components>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -147,6 +147,11 @@
         <!-- Intentions -->
 
         <intentionAction>
+            <className>org.elm.ide.intentions.AddExposureIntention</className>
+            <category>Elm</category>
+        </intentionAction>
+
+        <intentionAction>
             <className>org.elm.ide.intentions.RemoveExposureIntention</className>
             <category>Elm</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/AddExposureIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/AddExposureIntention/after.elm.template
@@ -1,0 +1,4 @@
+module User exposing (<spot>name, age</spot>)
+
+name = "Bob"
+age = 42

--- a/src/main/resources/intentionDescriptions/AddExposureIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/AddExposureIntention/before.elm.template
@@ -1,0 +1,4 @@
+module User exposing (<spot>name</spot>)
+
+name = "Bob"
+age = 42

--- a/src/main/resources/intentionDescriptions/AddExposureIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddExposureIntention/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Add a function or type to a module's <code>exposing</code> list.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/RemoveExposureIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/RemoveExposureIntention/after.elm.template
@@ -1,0 +1,4 @@
+module User exposing (<spot>name</spot>)
+
+name = "Bob"
+age = 42

--- a/src/main/resources/intentionDescriptions/RemoveExposureIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/RemoveExposureIntention/before.elm.template
@@ -1,0 +1,4 @@
+module User exposing (<spot>name, age</spot>)
+
+name = "Bob"
+age = 42

--- a/src/main/resources/intentionDescriptions/RemoveExposureIntention/description.html
+++ b/src/main/resources/intentionDescriptions/RemoveExposureIntention/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Removes a function or type from a module's <code>exposing</code> list.
+</body>
+</html>

--- a/src/test/kotlin/org/elm/ide/intentions/AddExposureIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddExposureIntentionTest.kt
@@ -1,0 +1,27 @@
+package org.elm.ide.intentions
+
+
+class AddExposureIntentionTest : ElmIntentionTestBase(AddExposureIntention()) {
+
+
+    fun `test expose a function`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+f0 = ()
+f1{-caret-} = ()
+""", """
+module Foo exposing (f0, f1)
+f0 = ()
+f1 = ()
+""")
+
+
+    fun `test cannot expose when the module already exposes everything`() = doUnavailableTest(
+            """
+module Foo exposing (..)
+f0 = ()
+f1{-caret-} = ()
+""")
+
+
+}

--- a/src/test/kotlin/org/elm/ide/intentions/ElmIntentionDocsTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmIntentionDocsTest.kt
@@ -1,0 +1,27 @@
+package org.elm.ide.intentions
+
+import com.intellij.codeInsight.intention.IntentionManager
+import org.elm.lang.ElmTestBase
+
+class ElmIntentionDocsTest : ElmTestBase() {
+
+    fun `test intentions has documentation`() {
+        IntentionManager.EP_INTENTION_ACTIONS
+                .extensions
+                .filter { it.category?.startsWith("Elm") == true }
+                .forEach {
+                    val simpleName = it.className.substringAfterLast(".")
+                    val directory = "intentionDescriptions/$simpleName"
+                    val files = listOf("before.elm.template", "after.elm.template", "description.html")
+                    for (file in files) {
+                        val text = getResourceAsString("$directory/$file")
+                                ?: fail("No HTML docs found for ${it.className}.\n" +
+                                        "Add ${files.joinToString()} to src/main/resources/$directory")
+
+                        if (file.endsWith(".html")) {
+                            checkHtmlStyle(text)
+                        }
+                    }
+                }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
@@ -8,13 +8,11 @@
 package org.elm.ide.intentions
 
 import com.intellij.codeInsight.intention.IntentionAction
-import org.elm.ide.inspections.ElmAnnotationTestBase
 import org.elm.lang.ElmTestBase
-import org.elm.replaceCaretMarker
 import org.intellij.lang.annotations.Language
 
 
-abstract class ElmIntentionTestBase(val intention: IntentionAction) : ElmAnnotationTestBase() {
+abstract class ElmIntentionTestBase(val intention: IntentionAction) : ElmTestBase() {
 
     protected fun doAvailableTest(@Language("Elm") before: String, @Language("Elm") after: String) {
         InlineFile(before).withCaret()

--- a/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
@@ -43,6 +43,40 @@ f2 = ()
 """)
 
 
+    fun `test hide a type in the exposing list`() = doAvailableTest("""
+module Foo exposing (Bar, f0)
+type Bar{-caret-} = BarVariant ()
+f0 = ()
+""", """
+module Foo exposing (f0)
+type Bar = BarVariant ()
+f0 = ()
+""")
+
+
+    fun `test hide a type, which exposes its variants, in the exposing list`() = doAvailableTest("""
+module Foo exposing (Bar(..), f0)
+type Bar{-caret-} = BarVariant ()
+f0 = ()
+""", """
+module Foo exposing (f0)
+type Bar = BarVariant ()
+f0 = ()
+""")
+
+
+    fun `test hide a type alias in the exposing list`() = doAvailableTest("""
+module Foo exposing (Bar, f0)
+type alias Bar{-caret-} = ()
+f0 = ()
+""", """
+module Foo exposing (f0)
+type alias Bar = ()
+f0 = ()
+""")
+
+
+
     // Elm does not allow an empty exposing list, so we will refuse to remove it in such cases
     // (the only alternative is to change it to `exposing (..)` or drop the module declaration
     // entirely; both are bad options).

--- a/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
@@ -1,0 +1,54 @@
+package org.elm.ide.intentions
+
+
+class RemoveExposureIntentionTest : ElmIntentionTestBase(RemoveExposureIntention()) {
+
+
+    fun `test hide the first value in the exposing list`() = doAvailableTest("""
+module Foo exposing (f0, f1, f2)
+f0{-caret-} = ()
+f1 = ()
+f2 = ()
+""", """
+module Foo exposing (f1, f2)
+f0 = ()
+f1 = ()
+f2 = ()
+""")
+
+
+    fun `test hide the middle value in the exposing list`() = doAvailableTest("""
+module Foo exposing (f0, f1       ,   f2)
+f0 = ()
+f1{-caret-} = ()
+f2 = ()
+""", """
+module Foo exposing (f0, f2)
+f0 = ()
+f1 = ()
+f2 = ()
+""")
+
+
+    fun `test hide the last value in the exposing list`() = doAvailableTest("""
+module Foo exposing (f0, f1, f2)
+f0 = ()
+f1 = ()
+f2{-caret-} = ()
+""", """
+module Foo exposing (f0, f1)
+f0 = ()
+f1 = ()
+f2 = ()
+""")
+
+
+    // Elm does not allow an empty exposing list, so we will refuse to remove it in such cases
+    // (the only alternative is to change it to `exposing (..)` or drop the module declaration
+    // entirely; both are bad options).
+    fun `test refuse to hide the last remaining exposed value`() = doUnavailableTest("""
+module Foo exposing (bar)
+bar{-caret-} = ()
+""")
+
+}

--- a/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
@@ -85,4 +85,10 @@ module Foo exposing (bar)
 bar{-caret-} = ()
 """)
 
+
+    fun `test refuse to hide when the module exposes everything`() = doUnavailableTest("""
+module Foo exposing (..)
+bar{-caret-} = ()
+""")
+
 }

--- a/src/test/kotlin/org/elm/lang/ElmTestBase.kt
+++ b/src/test/kotlin/org/elm/lang/ElmTestBase.kt
@@ -293,6 +293,16 @@ abstract class ElmTestBase : LightPlatformCodeInsightFixtureTestCase(), ElmTestC
         }
 
         @JvmStatic
+        fun checkHtmlStyle(html: String) {
+            // Consistency check for the HTML documentation of intention actions
+            // http://stackoverflow.com/a/1732454
+            val re = "<body>(.*)</body>".toRegex(RegexOption.DOT_MATCHES_ALL)
+            val body = (re.find(html)?.let { it.groups[1]!!.value } ?: html).trim()
+            check(body[0].isUpperCase()) { "Please start description with the capital latter" }
+            check(body.last() == '.') { "Please end description with a period" }
+        }
+
+        @JvmStatic
         fun getResourceAsString(path: String): String? {
             val stream = ElmTestBase::class.java.classLoader.getResourceAsStream(path)
                     ?: return null


### PR DESCRIPTION
Fixes #147 

New stuff:
1. "add to exposing list" intention
2. "remove from exposing list" intention
3. the "e" gutter line marker icon is now clickable: it takes you to where the thing is exposed in the exposing list

<img width="294" alt="add" src="https://user-images.githubusercontent.com/84525/50489894-1f4c2c00-09bf-11e9-9cb8-d82f04380933.png">

<img width="258" alt="remove" src="https://user-images.githubusercontent.com/84525/50489896-22471c80-09bf-11e9-8400-79330d7983f9.png">

I also consolidated the logic for determining if a value/function/type is exposed and added some utility functions for creating/deleting stuff in an `exposing` list. These utility functions will be used in a subsequent pull request to cleanup the "add import" intention code.
