### PR TITLE
Fix false positives in unused-code inspection; refactor how "exposure" is determined

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -46,7 +46,7 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
             when {
                 element is ElmFunctionDeclarationLeft ->
                     element.name == "main" || element.isElmTestEntryPoint()
-                element is ElmPortAnnotation -> true
+                element is ElmPortAnnotation -> isExposed(element)
                 else -> false
             }
 
@@ -75,6 +75,11 @@ private fun ElmFunctionDeclarationLeft.isElmTestEntryPoint(): Boolean {
         return false
 
     // The elm-test runner requires that the entry-point be exposed by the module
+    return isExposed(this)
+}
+
+
+private fun isExposed(decl: ElmExposableTag): Boolean {
     val exposingList = decl.elmFile.getModuleDecl()?.exposingList ?: return false
-    return exposingList.exposes(this)
+    return exposingList.exposes(decl)
 }

--- a/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
@@ -6,11 +6,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.ElmNameIdentifierOwner
-import org.elm.lang.core.psi.elements.ElmExposingList
-import org.elm.lang.core.psi.elements.ElmUnionVariant
-import org.elm.lang.core.psi.elements.addItem
-import org.elm.lang.core.psi.elements.findMatchingItemFor
+import org.elm.lang.core.psi.elements.*
 
 /**
  * An intention action that adds a function/type to a module's `exposing` list.
@@ -26,22 +22,24 @@ class AddExposureIntention : ElmAtCaretIntentionActionBase<AddExposureIntention.
         val exposingList = (element.containingFile as? ElmFile)?.getModuleDecl()?.exposingList
                 ?: return null
 
-        if (exposingList.doubleDot != null) {
-            // The module already exposes everything. Nothing to do here.
-            return null
-        }
+        // check if the caret is on the identifier that names the exposable declaration
+        val decl = element.parent as? ElmExposableTag ?: return null
+        if (decl.nameIdentifier != element) return null
 
-        val parent = element.parent as? ElmNameIdentifierOwner ?: return null
-        if (parent.nameIdentifier != element) return null
-
-        return if (parent is ElmExposableTag && parent !is ElmUnionVariant) {
-            if (exposingList.findMatchingItemFor(parent) == null) {
-                Context(parent.name, exposingList)
-            } else {
+        return when {
+            decl is ElmUnionVariant -> {
+                // might be nice to support this in the future (making a union type fully exposed)
                 null
             }
-        } else {
-            null
+
+            decl is ElmFunctionDeclarationLeft && !decl.isTopLevel ->
+                null
+
+            !exposingList.exposes(decl) ->
+                Context(decl.name, exposingList)
+
+            else ->
+                null
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
@@ -4,9 +4,13 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNameIdentifierOwner
-import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.psi.elements.ElmExposingList
+import org.elm.lang.core.psi.elements.ElmUnionVariant
+import org.elm.lang.core.psi.elements.addItem
+import org.elm.lang.core.psi.elements.findMatchingItemFor
 
 /**
  * An intention action that adds a function/type to a module's `exposing` list.
@@ -28,20 +32,16 @@ class AddExposureIntention : ElmAtCaretIntentionActionBase<AddExposureIntention.
         }
 
         val parent = element.parent as? ElmNameIdentifierOwner ?: return null
-
         if (parent.nameIdentifier != element) return null
 
-        return when (parent) {
-            is ElmFunctionDeclarationLeft,
-            is ElmTypeDeclaration,
-            is ElmTypeAliasDeclaration ->
-                if (exposingList.findMatchingItemFor(parent) == null) {
-                    Context(parent.name, exposingList)
-                } else {
-                    null
-                }
-
-            else -> null
+        return if (parent is ElmExposableTag && parent !is ElmUnionVariant) {
+            if (exposingList.findMatchingItemFor(parent) == null) {
+                Context(parent.name, exposingList)
+            } else {
+                null
+            }
+        } else {
+            null
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
@@ -7,7 +7,6 @@ import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.ElmNameIdentifierOwner
 import org.elm.lang.core.psi.elements.ElmExposingList
 import org.elm.lang.core.psi.elements.ElmUnionVariant
 import org.elm.lang.core.psi.elements.findMatchingItemFor
@@ -35,13 +34,16 @@ class RemoveExposureIntention : ElmAtCaretIntentionActionBase<RemoveExposureInte
             return null
         }
 
-        val parent = element.parent as? ElmNameIdentifierOwner ?: return null
-        if (parent.nameIdentifier != element) return null
+        // check if the caret is on the identifier that names the exposable declaration
+        val decl = element.parent as? ElmExposableTag ?: return null
+        if (decl.nameIdentifier != element) return null
 
-        return if (parent is ElmExposableTag && parent !is ElmUnionVariant) {
-            exposingList.findMatchingItemFor(parent)?.let { Context(it, exposingList) }
-        } else {
+        return if (decl is ElmUnionVariant) {
+            // might be nice to support this in the future (making a union type opaque)
             null
+        } else {
+            exposingList.findMatchingItemFor(decl)
+                    ?.let { Context(it, exposingList) }
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
@@ -4,10 +4,14 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNameIdentifierOwner
-import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.psi.elements.ElmExposingList
+import org.elm.lang.core.psi.elements.ElmUnionVariant
+import org.elm.lang.core.psi.elements.findMatchingItemFor
+import org.elm.lang.core.psi.elements.removeItem
 
 /**
  * An intention action that removes a function/type from a module's `exposing` list.
@@ -32,15 +36,12 @@ class RemoveExposureIntention : ElmAtCaretIntentionActionBase<RemoveExposureInte
         }
 
         val parent = element.parent as? ElmNameIdentifierOwner ?: return null
-
         if (parent.nameIdentifier != element) return null
 
-        return when (parent) {
-            is ElmFunctionDeclarationLeft,
-            is ElmTypeDeclaration,
-            is ElmTypeAliasDeclaration ->
-                exposingList.findMatchingItemFor(parent)?.let { Context(it, exposingList) }
-            else -> null
+        return if (parent is ElmExposableTag && parent !is ElmUnionVariant) {
+            exposingList.findMatchingItemFor(parent)?.let { Context(it, exposingList) }
+        } else {
+            null
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.psi.PsiElement
 import org.elm.ide.icons.ElmIcons
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNameIdentifierOwner
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
@@ -32,7 +33,9 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
                 if (!parentDecl.isTopLevel) null
                 else makeMarkerIfExposed(element, parentDecl)
 
-            is ElmTypeDeclaration,
+            is ElmTypeDeclaration ->
+                makeMarkerIfExposed(element, parentDecl)
+
             is ElmTypeAliasDeclaration ->
                 makeMarkerIfExposed(element, parentDecl)
 
@@ -47,7 +50,7 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
 }
 
 
-private fun makeMarkerIfExposed(element: PsiElement, decl: ElmNameIdentifierOwner): LineMarkerInfo<PsiElement>? {
+private fun makeMarkerIfExposed(element: PsiElement, decl: ElmExposableTag): LineMarkerInfo<PsiElement>? {
     val elmFile = element.containingFile as? ElmFile ?: return null
     val moduleDecl = elmFile.getModuleDecl() ?: return null
     val exposingList = moduleDecl.exposingList ?: return null

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
@@ -12,8 +12,7 @@ import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.elementType
 import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
-import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
-import org.elm.lang.core.psi.elements.ElmTypeDeclaration
+import org.elm.lang.core.psi.elements.ElmUnionVariant
 import org.elm.lang.core.psi.elements.findMatchingItemFor
 
 /**
@@ -29,14 +28,14 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
         if (parentDecl !is ElmNameIdentifierOwner || parentDecl.nameIdentifier != element) return null
 
         return when (parentDecl) {
+            is ElmUnionVariant ->
+                null
+
             is ElmFunctionDeclarationLeft ->
                 if (!parentDecl.isTopLevel) null
                 else makeMarkerIfExposed(element, parentDecl)
 
-            is ElmTypeDeclaration ->
-                makeMarkerIfExposed(element, parentDecl)
-
-            is ElmTypeAliasDeclaration ->
+            is ElmExposableTag ->
                 makeMarkerIfExposed(element, parentDecl)
 
             else ->

--- a/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
@@ -56,3 +56,6 @@ interface ElmFieldAccessTargetTag : ElmPsiElement
 
 /** An element which can occur in a module or import's exposing list */
 interface ElmExposedItemTag : ElmPsiElement
