### PR TITLE
Make reference resolve faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
                 - choco install --yes elm-platform
                 - choco install jdk8
                 - ls "/c/Program Files/Java"
-                - export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_191/bin"
+                - export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_201/bin"
 
         -   os: linux
             before_install:

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmImportClause.kt
@@ -1,7 +1,6 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
@@ -45,7 +44,7 @@ class ElmImportClause(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElem
             object : ElmReferenceCached<ElmImportClause>(this) {
 
                 override fun resolveInner(): ElmNamedElement? =
-                        getVariants().find { it.name == element.referenceName }
+                        ElmModulesIndex.get(element.referenceName, elmFile)
 
                 override fun getVariants(): Array<ElmNamedElement> =
                         ElmModulesIndex.getAll(elmFile).toTypedArray()

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
@@ -26,7 +26,6 @@ class ExpressionScope(val element: PsiElement) {
                 results.add(it)
             }
 
-            // TODO [kl] might need to de-dupe because an [ElmValueDeclaration] is also a named element
             if (it is ElmValueDeclaration) {
                 results.addAll(it.declaredNames())
             }

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
@@ -11,7 +11,6 @@ import org.elm.lang.core.psi.ClientLocation
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
 import org.elm.lang.core.stubs.ElmFileStub
 import org.elm.lang.core.stubs.ElmModuleDeclarationStub
-import org.elm.openapiext.findFileByMaybeRelativePath
 import org.elm.openapiext.findFileByPathTestAware
 import org.elm.workspace.ElmProject
 
@@ -165,6 +164,6 @@ private fun ElmProject.sourceDirectoryContains(moduleDeclaration: ElmModuleDecla
     val extraDirs = if (includeTestDirectory) listOf(testsDirPath) else emptyList()
     val elmModuleRelativePath = moduleDeclaration.name.replace('.', '/') + ".elm"
     return (candidateSrcDirs + extraDirs)
-            .mapNotNull { findFileByPathTestAware(it) }
-            .any { it.findFileByMaybeRelativePath(elmModuleRelativePath) != null }
+            .mapNotNull { findFileByPathTestAware(it.resolve(elmModuleRelativePath)) }
+            .isNotEmpty()
 }

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -14,6 +14,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -85,8 +86,10 @@ sealed class ElmProject(
         val paths = mutableListOf<Path>()
         for (a in absoluteSourceDirectories) {
             for (b in otherProject.absoluteSourceDirectories) {
-                if (Files.exists(a) && Files.exists(b) && Files.isSameFile(a, b)) {
-                    paths.add(a)
+                try {
+                    if (Files.isSameFile(a, b)) paths.add(a)
+                } catch (e: NoSuchFileException) {
+                    // ignore
                 }
             }
         }


### PR DESCRIPTION
There were a couple of problems that showed up in CPU profiling when resolving refs:

1) too much file I/O in `ElmProject.exposes`
2) `ElmImportClause.resolve` was slow
3) `QualifiedModuleNameReference.resolve` was slow

Fixes #157

----

My perf benchmark was typing `jkl = (String.length "") + (String.length "")` at the top-level of an 1,800 line file with 50 imports.

BEFORE:
<img width="1325" alt="before" src="https://user-images.githubusercontent.com/84525/51500173-fb8fc200-1d81-11e9-91f5-f3e46afcfa79.png">

AFTER:
<img width="1326" alt="after" src="https://user-images.githubusercontent.com/84525/51500177-ffbbdf80-1d81-11e9-8a31-7868c5bd0cac.png">