### PR TITLE
Do not mark native/kernel module imports as unused

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
@@ -21,4 +21,15 @@ interface ElmQID : ElmPsiElement {
                 upperCaseIdentifierList
             return frontParts.joinToString(".") { it.text }
         }
+
+    /** Returns true if the qualified ID refers to Elm's "Kernel" modules,
+     * which are defined in Javascript. This is useful since we don't (currently)
+     * support PsiReferences between JS and Elm
+     */
+    val isKernelModule: Boolean
+        get() {
+            val moduleName = upperCaseIdentifierList.joinToString(".") { it.text }
+            return moduleName.startsWith("Elm.Kernel.")
+                    || moduleName.startsWith("Native.") // TODO [drop 0.18] remove the "Native" clause
+        }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueExpr.kt
@@ -2,10 +2,7 @@ package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
-import org.elm.lang.core.psi.ElmAtomTag
-import org.elm.lang.core.psi.ElmFieldAccessTargetTag
-import org.elm.lang.core.psi.ElmFunctionCallTargetTag
-import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.Flavor.*
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.*
@@ -35,6 +32,8 @@ class ElmValueExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElement
     val upperCaseQID: ElmUpperCaseQID?
         get() = findChildByClass(ElmUpperCaseQID::class.java)
 
+    val qid: ElmQID
+        get() = valueQID ?: upperCaseQID!!
 
     val flavor: Flavor
         get() = when {

--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedImportInspectionTest.kt
@@ -85,6 +85,17 @@ class ElmUnusedImportInspectionTest : ElmInspectionsTestBase(ElmUnusedImportInsp
     """.trimIndent())
 
 
+    fun `test imports of Elm 19 kernel JS modules are ignored`() = checkByText("""
+        import Elm.Kernel.Dom{-caret-}
+    """.trimIndent())
+
+
+    // TODO [drop 0.18] remove this test
+    fun `test imports of Elm 18 native JS modules are ignored`() = checkByText("""
+        import Native.Dom{-caret-}
+    """.trimIndent())
+
+
     // TODO we should support this eventually; punting for now
     fun `test unused union types in the exposing list are ignored, for now`() = checkByFileTree("""
         --@ Main.elm


### PR DESCRIPTION
Fixes #221 

Until we model the PsiReference system between the Elm/JS boundary, we must consider all native/kernel module imports as always being used/active.