### PR TITLE
Importing and exposing a custom type variant constructor now exposes all

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import org.elm.ide.intentions.ElmImportIntentionAction
+import org.elm.ide.intentions.AddImportIntention
 import org.elm.ide.intentions.ElmMakeDeclarationIntentionAction
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmQID
@@ -66,7 +66,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
                 else -> element.textRange
             }
             holder.createErrorAnnotation(errorRange, "Unresolved reference '${ref.canonicalText}'")
-                    .also { it.registerFix(ElmImportIntentionAction()) }
+                    .also { it.registerFix(AddImportIntention()) }
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
@@ -20,7 +20,7 @@ import java.awt.Component
 import javax.swing.DefaultListCellRenderer
 import javax.swing.JList
 
-class ElmImportIntentionAction : ElmAtCaretIntentionActionBase<ElmImportIntentionAction.Context>() {
+class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Context>() {
 
     data class Context(
             val refName: String,

--- a/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
@@ -233,7 +233,7 @@ data class Candidate(
             val (nameForImport, isExposedDirectly) = when (element) {
                 is ElmUnionVariant -> {
                     val typeName = element.parentOfType<ElmTypeDeclaration>()!!.name
-                    Pair("$typeName($name)", exposingList.exposesConstructor(name, typeName))
+                    Pair("$typeName(..)", exposingList.exposesConstructor(name, typeName))
                 }
 
                 is ElmInfixDeclaration ->

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedType.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedType.kt
@@ -32,6 +32,8 @@ class ElmExposedType : ElmStubbedElement<ElmExposedTypeStub>, ElmReferenceElemen
         get() = findNotNullChildByType(UPPER_CASE_IDENTIFIER)
 
 
+    // TODO [drop 0.18] starting with 0.19, only `..` is allowed when exposing a union type
+    //      the individual union variant constructors can no longer be exposed individually.
     val exposedUnionConstructors: ElmExposedUnionConstructors?
         get() = PsiTreeUtil.getStubChildOfType(this, ElmExposedUnionConstructors::class.java)
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -80,6 +80,15 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
 fun ElmExposingList.findMatchingItemFor(decl: ElmNameIdentifierOwner): ElmExposedItemTag? =
         allExposedItems.find { it.reference?.isReferenceTo(decl) ?: false }
 
+/**
+ * Returns true if [decl] is explicitly exposed by the receiver
+ *
+ * NOTE: This only handles the case where it is exposed directly by name.
+ *       You must check separately to see if the receiver uses Elm's `..` syntax
+ *       to expose *all* names.
+ */
+fun ElmExposingList.explicitlyExposes(decl: ElmNameIdentifierOwner): Boolean =
+        findMatchingItemFor(decl) != null
 
 /**
  * Add a function/type to the exposing list, while ensuring that the necessary comma and whitespace are also added.

--- a/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
@@ -51,6 +51,21 @@ main = Foo.bar
 """)
 
 
+    // see https://github.com/klazuka/intellij-elm/issues/77
+    fun `test importing a union variant constructor exposes all variants`() = check(
+            """
+--@ main.elm
+main = BarVariant{-caret-}
+--@ Foo.elm
+module Foo exposing (Bar(..))
+type Bar = BarVariant ()
+""",
+            """
+import Foo exposing (Bar(..))
+main = BarVariant
+""")
+
+
     fun `test binary infix operator`() = check(
             """
 --@ main.elm
@@ -147,21 +162,6 @@ main = quux + bar
 """)
 
 
-    fun `test merge with existing exposed union constructors`() = check(
-            """
---@ main.elm
-import App exposing (Page(Home))
-main = Settings{-caret-}
---@ App.elm
-module App exposing (Page(..))
-type Page = Home | Settings
-""",
-            """
-import App exposing (Page(Home, Settings))
-main = Settings
-""")
-
-
     fun `test merge with existing exposed union type`() = check(
             """
 --@ main.elm
@@ -172,7 +172,7 @@ module App exposing (Page(..))
 type Page = Home | Settings
 """,
             """
-import App exposing (Page(Settings))
+import App exposing (Page(..))
 main = Settings
 """)
 

--- a/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.vfs.VirtualFileFilter
 import org.elm.fileTreeFromText
 import org.intellij.lang.annotations.Language
 
-class ElmImportIntentionTest : ElmIntentionTestBase(ElmImportIntentionAction()) {
+class AddImportIntentionTest : ElmIntentionTestBase(AddImportIntention()) {
 
 
     fun `test un-qualified value`() = check(
@@ -20,19 +20,6 @@ import Foo exposing (bar)
 main = bar
 """)
 
-    fun `test annotation`() = check(
-            """
---@ main.elm
-bar{-caret-} : Int -> Int
-bar = ()
---@ Foo.elm
-module Foo exposing (bar)
-bar = 42
-""",
-            """
-bar : Int -> Int
-bar = ()
-""")
 
     fun `test annotation value`() = check(
             """
@@ -79,7 +66,7 @@ main = 2 ** 3
 """)
 
 
-    fun `test import between module decl and value-decl`() = check(
+    fun `test inserts import between module decl and value-decl`() = check(
             """
 --@ main.elm
 module Main exposing (..)
@@ -95,7 +82,7 @@ main = Foo.bar{-caret-}
 """)
 
 
-    fun `test import between module decl and doc-comment`() = check(
+    fun `test inserts import between module decl and doc-comment`() = check(
             """
 --@ main.elm
 module Main exposing (..)
@@ -190,7 +177,7 @@ main = Settings
 """)
 
 
-    fun `test insert import after import`() = check(
+    fun `test inserts import after existing import`() = check(
             """
 --@ main.elm
 import Foo exposing (bar)
@@ -218,6 +205,15 @@ module Foo exposing ()
 bar = 42
 """)
 
+    fun `test verify unavailable on type annotation when local function hides external name`() = verifyUnavailable(
+            """
+--@ main.elm
+bar{-caret-} : Int -> Int
+bar = ()
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""")
 
     fun `test binary infix operator containing dot is never qualified`() = check(
             """


### PR DESCRIPTION
Fixes #77 

Starting in Elm 0.19, it is no longer valid to import individual variants
of a custom type. This change makes it so that when we add an import
for a single variant, it also exposes all of the other variants.

For Elm 0.18 users, this may be a minor inconvenience, but it's easy
enough to workaround, and I don't want to make the code more
complicated to support a dead codepath.