+
+/** A named declaration which can be exposed by a module */
+interface ElmExposableTag : ElmPsiElement, ElmNameIdentifierOwner

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedType.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedType.kt
@@ -56,3 +56,18 @@ class ElmExposedType : ElmStubbedElement<ElmExposedTypeStub>, ElmReferenceElemen
 }
 
 
+fun ElmExposedType.exposes(variant: ElmUnionVariant): Boolean {
+    val targetTypeDecl = reference.resolve()
+    if (variant.parentOfType<ElmTypeDeclaration>() != targetTypeDecl) {
+        // they do not belong to the same union type
+        return false
+    }
+
+    if (exposesAll)
+        return true
+
+    val exposedCtors = exposedUnionConstructors?.exposedUnionConstructors ?: return false
+    return exposedCtors.any { it.name == variant.name }
+}
+
+

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -86,9 +86,22 @@ fun ElmExposingList.findMatchingItemFor(decl: ElmNameIdentifierOwner): ElmExpose
  * NOTE: This only handles the case where it is exposed directly by name.
  *       You must check separately to see if the receiver uses Elm's `..` syntax
  *       to expose *all* names.
+ *
+ * @see exposes
  */
 fun ElmExposingList.explicitlyExposes(decl: ElmNameIdentifierOwner): Boolean =
         findMatchingItemFor(decl) != null
