### PR TITLE
Problem: False positive for non-exhaustive case expression

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -96,6 +96,10 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
             }
         }
 
+        if (missingBranches.isEmpty()) {
+            return Result.NoMissing
+        }
+
         val qualifierPrefix = ModuleScope(element.elmFile).getQualifierForTypeName(exprTy.module, exprTy.name) ?: ""
 
         return Result.MissingVariants(missingBranches.mapKeys { (k, _) -> qualifierPrefix + k })


### PR DESCRIPTION
PR #211 introduced a bug where it determines a case expression
is non-exhaustive when it is actually exhaustive.

Solution: If missing branches is empty then no branches are missing

(I feel really silly writing that :D)

Fixes #214