### PR TITLE
Support more expression types in Smart Enter Processor

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmTypeInferenceInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmTypeInferenceInspection.kt
@@ -3,6 +3,7 @@ package org.elm.ide.inspections
 import org.elm.lang.core.diagnostics.ElmDiagnostic
 import org.elm.lang.core.psi.ElmPsiElement
 import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.psi.isTopLevel
 import org.elm.lang.core.types.findInference
 
 class ElmTypeInferenceInspection : ElmDiagnosticBasedInspection() {

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -1,6 +1,6 @@
 package org.elm.ide.inspections
 
-import org.elm.ide.presentation.guessIndent
+import org.elm.ide.typing.guessIndent
 import org.elm.lang.core.psi.ElmPsiFactory
 import org.elm.lang.core.psi.elements.ElmAnythingPattern
 import org.elm.lang.core.psi.elements.ElmCaseOfExpr

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -1,8 +1,7 @@
 package org.elm.ide.inspections
 
-import org.elm.lang.core.psi.ElmFile
+import org.elm.ide.presentation.guessIndent
 import org.elm.lang.core.psi.ElmPsiFactory
-import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.ElmAnythingPattern
 import org.elm.lang.core.psi.elements.ElmCaseOfExpr
 import org.elm.lang.core.psi.elements.ElmUnionPattern
@@ -41,7 +40,7 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
     private fun addPatterns(patterns: List<String>) {
         val factory = ElmPsiFactory(element.project)
         val existingBranches = element.branches
-        val indent = "    ".repeat(element.ancestors.takeWhile { it !is ElmFile }.count())
+        val indent = guessIndent(element) + "    "
         val elements = factory.createCaseOfBranches(indent, patterns)
         // Add the two or first generated branch, which are the indent
         // and newline

--- a/src/main/kotlin/org/elm/ide/presentation/PresentationUtils.kt
+++ b/src/main/kotlin/org/elm/ide/presentation/PresentationUtils.kt
@@ -3,8 +3,10 @@ package org.elm.ide.presentation
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmPsiElement
+import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.ElmValueDeclaration
 
 
@@ -34,3 +36,7 @@ private fun presentableName(element: PsiElement): String? =
             else ->
                 null
         }
+
+/** Return the string that should indent an element based on the number of ancestors it has */
+fun guessIndent(element: PsiElement, offset: Int = -1): String =
+        "    ".repeat(element.ancestors.takeWhile { it !is ElmFile }.count() + offset)

--- a/src/main/kotlin/org/elm/ide/presentation/PresentationUtils.kt
+++ b/src/main/kotlin/org/elm/ide/presentation/PresentationUtils.kt
@@ -3,10 +3,8 @@ package org.elm.ide.presentation
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
-import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmPsiElement
-import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.ElmValueDeclaration
 
 
@@ -37,6 +35,3 @@ private fun presentableName(element: PsiElement): String? =
                 null
         }
 
-/** Return the string that should indent an element based on the number of ancestors it has */
-fun guessIndent(element: PsiElement, offset: Int = -1): String =
-        "    ".repeat(element.ancestors.takeWhile { it !is ElmFile }.count() + offset)

--- a/src/main/kotlin/org/elm/ide/typing/ElementUtils.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElementUtils.kt
@@ -1,0 +1,9 @@
+package org.elm.ide.typing
+
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ancestors
+
+/** Return the string that should indent an element based on the number of ancestors it has */
+fun guessIndent(element: PsiElement, offset: Int = -1): String =
+        "    ".repeat(element.ancestors.takeWhile { it !is ElmFile }.count() + offset)

--- a/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
@@ -3,46 +3,178 @@ package org.elm.ide.typing
 import com.intellij.lang.SmartEnterProcessorWithFixers
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
-import com.intellij.psi.util.parentOfType
 import org.elm.ide.inspections.MissingCaseBranchAdder
