### PR TITLE
Add 'optimize imports' quick fix

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -7,6 +7,7 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import org.elm.ide.inspections.fixes.OptimizeImportsFix
 import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.elements.ElmExposedValue
@@ -49,7 +50,8 @@ class ElmUnusedImportInspection : LocalInspectionTool() {
         holder.registerProblem(
                 importClause,
                 "Unused import",
-                ProblemHighlightType.LIKE_UNUSED_SYMBOL
+                ProblemHighlightType.LIKE_UNUSED_SYMBOL,
+                OptimizeImportsFix()
         )
     }
 

--- a/src/main/kotlin/org/elm/ide/inspections/fixes/OptimizeImportsFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/fixes/OptimizeImportsFix.kt
@@ -1,0 +1,42 @@
+package org.elm.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import org.elm.ide.inspections.ImportVisitor
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.psi.elements.removeItem
+import org.elm.lang.core.psi.parentOfType
+import org.elm.lang.core.psi.prevSiblings
+import org.elm.lang.core.resolve.scope.ModuleScope
+
+class OptimizeImportsFix : LocalQuickFix {
+
+    override fun getName() = "Optimize imports"
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val file = descriptor.psiElement?.containingFile as? ElmFile ?: return
+        val visitor = ImportVisitor(ModuleScope(file).getImportDecls())
+
+        file.accept(object : PsiRecursiveElementWalkingVisitor() {
+            override fun visitElement(element: PsiElement) {
+                element.accept(visitor)
+                super.visitElement(element)
+            }
+        })
+
+        for (unusedImport in visitor.unusedImports) {
+            val prevNewline = unusedImport.prevSiblings.firstOrNull { it.textContains('\n') }
+            if (prevNewline == null) unusedImport.delete()
+            else unusedImport.parent.deleteChildRange(prevNewline, unusedImport)
+        }
+
+        for (item in visitor.unusedExposedItems) {
+            item.parentOfType<ElmImportClause>()?.exposingList?.removeItem(item)
+        }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/inspections/ElmInspectionsTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmInspectionsTestBase.kt
@@ -71,6 +71,18 @@ abstract class ElmAnnotationTestBase : ElmTestBase() {
         checkAfter(after)
     }
 
+    protected fun checkFixByFileTree(
+            fixName: String,
+            @Language("Elm") treeText: String,
+            @Language("Elm") after: String,
+            checkWarn: Boolean = true,
+            checkInfo: Boolean = false,
+            checkWeakWarn: Boolean = false
+    ) = checkFix(fixName, treeText, after,
+            configure = this::configureByFileTree,
+            checkBefore = { myFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn) },
+            checkAfter = this::checkByText)
+
     private fun check(
             @Language("Elm") text: String,
             checkWarn: Boolean,


### PR DESCRIPTION
- removes imports that are unused
- removes things from the `exposing` list which are unused

You can run this on your entire project by running the "Unused imports" inspection and then clicking the button to apply it to all files:

<img width="978" alt="screen shot 2019-01-05 at 7 40 19 pm" src="https://user-images.githubusercontent.com/84525/50730725-e67c2780-1121-11e9-8b25-8cbad9a15568.png">

Caveats:
- this is not yet hooked into the version control commit hook so you will have to invoke it manually