### PR TITLE
Properly handle `.elm` suffix when creating a new Elm file

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
@@ -27,12 +27,13 @@ class ElmCreateFileAction : CreateFileFromTemplateAction(CAPTION, "", ElmFileTyp
 
     override fun createFile(name: String?, templateName: String, dir: PsiDirectory): PsiFile? {
         if (name == null) return null
-        val newFile = super.createFile(name, templateName, dir) ?: return null
+        val cleanedName = name.removeSuffix(".elm")
+        val newFile = super.createFile(cleanedName, templateName, dir) ?: return null
 
         if (templateName == ELM_MODULE_KIND) {
             // HACK: I use an empty template to generate the file and then fill in the contents here
             // TODO ask around to find out what's the right way to do this
-            newFile.viewProvider.document?.setText("module ${qualifyModuleName(dir, name)} exposing (..)")
+            newFile.viewProvider.document?.setText("module ${qualifyModuleName(dir, cleanedName)} exposing (..)")
         }
 
         return newFile

--- a/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
@@ -28,15 +28,20 @@ class ElmCreateFileActionTest : ElmWorkspaceTestBase() {
     fun `test file creation outside of a source root uses an empty module qualifier`() =
             doTest("outside", "Quux", "module Quux exposing (..)")
 
+    // https://github.com/klazuka/intellij-elm/issues/231
+    fun `test file creation including file extension`() =
+            doTest("src", "Quux.elm", "module Quux exposing (..)")
 
-    private fun doTest(dirPath: String, newFileName: String, expectedContents: String) {
+
+    private fun doTest(dirPath: String, name: String, expectedContents: String) {
         val testProject = makeTestProjectFixture()
         val action = ElmCreateFileAction()
         val dirVirtualFile = testProject.root.findFileByRelativePath(dirPath)!!
         myFixture.project.runWriteCommandAction {
-            action.testHelperCreateFile(newFileName, myFixture.psiManager.findDirectory(dirVirtualFile)!!)
+            action.testHelperCreateFile(name, myFixture.psiManager.findDirectory(dirVirtualFile)!!)
         }
-        myFixture.checkResult("$dirPath/$newFileName.elm", expectedContents, true)
+        val filename = name.removeSuffix(".elm")
+        myFixture.checkResult("$dirPath/$filename.elm", expectedContents, true)
     }
 
 


### PR DESCRIPTION
Fixes #231 