### PR TITLE
Improve 'extend selection' to also grab the type annotation

### DIFF
--- a/src/main/kotlin/org/elm/ide/wordSelection/ElmDeclAnnotationSelectionHandler.kt
+++ b/src/main/kotlin/org/elm/ide/wordSelection/ElmDeclAnnotationSelectionHandler.kt
@@ -1,0 +1,70 @@
+package org.elm.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.psi.parentOfType
+
+/**
+ * Adjusts the 'extend selection' behavior for [ElmValueDeclaration] and [ElmTypeAnnotation] so that they
+ * mutually extend the selection to include the other.
+ */
+class ElmDeclAnnotationSelectionHandler : ExtendWordSelectionHandlerBase() {
+
+    /*
+        The plugin mechanism for refining the default 'extend selection' behavior is poor.
+
+        Based on tracing the code, here is my understanding of how the internal logic works:
+
+        It all starts in `SelectWordHandler.doExecute`. Starting with the element at the caret,
+        it creates a selection range that just covers the caret position itself. And it defines
+        an initial minimum range which spans the entire document. It then asks each registered
+        `ExtendWordSelectionHandler` plugin extension point if it can select the thing and if so,
+        to return a list of text ranges describing what it would like to select.
+
+        Each candidate range is then checked to see if:
+
+            (a) it would expand the current selection range
+            (b) it is smaller than any candidate range seen so far
+
+        If both conditions pass, the remaining candidates are ignored and IntelliJ will select
+        the text in the editor described by the candidate that succeeded. Otherwise, the algorithm
+        will walk the Psi tree upwards until it finds a larger selection.
+
+        In terms of how this affects plugin authors, it appears that the following guidelines
+        should be followed:
+
+            (1) if you want to return a *larger* selection than would normally be returned for
+                the given element, then you must call `ExtendWordSelectionHandlerBase.expandToWholeLine`
+                with your desired range and return the resulting list of ranges. I have no idea why
+                this is, but it appears to work.
+            (2) if you want to return a *smaller* selection than would normally be returned for
+                the given element, then you can just return the desired range directly.
+
+     */
+
+    override fun canSelect(e: PsiElement): Boolean =
+            e is ElmValueDeclaration || e is ElmTypeAnnotation
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        when (e) {
+            is ElmValueDeclaration -> {
+                // extend the selection so that it also includes the preceding type annotation
+                val typeAnnotation = e.typeAnnotation ?: return null
+                val range = TextRange(typeAnnotation.textRange.startOffset, e.textRange.endOffset)
+                return expandToWholeLine(editorText, range)
+            }
+            is ElmTypeAnnotation -> {
+                // extend the selection so that it also includes the function body
+                val targetDecl = e.reference.resolve() ?: return null
+                val valueDecl = targetDecl.parentOfType<ElmValueDeclaration>()!!
+                val range = TextRange(e.textRange.startOffset, valueDecl.textRange.endOffset)
+                return expandToWholeLine(editorText, range)
+            }
+            else -> return null
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -125,6 +125,7 @@
         <codeInsight.lineMarkerProvider language="Elm"
                                         implementationClass="org.elm.ide.lineMarkers.ElmExposureLineMarkerProvider"/>
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
+        <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
 
         <!-- Inspections -->
 

--- a/src/test/kotlin/org/elm/ide/wordSelection/ElmDeclAnnotationSelectionHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/wordSelection/ElmDeclAnnotationSelectionHandlerTest.kt
@@ -1,0 +1,65 @@
+package org.elm.ide.wordSelection
+
+
+class ElmDeclAnnotationSelectionHandlerTest : ElmExtendSelectionTestBase() {
+
+
+    fun `test extends selection from func body to include type annotation`() = doTestWithTrimmedMargins("""
+x = "hi"
+f : Int
+f = 0<caret>
+""",
+            """
+x = "hi"
+f : Int
+f = <selection>0<caret></selection>
+""",
+            """
+x = "hi"
+f : Int
+<selection>f = 0<caret></selection>
+""",
+            """
+x = "hi"
+<selection>f : Int
+f = 0<caret></selection>
+""",
+            """
+<selection>x = "hi"
+f : Int
+f = 0<caret></selection>
+""")
+
+
+    fun `test extends selection from type annotation to include func body`() = doTestWithTrimmedMargins("""
+x = "hi"
+f : Int<caret>
+f = 0
+""",
+            """
+x = "hi"
+f : <selection>Int<caret></selection>
+f = 0
+""",
+            """
+x = "hi"
+<selection>f : Int<caret></selection>
+f = 0
+""",
+            """
+x = "hi"
+<selection>f : Int<caret>
+</selection>f = 0
+""",
+            """
+x = "hi"
+<selection>f : Int<caret>
+f = 0</selection>
+""",
+            """
+<selection>x = "hi"
+f : Int<caret>
+f = 0</selection>
+""")
+
+}

--- a/src/test/kotlin/org/elm/ide/wordSelection/ElmExtendSelectionTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/wordSelection/ElmExtendSelectionTestBase.kt
@@ -1,0 +1,48 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elm.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.SelectWordHandler
+import com.intellij.ide.DataManager
+import org.elm.lang.ElmTestBase
+
+abstract class ElmExtendSelectionTestBase : ElmTestBase() {
+
+    fun doTest(before: String, vararg after: String) {
+        myFixture.configureByText("main.elm", before)
+        val action = SelectWordHandler(null)
+        val dataContext = DataManager.getInstance().getDataContext(myFixture.editor.component)
+        for (text in after) {
+            action.execute(myFixture.editor, null, dataContext)
+            myFixture.checkResult(text, false)
+        }
+    }
+
+    fun doTestWithTrimmedMargins(before: String, vararg after: String) {
+        doTest(before.trimMargin(), *after.map { it.trimMargin() }.toTypedArray())
+    }
+}


### PR DESCRIPTION
Now you can press `option/alt-<up-arrow>` inside a function body and it will also select the type annotation. This makes it easier to delete/cut/copy an entire function.