### PR TITLE
Cache the Elm version used by the 'check toolchain' notification

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -387,6 +387,8 @@ class ElmWorkspaceService(
 
 
     companion object {
+        // This topic covers any changes to the projects contained within the Elm workspace as
+        // well as changes to the workspace settings.
         val WORKSPACE_TOPIC = Topic("Elm workspace changes", ElmWorkspaceListener::class.java)
     }
 }


### PR DESCRIPTION
Fixes #200 

It looks like there are some cases where IntelliJ aggressively invalidates the notification panel associated with each file. And every time this happened, we were synchronously invoking the external Elm process to check its version.

This PR caches the Elm compiler version and invalidates it whenever there is a change to the workspace or its settings (which includes the path to the Elm compiler).