-import org.elm.lang.core.psi.elements.ElmCaseOfBranch
-import org.elm.lang.core.psi.elements.ElmCaseOfExpr
+import org.elm.ide.presentation.guessIndent
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ElmTypes.*
+import org.elm.lang.core.psi.elements.*
 
 class ElmSmartEnterProcessor : SmartEnterProcessorWithFixers() {
     init {
-        addFixers(CaseBranchFixer())
-        addEnterProcessors(PlainEnterProcessor())
+        addFixers(
+                CaseBranchFixer(),
+                CaseExpressionFixer(),
+                LetInFixer(),
+                IfElseFixer(),
+                FunctionBodyFixer()
+        )
+        addEnterProcessors(ElmEnterProcessor())
     }
 
+    // All of the fixers will be called with the returned element. Then this function will be called
+    // again, and the return value passed to the enter processor. This means that the function needs
+    // to return the same element both times. If any fixer modified the document, then process
+    // repeats. Fixers need to make sure they're idempotent, or they can create an infinite loop. If
+    // that happens, the processor will stop calling this function and discard any changes already
+    // made.
     override fun getStatementAtCaret(editor: Editor?, psiFile: PsiFile?): PsiElement? {
         val statement = super.getStatementAtCaret(editor, psiFile)
         if (statement == null || statement is PsiWhiteSpace) return null
-        if (statement.parentOfType<ElmCaseOfBranch>() != null) return null
-        return statement.parentOfType<ElmCaseOfExpr>()
+
+        // Identifiers don't parse as value declarations unless an `=` is present so we need to
+        // check for that case separately.
+        if (elementIsValueDeclWithoutEquals(statement)) {
+            return statement
+        }
+
+        return statement.ancestors
+                .takeWhile { it !is ElmFile }
+                .find {
+                    it is ElmCaseOfBranch
+                            || it is ElmCaseOfExpr
+                            || it is ElmLetInExpr
+                            || it is ElmIfElseExpr
+                            || it is ElmValueDeclaration
+                }
     }
 }
 
-private class PlainEnterProcessor : SmartEnterProcessorWithFixers.FixEnterProcessor() {
+private class ElmEnterProcessor : SmartEnterProcessorWithFixers.FixEnterProcessor() {
     override fun doEnter(atCaret: PsiElement, file: PsiFile, editor: Editor, modified: Boolean): Boolean {
         if (modified && atCaret is ElmCaseOfExpr && atCaret.branches.isNotEmpty()) {
-            val caretModel = editor.caretModel
             val branch = atCaret.branches.first()
-            val branchOffset = branch.textOffset
-            val indentLen = branch.prevSibling.textLength
-            val extraIndent = 5 // \n + 4 spaces
-            caretModel.moveToOffset(branchOffset + branch.textLength + indentLen + extraIndent)
+            indentAfterElement(editor, branch, branch)
+        } else if (modified && atCaret is ElmLetInExpr) {
+            val inKeyword = atCaret.inKeyword ?: return true
+            val indentedElement = (inKeyword.parent as? PsiErrorElement ?: inKeyword)
+            val anchor = if (atCaret.valueDeclarationList.isEmpty()) atCaret.letKeyword else inKeyword
+            indentAfterElement(editor, anchor, indentedElement)
+        } else if (modified && atCaret is ElmCaseOfBranch && atCaret.arrow != null) {
+            indentAfterElement(editor, atCaret.arrow!!, atCaret)
+        } else if (modified && atCaret is ElmIfElseExpr && atCaret.thenKeywords.isNotEmpty() && atCaret.elseKeywords.isNotEmpty()) {
+            val anchor = if (atCaret.expressionList.size > atCaret.thenKeywords.size) {
+                atCaret.elseKeywords.last()
+            } else {
+                atCaret.thenKeywords.last()
+            }
+            indentAfterElement(editor, anchor, atCaret.elseKeywords.last())
+        } else if (modified && atCaret is ElmValueDeclaration && atCaret.eqElement != null) {
+            indentAfterElement(editor, atCaret.eqElement!!, atCaret)
         } else {
             plainEnter(editor)
         }
         return true
     }
+
+    private fun indentAfterElement(editor: Editor, anchor: PsiElement, indentedElement: PsiElement) {
+        val extraIndent = 5 // \n + 4 spaces
+        val indentLen = if (indentedElement.isTopLevel) 0 else indentedElement.prevSibling.textLength
+        moveAfterElement(editor, anchor, indentLen + extraIndent)
+    }
+
+    private fun moveAfterElement(editor: Editor, anchor: PsiElement, offset: Int) {
+        editor.caretModel.moveToOffset(anchor.textRange.endOffset + offset)
+    }
 }
 
-private class CaseBranchFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
+private class CaseExpressionFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
     override fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement) {
         if (element !is ElmCaseOfExpr || element.branches.isNotEmpty()) return
         MissingCaseBranchAdder(element).addMissingBranches()
     }
