### PR TITLE
Improve case branch completion

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
@@ -8,12 +8,18 @@ class ElmIncompletePatternInspection : ElmLocalInspection() {
     override fun visitElement(element: ElmPsiElement, holder: ProblemsHolder, isOnTheFly: Boolean) {
         if (element !is ElmCaseOfExpr) return
         val fixer = MissingCaseBranchAdder(element)
-        if (fixer.missingBranches.isEmpty()) return
+
+        if (fixer.result == MissingCaseBranchAdder.Result.NoMissing) return
+
+        val extraFixes = if (fixer.result is MissingCaseBranchAdder.Result.MissingVariants) {
+            arrayOf(quickFix("Add missing case branches") { _, _ -> fixer.addMissingBranches() })
+        } else emptyArray()
+
+        val fixes = extraFixes + arrayOf(quickFix("Add '_' branch") { _, _ -> fixer.addWildcardBranch() })
 
         holder.registerProblem(element.firstChild,
                 "Case expression is not exhaustive",
-                quickFix("Add missing case branches") { _, _ -> fixer.addMissingBranches() },
-                quickFix("Add '_' branch") { _, _ -> fixer.addWildcardBranch() }
+                *fixes
         )
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -14,19 +14,28 @@ import org.elm.lang.core.types.*
  * This class can detect missing branches for case expressions and insert them into the PSI in place.
  */
 class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
+    sealed class Result {
+        /** There are missing union variant branches */
+        data class MissingVariants(val variants: VariantParameters): Result()
+        /** There are missing branches, but we can't offer suggestions */
+        object NoSuggestions: Result()
+        /** There are no missing branches that we can detect */
+        object NoMissing: Result()
+    }
+
     // This should be a lazy {}, but using it causes a compilation error due to conflicting
     // declarations.
-    val missingBranches: VariantParameters
+    val result: Result
         get() {
-            if (_missingBranches == null) _missingBranches = calcMissingBranches()
-            return _missingBranches!!
+            if (_result == null) _result = calcMissingBranches()
+            return _result!!
         }
-    private var _missingBranches: VariantParameters? = null
+    private var _result: Result? = null
 
     fun addMissingBranches() {
-        if (missingBranches.isEmpty()) return
+        val result = this.result as? Result.MissingVariants ?: return
 
-        val patterns = missingBranches.map { (name, params) ->
+        val patterns = result.variants.map { (name, params) ->
             (listOf(name) + params.map { it.renderParam() }).joinToString(" ")
         }
 
@@ -34,7 +43,7 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
     }
 
     fun addWildcardBranch() {
-        if (missingBranches.isEmpty()) return
+        if (result is Result.NoMissing) return
         addPatterns(listOf("_"))
     }
 
@@ -60,16 +69,18 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
         element.addRange(trailingWs.first(), trailingWs.last())
     }
 
-    private fun calcMissingBranches(): VariantParameters {
-        val inference = element.findInference() ?: return emptyMap()
+    private fun calcMissingBranches(): Result {
+        val defaultResult = if (element.branches.isEmpty()) Result.NoSuggestions else Result.NoMissing
+
+        val inference = element.findInference() ?: return defaultResult
 
         // This only works on case expressions with a union type for now
         val exprTy = element.expression?.let { inference.elementType(it) } as? TyUnion
-                ?: return emptyMap()
+                ?: return defaultResult
 
         val project = element.project
         val declaration = ElmNamedElementIndex.findElement<ElmTypeDeclaration>(exprTy.name, exprTy.module, project)
-                ?: return emptyMap()
+                ?: return defaultResult
 
         val allBranches = declaration.variantInference().value
         val missingBranches = allBranches.toMutableMap()
@@ -77,16 +88,16 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
         for (branch in element.branches) {
             val pat = branch.pattern.child
             when (pat) {
-                is ElmAnythingPattern -> return emptyMap() // covers all cases
+                is ElmAnythingPattern -> return Result.NoMissing // covers all cases
                 is ElmUnionPattern -> {
                     missingBranches.remove(pat.referenceName)
                 }
-                else -> return emptyMap() // invalid pattern
+                else -> return Result.NoMissing // invalid pattern
             }
         }
 
         val qualifierPrefix = ModuleScope(element.elmFile).getQualifierForTypeName(exprTy.module, exprTy.name) ?: ""
 
-        return missingBranches.mapKeys { (k, _) -> qualifierPrefix + k }
+        return Result.MissingVariants(missingBranches.mapKeys { (k, _) -> qualifierPrefix + k })
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
@@ -9,8 +9,6 @@ import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
 import org.elm.lang.core.stubs.index.ElmModulesIndex
 
-private val log = logger<ElmImportClause>()
-
 /**
  * An import declaration at the top of the module.
  *

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -64,6 +64,36 @@ class ModuleScope(val elmFile: ElmFile) {
                 qualifierPrefix == it.asClause?.name ?: it.moduleQID.text
             }
 
+    /**
+     * Given a [name] in a [module], return the qualifier prefix necessary to reference the name in this scope.
+     *
+     * Note that this function does not ensure that [name] is actually declared in [module].
+     *
+     * e.g.
+     *
+     * ```
+     * import M exposing(N)
+     * import Q.U exposing(N)
+     * import A exposing(..)
+     * ```
+     *
+     * - `getQualifierForTypeName(M, N)` -> `""`
+     * - `getQualifierForTypeName(M, O)` -> `"M."`
+     * - `getQualifierForTypeName(Q.U, O)` -> `"Q.U."`
+     * - `getQualifierForTypeName(A, B)` -> `""`
+     * - `getQualifierForTypeName(X, Y)` -> `null`
+     */
+    fun getQualifierForTypeName(module: String, name: String): String? =
+            getImportDecls()
+                    .find { it.moduleQID.text == module }
+                    ?.let { importDecl ->
+                        when {
+                            getVisibleImportTypes(importDecl).any { it.name == name } -> ""
+                            importDecl.asClause != null -> importDecl.asClause!!.name + "."
+                            else -> importDecl.moduleQID.text + "."
+                        }
+                    }
+
 
     // VALUES
 

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmNamedElementIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmNamedElementIndex.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.stubs.ElmFileStub
+import org.elm.lang.core.types.moduleName
 
 class ElmNamedElementIndex : StringStubIndexExtension<ElmNamedElement>() {
 
@@ -31,5 +32,15 @@ class ElmNamedElementIndex : StringStubIndexExtension<ElmNamedElement>() {
          */
         fun getAllNames(project: Project): Collection<String> =
                 StubIndex.getInstance().getAllKeys(KEY, project)
+
+        /** Find the named element with [name] declared in [module] */
+        inline fun <reified T : ElmNamedElement> findElement(
+                name: String,
+                module: String,
+                project: Project,
+                scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
+        ): T? = find(name, project, scope)
+                .filterIsInstance<T>()
+                .find { it.moduleName == module }
     }
 }

--- a/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
@@ -1,8 +1,10 @@
 package org.elm.ide.inspections
 
+import org.intellij.lang.annotations.Language
+
 class ElmIncompletePatternInspectionTest : ElmInspectionsTestBase(ElmIncompletePatternInspection()) {
 
-    fun `test no existing branch`() = checkFixByText("Add missing case branches", """
+    fun `test no existing branch`() = checkFixByText("""
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -15,16 +17,16 @@ foo : Foo -> ()
 foo it =
     case it of
         Bar ->
-            
+            --EOL
 
         Baz ->
-            
+            --EOL
 
         Qux ->
-            
+            --EOL
 """)
 
-    fun `test one existing branch`() = checkFixByText("Add missing case branches", """
+    fun `test one existing branch`() = checkFixByText("""
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -42,13 +44,13 @@ foo it =
             ()
 
         Bar ->
-            
+            --EOL
 
         Qux ->
-            
+            --EOL
 """)
 
-    fun `test two existing branches`() = checkFixByText("Add missing case branches", """
+    fun `test two existing branches`() = checkFixByText("""
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -72,10 +74,10 @@ foo it =
             ()
 
         Bar ->
-            
+            --EOL
 """)
 
-    fun `test params`() = checkFixByText("Add missing case branches", """
+    fun `test params`() = checkFixByText("""
 type Foo = Foo
 type alias BarBaz = Foo
 type Maybe a = Just a | Nothing
@@ -106,22 +108,22 @@ foo : Msg a b -> ()
 foo it =
     case it of
         MsgOne foo barBaz ->
-            
+            --EOL
 
         MsgTwo maybe ->
-            
+            --EOL
 
         MsgThree b a ->
-            
+            --EOL
 
         MsgFour record ->
-            
+            --EOL
 
         MsgFive (x, y) ->
-            
+            --EOL
 
         MsgSix msg ->
-            
+            --EOL
 """)
 
     fun `test one existing branch, wildcard pattern`() = checkFixByText("Add '_' branch", """
@@ -142,10 +144,10 @@ foo it =
             ()
 
         _ ->
-            
-""")
+            --EOL
+""".replace("--EOL", ""))
 
-    fun `test no leading whitespace`() = checkFixByText("Add missing case branches", """
+    fun `test no leading whitespace`() = checkFixByText("""
 type Foo = Bar
 
 foo : Foo -> ()
@@ -156,10 +158,10 @@ type Foo = Bar
 foo : Foo -> ()
 foo it =case it of
         Bar ->
-            
+            --EOL
 """)
 
-    fun `test nesting in let`() = checkFixByText("Add missing case branches", """
+    fun `test nesting in let`() = checkFixByText("""
 type Foo = Bar
 
 foo : Foo -> ()
@@ -178,12 +180,12 @@ foo it =
         bar =
             case it of
                 Bar ->
-                    
+                    --EOL
     in
         ()
 """)
 
-    fun `test nesting in case`() = checkFixByText("Add missing case branches", """
+    fun `test nesting in case`() = checkFixByText("""
 type Foo = Bar
 
 foo : Foo -> ()
@@ -200,6 +202,97 @@ foo it =
         () ->
             case it of
                 Bar ->
-                    
+                    --EOL
 """)
+
+    fun `test qualified import`() = checkFixByFileTree("""
+--@ Data/User.elm
+module Data.User exposing (..)
+type Foo = Bar | Baz | Qux
+
+--@ main.elm
+import Data.User
+foo : Data.User.Foo -> ()
+foo it =
+    <error>case{-caret-}</error> it of
+""", """
+import Data.User
+foo : Data.User.Foo -> ()
+foo it =
+    case it of
+        Data.User.Bar ->
+            --EOL
+
+        Data.User.Baz ->
+            --EOL
+
+        Data.User.Qux ->
+            --EOL
+""")
+
+    fun `test import with alias`() = checkFixByFileTree("""
+--@ Data/User.elm
+module Data.User exposing (..)
+type Foo = Bar | Baz | Qux
+
+--@ main.elm
+import Data.User as UserData
+foo : UserData.Foo -> ()
+foo it =
+    <error>case{-caret-}</error> it of
+""", """
+import Data.User as UserData
+foo : UserData.Foo -> ()
+foo it =
+    case it of
+        UserData.Bar ->
+            --EOL
+
+        UserData.Baz ->
+            --EOL
+
+        UserData.Qux ->
+            --EOL
+""")
+
+    fun `test exposed import`() = checkFixByFileTree("""
+--@ Data/User.elm
+module Data.User exposing (..)
+type Foo = Bar | Baz | Qux
+
+--@ main.elm
+import Data.User exposing (..)
+foo : Data.User.Foo -> ()
+foo it =
+    <error>case{-caret-}</error> it of
+""", """
+import Data.User exposing (..)
+foo : Data.User.Foo -> ()
+foo it =
+    case it of
+        Bar ->
+            --EOL
+
+        Baz ->
+            --EOL
+
+        Qux ->
+            --EOL
+""")
+
+    private fun checkFixByText(
+            @Language("Elm") before: String,
+            @Language("Elm") after: String) {
+        // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
+        // significant for this test.
+        checkFixByText("Add missing case branches", before, after.replace("--EOL", ""))
+    }
+
+    private fun checkFixByFileTree(
+            @Language("Elm") before: String,
+            @Language("Elm") after: String) {
+        // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
+        // significant for this test.
+        checkFixByFileTree("Add missing case branches", before, after.replace("--EOL", ""))
+    }
 }

--- a/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
@@ -4,7 +4,7 @@ import org.intellij.lang.annotations.Language
 
 class ElmIncompletePatternInspectionTest : ElmInspectionsTestBase(ElmIncompletePatternInspection()) {
 
-    fun `test no existing branch`() = checkFixByText("""
+    fun `test no existing branch`() = checkFixByText("Add missing case branches", """
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -26,7 +26,7 @@ foo it =
             --EOL
 """)
 
-    fun `test one existing branch`() = checkFixByText("""
+    fun `test one existing branch`() = checkFixByText("Add missing case branches", """
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -50,7 +50,7 @@ foo it =
             --EOL
 """)
 
-    fun `test two existing branches`() = checkFixByText("""
+    fun `test two existing branches`() = checkFixByText("Add missing case branches", """
 type Foo = Bar | Baz | Qux
 
 foo : Foo -> ()
@@ -77,7 +77,7 @@ foo it =
             --EOL
 """)
 
-    fun `test params`() = checkFixByText("""
+    fun `test params`() = checkFixByText("Add missing case branches", """
 type Foo = Foo
 type alias BarBaz = Foo
 type Maybe a = Just a | Nothing
@@ -145,9 +145,19 @@ foo it =
 
         _ ->
             --EOL
-""".replace("--EOL", ""))
+""")
 
-    fun `test no leading whitespace`() = checkFixByText("""
+    fun `test no branches with non-union, wildcard pattern`() = checkFixByText("Add '_' branch", """
+foo =
+    <error>case{-caret-}</error> 1 of
+""", """
+foo =
+    case 1 of
+        _ ->
+            --EOL
+""")
+
+    fun `test no leading whitespace`() = checkFixByText("Add missing case branches", """
 type Foo = Bar
 
 foo : Foo -> ()
@@ -161,7 +171,7 @@ foo it =case it of
             --EOL
 """)
 
-    fun `test nesting in let`() = checkFixByText("""
+    fun `test nesting in let`() = checkFixByText("Add missing case branches", """
 type Foo = Bar
 
 foo : Foo -> ()
@@ -185,7 +195,7 @@ foo it =
         ()
 """)
 
-    fun `test nesting in case`() = checkFixByText("""
+    fun `test nesting in case`() = checkFixByText("Add missing case branches", """
 type Foo = Bar
 
 foo : Foo -> ()
@@ -205,7 +215,7 @@ foo it =
                     --EOL
 """)
 
-    fun `test qualified import`() = checkFixByFileTree("""
+    fun `test qualified import`() = checkFixByFileTree("Add missing case branches", """
 --@ Data/User.elm
 module Data.User exposing (..)
 type Foo = Bar | Baz | Qux
@@ -230,7 +240,7 @@ foo it =
             --EOL
 """)
 
-    fun `test import with alias`() = checkFixByFileTree("""
+    fun `test import with alias`() = checkFixByFileTree("Add missing case branches", """
 --@ Data/User.elm
 module Data.User exposing (..)
 type Foo = Bar | Baz | Qux
@@ -255,7 +265,7 @@ foo it =
             --EOL
 """)
 
-    fun `test exposed import`() = checkFixByFileTree("""
+    fun `test exposed import`() = checkFixByFileTree("Add missing case branches", """
 --@ Data/User.elm
 module Data.User exposing (..)
 type Foo = Bar | Baz | Qux
@@ -281,18 +291,18 @@ foo it =
 """)
 
     private fun checkFixByText(
+            fixName: String,
             @Language("Elm") before: String,
             @Language("Elm") after: String) {
         // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
         // significant for this test.
-        checkFixByText("Add missing case branches", before, after.replace("--EOL", ""))
+        super.checkFixByText(fixName, before, after.replace("--EOL", ""), true, false, false)
     }
 
     private fun checkFixByFileTree(
+            fixName: String,
             @Language("Elm") before: String,
             @Language("Elm") after: String) {
-        // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
-        // significant for this test.
-        checkFixByFileTree("Add missing case branches", before, after.replace("--EOL", ""))
+        super.checkFixByFileTree(fixName, before, after.replace("--EOL", ""), true, false, false)
     }
 }


### PR DESCRIPTION
This PR has two commits:

1. Qualifies generated union variants when necessary (i.e. the module import doesn't expose the union type)
2. Shows the wildcard fix for all case expressions without branches. Previously no error was shown unless the expression was a union, even if the case has no branches.

Fixes #192