+
+
+/**
+ * Returns true if [decl] is exposed by the receiver, either directly by name or
+ * indirectly by the `..` (expose-all) syntax.
+ *
+ * @see explicitlyExposes
+ */
+fun ElmExposingList.exposes(decl: ElmNameIdentifierOwner): Boolean =
+        doubleDot != null || findMatchingItemFor(decl) != null
+
 
 /**
  * Add a function/type to the exposing list, while ensuring that the necessary comma and whitespace are also added.

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
@@ -25,7 +25,7 @@ import org.elm.lang.core.stubs.ElmFunctionDeclarationLeftStub
  *      foo = 42
  *  in ...`
  */
-class ElmFunctionDeclarationLeft : ElmStubbedNamedElementImpl<ElmFunctionDeclarationLeftStub> {
+class ElmFunctionDeclarationLeft : ElmStubbedNamedElementImpl<ElmFunctionDeclarationLeftStub>, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.LOWER)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmInfixDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmInfixDeclaration.kt
@@ -3,7 +3,6 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
-import com.intellij.psi.tree.TokenSet
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.stubs.ElmInfixDeclarationStub
 
@@ -16,7 +15,7 @@ import org.elm.lang.core.stubs.ElmInfixDeclarationStub
  *
  * As of Elm 0.19, these are now restricted to packages owned by elm-lang (and elm-explorations?)
  */
-class ElmInfixDeclaration : ElmStubbedNamedElementImpl<ElmInfixDeclarationStub> {
+class ElmInfixDeclaration : ElmStubbedNamedElementImpl<ElmInfixDeclarationStub>, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.OPERATOR)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.ElmTypes.OPERATOR_IDENTIFIER
@@ -19,7 +20,7 @@ import org.elm.lang.core.stubs.ElmOperatorDeclarationLeftStub
  *
  * @see [ElmFunctionDeclarationLeft]
  */
-class ElmOperatorDeclarationLeft : ElmStubbedNamedElementImpl<ElmOperatorDeclarationLeftStub> {
+class ElmOperatorDeclarationLeft : ElmStubbedNamedElementImpl<ElmOperatorDeclarationLeftStub>, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.OPERATOR)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmPortAnnotation.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmPortAnnotation.kt
@@ -3,6 +3,7 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.IdentifierCase
@@ -15,7 +16,7 @@ import org.elm.lang.core.stubs.ElmPortAnnotationStub
  * e.g. `port doSomething : String -> Cmd Int`
  *
  */
-class ElmPortAnnotation : ElmStubbedNamedElementImpl<ElmPortAnnotationStub> {
+class ElmPortAnnotation : ElmStubbedNamedElementImpl<ElmPortAnnotationStub>, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.LOWER)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeAliasDeclaration.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
 import org.elm.lang.core.psi.ElmDocTarget
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.IdentifierCase
@@ -18,7 +19,7 @@ import org.elm.lang.core.stubs.ElmTypeAliasDeclarationStub
  * e.g. `type alias User = { name : String, age : Int }`
  *
  */
-class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarationStub>, ElmDocTarget {
+class ElmTypeAliasDeclaration : ElmStubbedNamedElementImpl<ElmTypeAliasDeclarationStub>, ElmDocTarget, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.UPPER)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeDeclaration.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
 import org.elm.lang.core.psi.ElmDocTarget