+}
+
+private class LetInFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
+    override fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement) {
+        if (element !is ElmLetInExpr || element.inKeyword != null) return
+        val indent = guessIndent(element)
+        val lastDecl = element.valueDeclarationList.lastOrNull()
+        val anchor = lastDecl ?: element.letKeyword
+        val endOffset = anchor.textRange.endOffset
+        val emptyLine = if (lastDecl == null) "\n$indent    " else ""
+
+        editor.document.insertString(endOffset,
+                "$emptyLine\n${indent}in\n$indent    ")
+    }
+}
+
+private class CaseBranchFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
+    override fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement) {
+        if (element !is ElmCaseOfBranch || element.arrow != null) return
+        val indent = guessIndent(element)
+        val endOffset = element.pattern.textRange.endOffset
+        editor.document.insertString(endOffset, " ->\n$indent    ")
+    }
+}
+
+private class IfElseFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
+    override fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement) {
+        if (element !is ElmIfElseExpr) return
+        val thenKeywords = element.thenKeywords
+        val elseKeywords = element.elseKeywords
+        if (elseKeywords.size > thenKeywords.size ||
+                elseKeywords.isNotEmpty() && elseKeywords.size == thenKeywords.size) return
+        val expressionList = element.expressionList
+        val expression = expressionList.lastOrNull() ?: return
+
+        // chained `if` expressions aren't parsed as a group if they're missing anything before the final else
+        val elementPrev = element.prevSiblings.withoutWs.firstOrNull()
+        val indentOffset = when {
+            elementPrev?.elementType == ElmTypes.ELSE -> -2
+            else -> -1
+        }
+
+        val indent = guessIndent(element, indentOffset)
+
+        val exprPrev = expression.prevSiblings.withoutWs.first()
+        val exprNext = expression.nextSiblings.withoutWs.firstOrNull()
+
+        val (thenString, endExpr) = when {
+            // `then` keyword present, cursor on predicate or `then`
+            (exprPrev.elementType == ElmTypes.THEN && expressionList.size % 2 == 1)
+                    || exprNext?.elementType == ElmTypes.THEN -> {
+                "\n$indent    " to exprNext!!
+            }
+            // `then` keyword not present
+            exprPrev.elementType == ElmTypes.IF -> {
+                " then\n$indent    " to expression
+            }
+            // cursor on body
+            else -> "" to expression
+        }
+
+        val s = thenString + "\n${indent}else\n$indent    "
+        val endOffset = endExpr.textRange.endOffset
+
+        editor.document.insertString(endOffset, s)
+    }
+}
+
+private class FunctionBodyFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
+    override fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement) {
+        if (!elementIsValueDeclWithoutEquals(element)) {
+            return
+        }
+        val indent = guessIndent(element)
+        editor.document.insertString(element.textRange.endOffset, " =\n$indent    ")
+    }
+}
+
+
+private fun elementIsValueDeclWithoutEquals(element: PsiElement): Boolean {
+    return element.elementType in listOf(LOWER_CASE_IDENTIFIER, RIGHT_BRACE, RIGHT_PARENTHESIS) &&
+            (element.isTopLevel || element.parent is ElmLetInExpr)
 }

--- a/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
@@ -7,7 +7,6 @@ import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import org.elm.ide.inspections.MissingCaseBranchAdder
-import org.elm.ide.presentation.guessIndent
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.*
 import org.elm.lang.core.psi.elements.*

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -93,3 +93,7 @@ fun PsiElement.offsetIn(owner: PsiElement): Int =
  */
 fun PsiElement.isVirtualLayoutToken(): Boolean =
         elementType in ELM_VIRTUAL_TOKENS
