### PR TITLE
Add test that checks all inspections for missing docs

### DIFF
--- a/src/main/resources/inspectionDescriptions/ElmIncompletePattern.html
+++ b/src/main/resources/inspectionDescriptions/ElmIncompletePattern.html
@@ -1,0 +1,1 @@
+There are missing branches in this case expression.

--- a/src/main/resources/inspectionDescriptions/ElmUnusedImport.html
+++ b/src/main/resources/inspectionDescriptions/ElmUnusedImport.html
@@ -1,1 +1,1 @@
-Find unused imports
+Find unused imports.

--- a/src/test/kotlin/org/elm/ide/inspections/ElmInspectionsTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmInspectionsTestBase.kt
@@ -137,6 +137,13 @@ abstract class ElmInspectionsTestBase(
         val inspection: LocalInspectionTool
 ) : ElmAnnotationTestBase() {
 
+    fun `test inspection has documentation`() {
+        val description = "inspectionDescriptions/${inspection.javaClass.simpleName?.dropLast("Inspection".length)}.html"
+        val text = getResourceAsString(description)
+                ?: error("No inspection description for ${inspection.javaClass} ($description)")
+        checkHtmlStyle(text)
+    }
+
     private fun enableInspection() = myFixture.enableInspections(inspection)
 
     override fun configureByText(text: String) {


### PR DESCRIPTION
If an inspection doesn't have docs, IntelliJ adds "Under Construction" to its description instead.

I also fixed the places where this new test failed.