### PR TITLE
Improve UX when generating a function body from type annotation

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -5,7 +5,7 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import org.elm.ide.intentions.AddImportIntention
-import org.elm.ide.intentions.ElmMakeDeclarationIntentionAction
+import org.elm.ide.intentions.MakeDeclarationIntention
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ancestors
@@ -77,7 +77,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
         if (element !is ElmTypeAnnotation) return false
 
         holder.createWeakWarningAnnotation(element, "'${ref.canonicalText}' does not exist")
-                .also { it.registerFix(ElmMakeDeclarationIntentionAction()) }
+                .also { it.registerFix(MakeDeclarationIntention()) }
 
         return true
     }

--- a/src/main/kotlin/org/elm/ide/intentions/MakeDeclarationIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MakeDeclarationIntention.kt
@@ -15,7 +15,7 @@ import org.elm.lang.core.types.TyFunction
 import org.elm.lang.core.types.renderParam
 import org.elm.lang.core.types.typeExpressionInference
 
-class ElmMakeDeclarationIntentionAction : ElmAtCaretIntentionActionBase<ElmMakeDeclarationIntentionAction.Context>() {
+class MakeDeclarationIntention : ElmAtCaretIntentionActionBase<MakeDeclarationIntention.Context>() {
 
     data class Context(val typeAnnotation: ElmTypeAnnotation)
 
@@ -74,7 +74,7 @@ class ElmMakeDeclarationIntentionAction : ElmAtCaretIntentionActionBase<ElmMakeD
             template.addTextSegment(" ")
         }
 
-        template.addTextSegment("= ")
+        template.addTextSegment("=\n    ")
         template.addEndVariable()
         return template
     }

--- a/src/test/kotlin/org/elm/ide/intentions/MakeDeclarationIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MakeDeclarationIntentionTest.kt
@@ -1,6 +1,7 @@
 package org.elm.ide.intentions
 
-class ElmMakeDeclarationIntentionTest : ElmIntentionTestBase(ElmMakeDeclarationIntentionAction()) {
+class MakeDeclarationIntentionTest : ElmIntentionTestBase(MakeDeclarationIntention()) {
+
     override fun getProjectDescriptor() = ElmWithStdlibDescriptor
 
 
@@ -11,7 +12,8 @@ f : Int{-caret-}
 """
                 , """
 f : Int
-f = {-caret-}
+f =
+    {-caret-}
 """)
     }
 
@@ -23,7 +25,8 @@ f : Int -> Int{-caret-}
 """
                 , """
 f : Int -> Int
-f int = {-caret-}
+f int =
+    {-caret-}
 """)
     }
 
@@ -35,7 +38,8 @@ f : (Int -> Int) -> List a -> (Char, String) -> { foo : Int } -> Bool{-caret-}
 """
                 , """
 f : (Int -> Int) -> List a -> (Char, String) -> { foo : Int } -> Bool
-f function list (char, string) record = {-caret-}
+f function list (char, string) record =
+    {-caret-}
 """)
     }
 
@@ -51,7 +55,8 @@ f : FooBar -> QuuxQuuxQuux -> Int{-caret-}
 type FooBar = FooBar
 type QuuxQuuxQuux = QuuxQuuxQuux
 f : FooBar -> QuuxQuuxQuux -> Int
-f fooBar quuxQuuxQuux = {-caret-}
+f fooBar quuxQuuxQuux =
+    {-caret-}
 """)
     }
 


### PR DESCRIPTION
Now it will automatically put the cursor on an newline, indented properly after filling out all parameter names.