+
+/** Return true if this element is a direct child of an [ElmFile] */
+val PsiElement.isTopLevel: Boolean
+    get() = parent is ElmFile

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmCaseOfBranch.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmCaseOfBranch.kt
@@ -1,10 +1,12 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmExpressionTag
 import org.elm.lang.core.psi.ElmNameDeclarationPatternTag
 import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.ElmTypes
 
 
 /**
@@ -32,4 +34,7 @@ class ElmCaseOfBranch(node: ASTNode) : ElmPsiElementImpl(node) {
      */
     val destructuredNames: List<ElmNameDeclarationPatternTag>
         get() = PsiTreeUtil.collectElementsOfType(pattern, ElmNameDeclarationPatternTag::class.java).toList()
+
+    /** The `->` element. In a well formed program, this will not return null */
+    val arrow: PsiElement? get() = findChildByType(ElmTypes.ARROW)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmIfElseExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmIfElseExpr.kt
@@ -1,10 +1,12 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmAtomTag
 import org.elm.lang.core.psi.ElmExpressionTag
 import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.ElmTypes
 
 /**
  * An if-else expression, possible with one or more else-if branches.
@@ -21,4 +23,10 @@ class ElmIfElseExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmAtomTag {
     val expressionList: List<ElmExpressionTag>
         get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmExpressionTag::class.java)
 
+    /** The `if` keywords. This will never be empty. */
+    val ifKeywords : List<PsiElement> get() = findChildrenByType(ElmTypes.IF)
+    /** The `then` keywords. In a well formed program, this will be the same size as [ifKeywords] */
+    val thenKeywords : List<PsiElement> get() = findChildrenByType(ElmTypes.THEN)
+    /** The `else` keywords. In a well formed program, this will be the same size as [ifKeywords] */
+    val elseKeywords : List<PsiElement> get() = findChildrenByType(ElmTypes.ELSE)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmLetInExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmLetInExpr.kt
@@ -1,10 +1,10 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.util.PsiTreeUtil
-import org.elm.lang.core.psi.ElmAtomTag
-import org.elm.lang.core.psi.ElmExpressionTag
-import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.*
 
 
 /**
@@ -35,4 +35,13 @@ class ElmLetInExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmAtomTag {
      */
     val expression: ElmExpressionTag?
         get() = findChildByClass(ElmExpressionTag::class.java)
+
+    /** The `let` element. In a well formed program, this will not return null */
+    val letKeyword: PsiElement get() = findNotNullChildByType(ElmTypes.LET)
+
+    /** The `in` element. In a well formed program, this will not return null */
+    val inKeyword: PsiElement?
+        get() = findChildByType(ElmTypes.IN) ?:
+        // If there's no valueDeclarationList, the in keyword is enclosed in an error element
+        (lastChild as? PsiErrorElement)?.firstChild?.takeIf { it.elementType == ElmTypes.IN }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -3,6 +3,7 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
@@ -112,7 +113,6 @@ class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub>, ElmDocTa
         get() = (prevSiblings.withoutWs.filter { it !is ElmTypeAnnotation }.firstOrNull() as? PsiComment)
                 ?.takeIf { it.text.startsWith("{-|") }
 
-    /** Return true if this declaration is not nested in a let-in expression */
-    val isTopLevel: Boolean
-        get() = parent is ElmFile
+    /** The `=` element. In a well-formed program, this will not be null */
+    val eqElement: PsiElement? get() = findChildByType(ElmTypes.EQ)
 }

