### PR TITLE
Improved "New Elm File" action

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
@@ -22,14 +22,14 @@ class ElmCreateFileAction : CreateFileFromTemplateAction(CAPTION, "", ElmFileTyp
     override fun buildDialog(project: Project?, directory: PsiDirectory?, builder: CreateFileFromTemplateDialog.Builder) {
         // TODO add additional "kinds" here (e.g. an `elm-test` skeleton module)
         builder.setTitle(CAPTION)
-                .addKind("Module", ElmFileType.icon, "Elm Module")
+                .addKind("Module", ElmFileType.icon, ELM_MODULE_KIND)
     }
 
     override fun createFile(name: String?, templateName: String, dir: PsiDirectory): PsiFile? {
         if (name == null) return null
         val newFile = super.createFile(name, templateName, dir) ?: return null
 
-        if (templateName == "Elm Module") {
+        if (templateName == ELM_MODULE_KIND) {
             // HACK: I use an empty template to generate the file and then fill in the contents here
             // TODO ask around to find out what's the right way to do this
             newFile.viewProvider.document?.setText("module ${qualifyModuleName(dir, name)} exposing (..)")
@@ -52,8 +52,14 @@ class ElmCreateFileAction : CreateFileFromTemplateAction(CAPTION, "", ElmFileTyp
         return if (qualifier == "") name else "$qualifier.$name"
     }
 
+    /** A helper utility intended only to be called from test code */
+    fun testHelperCreateFile(name: String, dir: PsiDirectory): PsiFile? =
+            createFile(name, ELM_MODULE_KIND, dir)
+
+
     private companion object {
         private val CAPTION = "New Elm file"
+        private val ELM_MODULE_KIND = "Elm Module" // must match name of internal template stored in JAR resources
     }
 }
 

--- a/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
@@ -1,0 +1,64 @@
+package org.elm.ide.actions
+
+import com.intellij.ide.actions.CreateFileFromTemplateAction
+import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
+import org.elm.lang.core.ElmFileType
+import org.elm.openapiext.pathAsPath
+import org.elm.workspace.ElmProject
+import org.elm.workspace.elmWorkspace
+import java.nio.file.Path
+
+class ElmCreateFileAction : CreateFileFromTemplateAction(CAPTION, "", ElmFileType.icon) {
+
+    private val log = logger<ElmCreateFileAction>()
+
+    override fun getActionName(directory: PsiDirectory?, newName: String?, templateName: String?): String =
+            CAPTION
+
+    override fun buildDialog(project: Project?, directory: PsiDirectory?, builder: CreateFileFromTemplateDialog.Builder) {
+        // TODO add additional "kinds" here (e.g. an `elm-test` skeleton module)
+        builder.setTitle(CAPTION)
+                .addKind("Module", ElmFileType.icon, "Elm Module")
+    }
+
+    override fun createFile(name: String?, templateName: String, dir: PsiDirectory): PsiFile? {
+        if (name == null) return null
+        val newFile = super.createFile(name, templateName, dir) ?: return null
+
+        if (templateName == "Elm Module") {
+            // HACK: I use an empty template to generate the file and then fill in the contents here
+            // TODO ask around to find out what's the right way to do this
+            newFile.viewProvider.document?.setText("module ${qualifyModuleName(dir, name)} exposing (..)")
+        }
+
+        return newFile
+    }
+
+    private fun qualifyModuleName(dir: PsiDirectory, name: String): String {
+        log.debug("trying to determine fully-qualified module name prefix based on parent dir")
+        val elmProject = dir.project.elmWorkspace.findProjectForFile(dir.virtualFile)
+        if (elmProject == null) log.warn("failed to determine the Elm project that owns the dir")
+        var rootDirPath = elmProject?.rootDirContaining(dir)
+        if (rootDirPath == null) {
+            log.warn("failed to determine root dir within the Elm project that owns the dir")
+            rootDirPath = dir.virtualFile.pathAsPath
+        }
+        val qualifier = rootDirPath.relativize(dir.virtualFile.pathAsPath).joinToString(".")
+        log.debug("using qualifier: '$qualifier'")
+        return if (qualifier == "") name else "$qualifier.$name"
+    }
+
+    private companion object {
+        private val CAPTION = "New Elm file"
+    }
+}
+
+private fun ElmProject.rootDirContaining(dir: PsiDirectory): Path? {
+    val dirPath = dir.virtualFile.pathAsPath
+    return (absoluteSourceDirectories + listOf(testsDirPath))
+            .find { dirPath.startsWith(it) }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -91,6 +91,7 @@
         <colorSettingsPage implementation="org.elm.ide.color.ElmColorSettingsPage"/>
         <enterHandlerDelegate implementation="org.elm.ide.typing.ElmOnEnterSmartIndentHandler"/>
         <fileTypeFactory implementation="org.elm.lang.core.ElmFileTypeFactory"/>
+        <internalFileTemplate name="Elm Module"/>
         <gotoSymbolContributor implementation="org.elm.ide.navigation.ElmGoToSymbolContributor"/>
         <lang.braceMatcher language="Elm" implementationClass="org.elm.ide.ElmPairedBraceMatcher"/>
         <lang.commenter language="Elm" implementationClass="org.elm.ide.commenter.ElmCommenter"/>
@@ -188,6 +189,13 @@
     </project-components>
 
     <actions>
+        <action id="Elm.NewElmFile"
+                class="org.elm.ide.actions.ElmCreateFileAction"
+                text="Elm File"
+                description="Create new Elm file">
+            <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+        </action>
+
         <!-- TODO [drop 0.18] change "Attach Elm JSON..." to "Attach elm.json ..."-->
         <action id="Elm.AttachElmProject"
                 class="org.elm.workspace.ElmAttachProjectAction"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -189,7 +189,7 @@
     </project-components>
 
     <actions>
-        <action id="Elm.NewElmFile"
+        <action id="Elm.NewFile"
                 class="org.elm.ide.actions.ElmCreateFileAction"
                 text="Elm File"
                 description="Create new Elm file">

--- a/src/main/resources/fileTemplates/Elm Module.elm.ft
+++ b/src/main/resources/fileTemplates/Elm Module.elm.ft
@@ -1,1 +1,0 @@
-module ${NAME} exposing (..)

--- a/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
@@ -1,0 +1,71 @@
+package org.elm.ide.actions
+
+import org.elm.TestProject
+import org.elm.openapiext.runWriteCommandAction
+import org.elm.workspace.ElmWorkspaceTestBase
+
+
+class ElmCreateFileActionTest : ElmWorkspaceTestBase() {
+
+    fun `test file creation in a root src-dir`() =
+            doTest("src", "Quux", "module Quux exposing (..)")
+
+    fun `test file creation within a sub-dir`() =
+            doTest("src/Foo", "Quux", "module Foo.Quux exposing (..)")
+
+    fun `test file creation within a deeper source root`() =
+            doTest("vendor/elm-foo", "Bar", "module Bar exposing (..)")
+
+    fun `test file creation within a deeper source root and within a sub-dir`() =
+            doTest("vendor/elm-foo/Internals", "Baz", "module Internals.Baz exposing (..)")
+
+    fun `test file creation in root of 'tests' directory`() =
+            doTest("tests", "Quux", "module Quux exposing (..)")
+
+    fun `test file creation in sub-dir of 'tests' directory`() =
+            doTest("tests/Legacy", "Quux", "module Legacy.Quux exposing (..)")
+
+    fun `test file creation outside of a source root uses an empty module qualifier`() =
+            doTest("outside", "Quux", "module Quux exposing (..)")
+
+
+    private fun doTest(dirPath: String, newFileName: String, expectedContents: String) {
+        val testProject = makeTestProjectFixture()
+        val action = ElmCreateFileAction()
+        val dirVirtualFile = testProject.root.findFileByRelativePath(dirPath)!!
+        myFixture.project.runWriteCommandAction {
+            action.testHelperCreateFile(newFileName, myFixture.psiManager.findDirectory(dirVirtualFile)!!)
+        }
+        myFixture.checkResult("$dirPath/$newFileName.elm", expectedContents, true)
+    }
+
+
+    private fun makeTestProjectFixture(): TestProject =
+            buildProject {
+                project("elm.json", """
+                {
+                    "type": "application",
+                    "source-directories": [
+                        "src",
+                        "vendor/elm-foo"
+                    ],
+                    "elm-version": "0.19.0",
+                    "dependencies":      { "direct": {}, "indirect": {} },
+                    "test-dependencies": { "direct": {}, "indirect": {} }
+                }
+                """.trimIndent())
+                dir("src") {
+                    dir("Foo") {}
+                    dir("Bar") {}
+                }
+                dir("vendor") {
+                    dir("elm-foo") {
+                        dir("Internals") {}
+                    }
+                }
+                dir("tests") {
+                    dir("Legacy") {}
+                }
+                dir("outside") {}
+            }
+}

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -1,6 +1,5 @@
 package org.elm.workspace
 
-import org.elm.FileTreeBuilder
 import org.elm.TestClientLocation
 import org.elm.fileTree
 import org.elm.lang.core.psi.elements.ElmImportClause
@@ -423,6 +422,4 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 //    }
 
 
-    fun buildProject(builder: FileTreeBuilder.() -> Unit) =
-            fileTree(builder).asyncCreateWithAutoDiscover().get()
 }

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -11,7 +11,9 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
 import org.elm.FileTree
+import org.elm.FileTreeBuilder
 import org.elm.TestProject
+import org.elm.fileTree
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -76,4 +78,7 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
         // IntelliJ will handle this output specially by showing a diff.
         throw AssertionError("\nExpected: $expected\n     but: was $actual")
     }
+
+    fun buildProject(builder: FileTreeBuilder.() -> Unit): TestProject =
+            fileTree(builder).asyncCreateWithAutoDiscover().get()
 }

--- a/src/test/resources/org/elm/ide/folding/fixtures/module.elm
+++ b/src/test/resources/org/elm/ide/folding/fixtures/module.elm
@@ -1,11 +1,11 @@
-module Mod<fold text='...'> exposing
-  ( foo
+module Mod exposing
+  (<fold text='...'> foo
   , bar
-  )
+  </fold>)
 
 -- some comments
 
 import <fold text='...'>Basics exposing (..)
 import Maybe
 import Maybe exposing ( Maybe(Just,Nothing) )
-import Native.List</fold></fold>
+import Native.List</fold>


### PR DESCRIPTION
Fixes #150 

Changes:
- generated module name now takes into account Elm project `source-directories` (and `tests` directory) structure
- lays the groundwork for generating other Elm file templates (e.g. a file containing tests)
- changed default folding behavior so that the module's exposing list is no longer folded by default