### PR TITLE
Detect unused exposing of functions/values

### DIFF
--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedImportInspectionTest.kt
@@ -53,4 +53,96 @@ class ElmUnusedImportInspectionTest : ElmInspectionsTestBase(ElmUnusedImportInsp
         bar = ()
     """.trimIndent())
 
+
+    fun `test unused functions in the exposing list are detected`() = checkByFileTree("""
+        --@ Main.elm
+        import Foo exposing (<warning descr="'f0' is exposed but unused">f0</warning>, f1)
+        main = f1
+        --^
+
+        --@ Foo.elm
+        module Foo exposing (..)
+        f0 = ()
+        f1 = ()
+    """.trimIndent())
+
+
+    // TODO we should support this eventually; punting for now
+    fun `test unused union types in the exposing list are ignored, for now`() = checkByFileTree("""
+        --@ Main.elm
+        import Foo exposing (Bar, Baz)
+        main : Baz -> ()
+        main _ = ()
+        --^
+
+        --@ Foo.elm
+        module Foo exposing (Bar, Baz)
+        type Bar = BarConstructor
+        type Baz = BazConstructor
+    """.trimIndent())
+
+
+    // TODO we should support this eventually; punting for now
+    fun `test unused type aliases in the exposing list are ignored, for now`() = checkByFileTree("""
+        --@ Main.elm
+        import Foo exposing (Bar, Baz)
+        main : Baz -> ()
+        main _ = ()
+        --^
+
+        --@ Foo.elm
+        module Foo exposing (Bar, Baz)
+        type alias Bar = ()
+        type alias Baz = ()
+    """.trimIndent())
+
+
+// TODO re-enable these 2 tests once we start detecting unused exposed functions/values
+//
+//    fun `test unused union types in the exposing list are detected`() = checkByFileTree("""
+//        --@ Main.elm
+//        import Foo exposing (<warning descr="Unused">Bar</warning>, Baz)
+//        main : Baz -> ()
+//        main _ = ()
+//        --^
+//
+//        --@ Foo.elm
+//        module Foo exposing (Bar, Baz)
+//        type Bar = BarConstructor
+//        type Baz = BazConstructor
+//    """.trimIndent())
+//
+//
+//    fun `test unused type aliases in the exposing list are detected`() = checkByFileTree("""
+//        --@ Main.elm
+//        import Foo exposing (<warning descr="Unused">Bar</warning>, Baz)
+//        main : Baz -> ()
+//        main _ = ()
+//        --^
+//
+//        --@ Foo.elm
+//        module Foo exposing (Bar, Baz)
+//        type alias Bar = ()
+//        type alias Baz = ()
+//    """.trimIndent())
+
+
+    // TODO [drop 0.18] revisit this. 0.18 allows individual union variants to be exposed, but Elm 0.19
+    //                  requires that they be exposed using `(..)`. Once support for 0.18 is dropped,
+    //                  implementing this will be simpler.
+    fun `test unused union variants in the exposing list are ignored, for now`() = checkByFileTree("""
+        --@ Main.elm
+        import Foo exposing (Bar(..), Baz(..))
+        main : Baz
+        main = BazConstructor
+        --^
+
+        --@ Foo.elm
+        module Foo exposing (Bar(..), Baz(..))
+        type Bar = BarConstructor
+        type Baz = BazConstructor
+    """.trimIndent())
+
+
+
 }


### PR DESCRIPTION
When a function is exposed by an import, but the bare/exposed name is never used, it will now be marked in gray as shown:
<img width="464" alt="screen shot 2019-01-05 at 7 52 15 am" src="https://user-images.githubusercontent.com/84525/50724632-d8e18600-10be-11e9-8bd6-26f46e1714d9.png">

I decided to only handle functions/values for now. There are some complications related to doing it for union types that will be simpler to deal with once we drop support for Elm 0.18.