### PR TITLE
Move variant info out of TyUnion

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmTypeDeclarationInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmTypeDeclarationInspection.kt
@@ -6,11 +6,12 @@ import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 import org.elm.lang.core.psi.elements.ElmTypeAnnotation
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.types.typeExpressionInference
+import org.elm.lang.core.types.variantInference
 
 class ElmTypeDeclarationInspection : ElmDiagnosticBasedInspection() {
     override fun getElementDiagnostics(element: ElmPsiElement): Iterable<ElmDiagnostic> {
         return when (element) {
-            is ElmTypeDeclaration -> element.typeExpressionInference().diagnostics
+            is ElmTypeDeclaration -> element.typeExpressionInference().diagnostics + element.variantInference().diagnostics
             is ElmTypeAliasDeclaration -> element.typeExpressionInference().diagnostics
             is ElmTypeAnnotation -> element.typeExpressionInference()?.diagnostics ?: emptyList()
             else -> emptyList()

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -1,14 +1,15 @@
 package org.elm.ide.inspections
 
+import com.intellij.psi.search.GlobalSearchScope
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmPsiFactory
 import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.ElmAnythingPattern
 import org.elm.lang.core.psi.elements.ElmCaseOfExpr
+import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.psi.elements.ElmUnionPattern
-import org.elm.lang.core.types.TyUnion
-import org.elm.lang.core.types.findInference
-import org.elm.lang.core.types.renderParam
+import org.elm.lang.core.stubs.index.ElmNamedElementIndex
+import org.elm.lang.core.types.*
 
 /**
  * This class can detect missing branches for case expressions and insert them into the PSI in place.
@@ -16,18 +17,18 @@ import org.elm.lang.core.types.renderParam
 class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
     // This should be a lazy {}, but using it causes a compilation error due to conflicting
     // declarations.
-    val missingBranches: List<TyUnion.Variant>
+    val missingBranches: VariantParameters
         get() {
             if (_missingBranches == null) _missingBranches = calcMissingBranches()
             return _missingBranches!!
         }
-    private var _missingBranches: List<TyUnion.Variant>? = null
+    private var _missingBranches: VariantParameters? = null
 
     fun addMissingBranches() {
         if (missingBranches.isEmpty()) return
 
-        val patterns = missingBranches.map { b ->
-            (listOf(b.name) + b.parameters.map { it.renderParam() }).joinToString(" ")
+        val patterns = missingBranches.map { (name, params) ->
+            (listOf(name) + params.map { it.renderParam() }).joinToString(" ")
         }
 
         addPatterns(patterns)
@@ -60,27 +61,32 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
         element.addRange(trailingWs.first(), trailingWs.last())
     }
 
-    private fun calcMissingBranches(): List<TyUnion.Variant> {
-        val inference = element.findInference() ?: return emptyList()
+    private fun calcMissingBranches(): VariantParameters {
+        val inference = element.findInference() ?: return emptyMap()
 
         // This only works on case expressions with a union type for now
         val exprTy = element.expression?.let { inference.elementType(it) } as? TyUnion
-                ?: return emptyList()
+                ?: return emptyMap()
 
-        val allBranches = exprTy.variants.associateBy { it.name }
+        val project = element.project
+        val declaration = ElmNamedElementIndex.find(exprTy.name, project, GlobalSearchScope.allScope(project))
+                .filterIsInstance<ElmTypeDeclaration>()
+                .find { it.moduleName == exprTy.module }
+                ?: return emptyMap()
+        val allBranches = declaration.variantInference().value
         val missingBranches = allBranches.toMutableMap()
 
         for (branch in element.branches) {
             val pat = branch.pattern.child
             when (pat) {
-                is ElmAnythingPattern -> return emptyList() // covers all cases
+                is ElmAnythingPattern -> return emptyMap() // covers all cases
                 is ElmUnionPattern -> {
                     missingBranches.remove(pat.referenceName)
                 }
-                else -> return emptyList() // invalid pattern
+                else -> return emptyMap() // invalid pattern
             }
         }
 
-        return missingBranches.values.toList()
+        return missingBranches
     }
 }

--- a/src/main/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionAction.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmMakeDeclarationIntentionAction.kt
@@ -63,7 +63,7 @@ class ElmMakeDeclarationIntentionAction : ElmAtCaretIntentionActionBase<ElmMakeD
         val name = typeAnnotation.referenceName
         template.addTextSegment("$name ")
 
-        val ty = typeAnnotation.typeExpressionInference()?.ty
+        val ty = typeAnnotation.typeExpressionInference()?.value
         val args: List<String> = when (ty) {
             is TyFunction -> ty.parameters.map { it.renderParam() }
             else -> emptyList()

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -60,11 +60,8 @@ data class TyUnion(
         val module: String,
         val name: String,
         val parameters: List<Ty>,
-        val variants: List<Variant>,
         override val alias: AliasInfo? = null
 ) : Ty() {
-    data class Variant(val name: String, val parameters: List<Ty>)
-
     override fun withAlias(alias: AliasInfo): TyUnion = copy(alias = alias)
 
     override fun toString(): String {
@@ -72,19 +69,19 @@ data class TyUnion(
     }
 }
 
-val TyInt = TyUnion("Basics", "Int", emptyList(), listOf(TyUnion.Variant("Int", emptyList())))
-val TyFloat = TyUnion("Basics", "Float", emptyList(), listOf(TyUnion.Variant("Float", emptyList())))
-val TyBool = TyUnion("Basics", "Bool", emptyList(), listOf(TyUnion.Variant("Bool", emptyList())))
-val TyString = TyUnion("String", "String", emptyList(), listOf(TyUnion.Variant("String", emptyList())))
-val TyChar = TyUnion("Char", "Char", emptyList(), listOf(TyUnion.Variant("Char", emptyList())))
+val TyInt = TyUnion("Basics", "Int", emptyList())
+val TyFloat = TyUnion("Basics", "Float", emptyList())
+val TyBool = TyUnion("Basics", "Bool", emptyList())
+val TyString = TyUnion("String", "String", emptyList())
+val TyChar = TyUnion("Char", "Char", emptyList())
 
 /** WebGL GLSL shader */
 // The actual type is `Shader attributes uniforms varyings`, but we would have to parse the
 // GLSL code to infer the type variables, so we just don't report diagnostics on shader types.
-val TyShader = TyUnion("WebGL", "Shader", listOf(TyUnknown(), TyUnknown(), TyUnknown()), emptyList())
+val TyShader = TyUnion("WebGL", "Shader", listOf(TyUnknown(), TyUnknown(), TyUnknown()))
 
 @Suppress("FunctionName")
-fun TyList(elementTy: Ty) = TyUnion("List", "List", listOf(elementTy), listOf(TyUnion.Variant("List", listOf(elementTy))))
+fun TyList(elementTy: Ty) = TyUnion("List", "List", listOf(elementTy))
 
 val TyUnion.isTyList: Boolean get() = module == "List" && name == "List"
 
@@ -132,16 +129,6 @@ object TyInProgressBinding : Ty() {
     override val alias: AliasInfo? get() = null
     override fun withAlias(alias: AliasInfo): TyInProgressBinding = this
     override fun toString(): String = javaClass.simpleName
-}
-
-/**
- * A Ty created from a type ref in a union variant parameter list that references the
- * union itself or an alias that references this union (creating a recursive type).
- */
-class TyVariantRecursiveReference(val module: String, val name: String) : Ty() {
-    override val alias: AliasInfo? get() = null
-    override fun withAlias(alias: AliasInfo): TyVariantRecursiveReference = this
-    override fun toString(): String = "<TyVariantRecursiveReference $name>"
 }
 
 /** Information about a type alias. This is not a [Ty]. */

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -11,7 +11,6 @@ fun Ty.renderedText(linkify: Boolean, withModule: Boolean): String {
         is TyVar -> name
         is TyUnit -> "()"
         is TyUnknown, TyInProgressBinding -> "unknown"
-        is TyVariantRecursiveReference -> renderedText(linkify, withModule)
         TyShader -> "shader"
     }
 }
@@ -37,11 +36,6 @@ fun TyUnion.renderedText(linkify: Boolean, withModule: Boolean): String {
     return if (withModule && module.isNotBlank()) "$module.$type" else type
 }
 
-fun TyVariantRecursiveReference.renderedText(linkify: Boolean, withModule: Boolean): String {
-    val name = buildString { renderLink(module, name, linkify) }
-    return if (withModule && module.isNotBlank()) "$module.$name" else name
-}
-
 fun TyRecord.renderedText(linkify: Boolean, withModule: Boolean): String {
     val prefix = if (baseTy != null) "{ ${baseTy.renderedText(linkify, withModule)} | " else "{ "
     return fields.entries.joinToString(", ", prefix = prefix, postfix = " }") { (name, ty) ->
@@ -54,7 +48,7 @@ fun TyTuple.renderedText(linkify: Boolean, withModule: Boolean): String {
 }
 
 fun AliasInfo.renderedText(linkify: Boolean, withModule: Boolean): String {
-    return TyUnion(module, name, parameters, emptyList()).renderedText(linkify, withModule)
+    return TyUnion(module, name, parameters).renderedText(linkify, withModule)
 }
 
 private fun StringBuilder.renderLink(refText: String, text: String, linkify: Boolean) {
@@ -71,7 +65,6 @@ fun Ty.renderParam(): String {
         is TyTuple -> renderParam()
         is TyVar -> name
         is TyUnit -> "()"
-        is TyVariantRecursiveReference -> name.toFirstCharLowerCased()
         is TyUnknown, TyInProgressBinding -> "unknown"
         TyShader -> "shader"
     }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -59,7 +59,6 @@ class TypeReplacement private constructor(
         is TyUnknown -> TyUnknown(replace(ty.alias))
         is TyUnion -> replaceUnion(ty)
         is TyRecord -> replaceRecord(ty)
-        is TyVariantRecursiveReference -> ty
         is TyUnit, TyInProgressBinding -> ty
     }
 
@@ -78,8 +77,7 @@ class TypeReplacement private constructor(
 
     private fun replaceUnion(ty: TyUnion): TyUnion {
         val parameters = ty.parameters.map { replace(it) }
-        val variants = ty.variants.map { m -> m.copy(parameters = m.parameters.map { replace(it) }) }
-        return TyUnion(ty.module, ty.name, parameters, variants, replace(ty.alias))
+        return TyUnion(ty.module, ty.name, parameters, replace(ty.alias))
     }
 
     private fun replaceRecord(ty: TyRecord): Ty {

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -224,7 +224,7 @@ type Foo
 <div class='content'><p>included <em>docs</em></p></div>
 <table class='sections'><tr><td valign='top' class='section'><p>Variants:</td><td><p>
 <p><code>Bar</code>
-<p><code>Baz</code> <a href="psi_element://">Foo</a>
+<p><code>Baz</code> <a href="psi_element://Foo">Foo</a>
 <p><code>Qux</code> (<a href="psi_element://List">List</a> a) a
 <p><code>Lorem</code> { ipsum : <a href="psi_element://Int">Int</a> }</td></table>
 """)

--- a/src/test/kotlin/org/elm/ide/inspections/TypeDeclarationInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeDeclarationInspectionTest.kt
@@ -20,6 +20,13 @@ type alias Alias = { value : Union }
 type Union = TUnion Alias
 """)
 
+    // https://github.com/klazuka/intellij-elm/issues/188
+    fun `test allowed recursion through two aliases`() = checkByText("""
+type Foo = Foo Alias1
+type alias Alias1 = Alias2
+type alias Alias2 = { foo : Foo }
+""")
+
     fun `test too few arguments to type`() = checkByText("""
 type Foo a b = Bar
 main : <error descr="The type expects 2 arguments, but it got 1 instead.">Foo ()</error>
@@ -36,6 +43,11 @@ main = Bar
 type Foo a b = Bar
 main : <error descr="The type expects 2 arguments, but it got 3 instead.">Foo () () ()</error>
 main = Bar
+""")
+
+    fun `test too many arguments to type in union variant`() = checkByText("""
+type Foo a b = Bar
+type Baz = Qux (<error descr="The type expects 2 arguments, but it got 3 instead.">Foo () () ()</error>)
 """)
 
     fun `test no arguments to type`() = checkByText("""

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1041,4 +1041,15 @@ type Bar = BarVariant Bar (Foo Bar)
 main : Foo ()
 main = <error descr="Type mismatch.Required: Foo ()Found: Bar → Foo Bar → Bar">BarVariant</error>
 """)
+
+    // https://github.com/klazuka/intellij-elm/issues/201
+    fun `test returning bound recursive union variant`() = checkByText("""
+type Tree a = Tree a (List (Tree a))
+
+directChildren : Tree a -> ()
+directChildren tree =
+    <error descr="Type mismatch.Required: ()Found: List (Tree a)">case tree of
+        Tree _ children ->
+            children</error>
+""")
 }


### PR DESCRIPTION
The union variant information added to `TyUnion` in #163 caused a lot of issues stemming from the fact that the data structure is now potentially recursive, both self recursive and mutually recursive through other unions and aliases. 

This PR moves the variant inference information out of `TyUnion` and caches it separately on the `ElmTypeDeclaration` element. Code that needs the variant information, but only has a `TyUnion`, can retrieve the PSI element with the `ElmNamedElementIndex`.

Fixes #203
Fixes #201
Fixes #188
Fixes #187
Fixes #181