--- a/src/test/kotlin/org/elm/ide/typing/ElmSmartEnterProcessorTest.kt
+++ b/src/test/kotlin/org/elm/ide/typing/ElmSmartEnterProcessorTest.kt
@@ -5,7 +5,7 @@ import org.elm.lang.ElmTestBase
 import org.intellij.lang.annotations.Language
 
 class ElmSmartEnterProcessorTest : ElmTestBase() {
-    fun `test fix missing case branches`() = doTest("""
+    fun `test case expression`() = doTest("""
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -21,15 +21,214 @@ foo it =
             {-caret-}
 
         Baz ->
-            
+            --EOL
 
         Qux ->
 
 """)
 
+    fun `test single case branch `() = doTest("""
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+    case it of
+        Bar{-caret-}
+""", """
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+    case it of
+        Bar ->
+            {-caret-}
+""")
+
+    fun `test let with no body`() = doTest("""
+foo =
+    let{-caret-}
+""", """
+foo =
+    let
+        {-caret-}
+    in
+        --EOL
+""")
+
+    fun `test nested let with no body and no parent in-keyword`() = doTest("""
+foo =
+    let
+        bar =
+            let{-caret-}
+""", """
+foo =
+    let
+        bar =
+            let
+                {-caret-}
+            in
+                --EOL
+""")
+
+    fun `test if with no then`() = doTest("""
+foo =
+    if True{-caret-}
+""", """
+foo =
+    if True then
+        {-caret-}
+    else
+        --EOL
+""")
+
+    fun `test if with no body`() = doTest("""
+foo =
+    if True then{-caret-}
+""", """
+foo =
+    if True then
+        {-caret-}
+    else
+        --EOL
+""")
+
+    fun `test if with no body, caret before then`() = doTest("""
+foo =
+    if True{-caret-} then
+""", """
+foo =
+    if True then
+        {-caret-}
+    else
+        --EOL
+""")
+
+    fun `test if with no else`() = doTest("""
+foo =
+    if True then
+        1{-caret-}
+""", """
+foo =
+    if True then
+        1
+    else
+        {-caret-}
+""")
+
+    fun `test chained if with no then`() = doTest("""
+foo =
+    if True then
+        1
+    else if True{-caret-}
+""", """
+foo =
+    if True then
+        1
+    else if True then
+        {-caret-}
+    else
+        --EOL
+""")
+
+    fun `test chained if with no else`() = doTest("""
+foo =
+    if True then
+        1
+    else if True then
+        2{-caret-}
+""", """
+foo =
+    if True then
+        1
+    else if True then
+        2
+    else
+        {-caret-}
+""")
+
+    // Need module statement to prevent `foo` from being parsed inside an error element
+    fun `test function declaration with no params`() = doTest("""
+module Main exposing (..)
+foo{-caret-}
+""", """
+module Main exposing (..)
+foo =
+    {-caret-}
+""")
+
+    fun `test function declaration with params`() = doTest("""
+module Main exposing (..)
+foo a b{-caret-}
+""", """
+module Main exposing (..)
+foo a b =
+    {-caret-}
+""")
+
+    fun `test nested function declaration with no params`() = doTest("""
+foo =
+    let
+        bar{-caret-}
+    in
+        ()
+""", """
+foo =
+    let
+        bar =
+            {-caret-}
+    in
+        ()
+""")
+
+    fun `test nested function declaration with params`() = doTest("""
+foo =
+    let
+        bar a b{-caret-}
+    in
+        ()
+""", """
+foo =
+    let
+        bar a b =
+            {-caret-}
+    in
+        ()
+""")
+
+    fun `test nested tuple destructuring with no params`() = doTest("""
+foo =
+    let
+        (a, b){-caret-}
+    in
+        ()
+""", """
+foo =
+    let
+        (a, b) =
+            {-caret-}
+    in
+        ()
+""")
+
+    fun `test nested record destructuring with no params`() = doTest("""
+foo =
+    let
+        {a, b}{-caret-}
+    in
+        ()
+""", """
+foo =
+    let
+        {a, b} =
+            {-caret-}
+    in
+        ()
+""")
 
     private fun doTest(@Language("Elm") before: String, @Language("Elm") after: String) =
-            checkByText(before, after) {
+            // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
+            // significant for this test.
+            checkByText(before, after.replace("--EOL", "")) {
                 myFixture.performEditorAction(IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
             }
 }


### PR DESCRIPTION
Add support for

- Individual case branches
- if/then expressions
- let/in expressions
- value declarations (top level and inside let/in expressions)

The value declaration support is a bit hacky due to the way our grammar is structured. The `ValueDeclaration` rule pins on `=`, so a top-level identifier just parses as an error. We can't just pin on the id, since that breaks type annotations. We can change move `TypeAnnotation` to be higher priority than `ValueDeclaration`, but that still causes some partial programs to parse weirdly. Since there's no `VIRTUAL_OPEN_DECL` token, we don't know whether an id is on a line by itself, so sometimes a `ValueDeclaration` would start on the same line as other code.

There's probably a solution that involves moving the annotation and declaration into the same rule, but I'm not going to work on that for now.

Fixes #173