### PR TITLE
Fix false-positive type error with extension record parameters

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -153,7 +153,9 @@ class TypeExpression(
 
     /** Get the type for an entire type expression */
     private fun typeExpresionType(typeExpr: ElmTypeExpression): Ty {
-        val segments = typeExpr.allSegments.map { typeSignatureDeclType(it) }.toList()
+        val segments = typeExpr.allSegments.map {
+            typeSignatureDeclType(it)
+        }.toList()
         val last = segments.last()
         return when {
             segments.size == 1 -> last

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -13,6 +13,8 @@ import org.elm.lang.core.diagnostics.TypeArgumentCountError
  * compare unequal, even if they have the same name.
  */
 class TypeReplacement private constructor(
+        // A map of variables that should be replaced to a pair of the ty to replace them with and
+        // the psi element for the argument, which is used to show errors.
         private val replacements: Map<TyVar, Pair<PsiElement, Ty>>
 ) {
     companion object {
@@ -89,7 +91,13 @@ class TypeReplacement private constructor(
         }
 
         val declaredFields = ty.fields.mapValues { (_, it) -> replace(it) }
-        val newBaseTy = (baseTy as? TyRecord)?.baseTy
+
+        val newBaseTy = when(baseTy) {
+            // If the base ty of the argument is a record, use it's base ty, which might be null.
+            is TyRecord -> baseTy.baseTy
+            // If it's another variable, use it as-is
+            else -> baseTy
+        }
         return TyRecord(baseFields + declaredFields, newBaseTy, replace(ty.alias))
     }
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -532,6 +532,15 @@ main : Bar -> Int
 main {foo} = <error descr="Type mismatch.Required: IntFound: ()">foo</error>
 """)
 
+    fun `test extension record parameter`() = checkByText("""
+type alias Extension base = { base | field : () }
+
+foo : Extension base -> ()
+foo e = ()
+
+main = foo { field = (), field2 = () }
+""")
+
     fun `test let-in with mismatched type in annotated inner func`() = checkByText("""
 main : ()
 main =


### PR DESCRIPTION
I noticed this bug when using elm-css, which has a fairly complex type hierarchy. The `baseTy` of records wasn't being replaced correctly if the argument was a variable rather than a record.