+import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.IdentifierCase
 import org.elm.lang.core.stubs.ElmTypeDeclarationStub
@@ -20,7 +21,7 @@ import org.elm.lang.core.stubs.ElmTypeDeclarationStub
  * In which case, [lowerTypeNameList] would contain a single element representing the
  * type variable `a`.
  */
-class ElmTypeDeclaration : ElmStubbedNamedElementImpl<ElmTypeDeclarationStub>, ElmDocTarget {
+class ElmTypeDeclaration : ElmStubbedNamedElementImpl<ElmTypeDeclarationStub>, ElmDocTarget, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.UPPER)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionVariant.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionVariant.kt
@@ -18,8 +18,8 @@ import org.elm.lang.core.stubs.ElmUnionVariantStub
  * ```
  */
 // TODO [drop 0.18] in Elm 0.19, a union variant is not exposable directly
-//      so we should probably stop implementing the `ElmExposableTag` interface
-//      once we remove support for Elm 0.18.
+//      so we MIGHT want to stop implementing the `ElmExposableTag` interface
+//      once we remove support for Elm 0.18. Or maybe there's a better way?
 class ElmUnionVariant : ElmStubbedNamedElementImpl<ElmUnionVariantStub>, ElmExposableTag {
 
     constructor(node: ASTNode) :

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionVariant.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionVariant.kt
@@ -3,11 +3,8 @@ package org.elm.lang.core.psi.elements
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
-import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
-import org.elm.lang.core.psi.IdentifierCase
-import org.elm.lang.core.psi.directChildren
-import org.elm.lang.core.psi.ElmUnionVariantParameterTag
 import org.elm.lang.core.stubs.ElmUnionVariantStub
 
 /**
@@ -20,7 +17,10 @@ import org.elm.lang.core.stubs.ElmUnionVariantStub
  *     | Nothing
  * ```
  */
-class ElmUnionVariant : ElmStubbedNamedElementImpl<ElmUnionVariantStub> {
+// TODO [drop 0.18] in Elm 0.19, a union variant is not exposable directly
+//      so we should probably stop implementing the `ElmExposableTag` interface
+//      once we remove support for Elm 0.18.
+class ElmUnionVariant : ElmStubbedNamedElementImpl<ElmUnionVariantStub>, ElmExposableTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.UPPER)

--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
@@ -66,6 +66,13 @@ class ElmUnusedSymbolInspectionTest : ElmInspectionsTestBase(ElmUnusedSymbolInsp
         """.trimIndent())
 
 
+    fun `test a port annotation that is not exposed should be checked for usage`() = checkByText("""
+        port module Foo exposing (foo)
+        port foo : () -> msg
+        port <warning descr="'bar' is never used">bar</warning> : () -> msg
+        """.trimIndent())
+
+
     fun `test the type annotation does not count as usage`() = checkByText("""
         f : ()
         <warning descr="'f' is never used">f</warning> = ()

--- a/src/test/kotlin/org/elm/ide/intentions/AddExposureIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddExposureIntentionTest.kt
@@ -24,4 +24,13 @@ f1{-caret-} = ()
 """)
 
 
+    fun `test cannot expose functions defined in a let-in expression`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 =
+    let f1{-caret-} = ()
+    in f1
+""")
+
+
 }

--- a/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/RemoveExposureIntentionTest.kt
@@ -91,4 +91,12 @@ module Foo exposing (..)
 bar{-caret-} = ()
 """)
 
+
+    fun `test refuse to hide functions defined within a let-in expression`() = doUnavailableTest("""
+module Foo exposing (..)
+bar =
+    let foo{-caret-} = ()
+    in foo
+""")
+
 }

--- a/src/test/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProviderTest.kt
@@ -60,4 +60,13 @@ type alias Foo = () --> Exposed
 type alias Bar = ()
 """
     )
+
+
+    fun `test module that exposes a port`() = doTestByText(
+            """
+port module Main exposing (foo)
+port foo : a -> () --> Exposed
+port bar : a -> ()
+""")
+
 }


### PR DESCRIPTION
Fixes #199 

Previously, the unused code inspection only knew about a single entry-point, `main`. But Elm's ports and elm-test's `Test` functions are also valid entry points, and the plugin was mistakenly identifying them as unused code. This PR fixes that.

While I was in there, I also refactored how "exposure" is determined (i.e. whether a function is exposed by a module or not). As an added bonus, the "exposed" gutter line-marker will now be shown for ports.