### PR TITLE
Use ElmProject structure to filter ElmNamedElementIndex results

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -1,18 +1,14 @@
 package org.elm.ide.inspections
 
 import org.elm.ide.typing.guessIndent
+import org.elm.lang.core.lookup.ElmLookup
 import org.elm.lang.core.psi.ElmPsiFactory
 import org.elm.lang.core.psi.elements.ElmAnythingPattern
 import org.elm.lang.core.psi.elements.ElmCaseOfExpr
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.psi.elements.ElmUnionPattern
 import org.elm.lang.core.resolve.scope.ModuleScope
-import org.elm.lang.core.stubs.index.ElmNamedElementIndex
-import org.elm.lang.core.types.TyUnion
-import org.elm.lang.core.types.VariantParameters
-import org.elm.lang.core.types.findInference
-import org.elm.lang.core.types.renderParam
-import org.elm.lang.core.types.variantInference
+import org.elm.lang.core.types.*
 
 /**
  * This class can detect missing branches for case expressions and insert them into the PSI in place.
@@ -88,8 +84,7 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
         val exprTy = element.expression?.let { inference.elementType(it) } as? TyUnion
                 ?: return defaultResult
 
-        val project = element.project
-        val declaration = ElmNamedElementIndex.findElement<ElmTypeDeclaration>(exprTy.name, exprTy.module, project)
+        val declaration = ElmLookup.findByNameAndModule<ElmTypeDeclaration>(exprTy.name, exprTy.module, element.elmFile)
                 ?: return defaultResult
 
         val allBranches = declaration.variantInference().value

--- a/src/main/kotlin/org/elm/lang/core/lookup/ClientLocation.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ClientLocation.kt
@@ -1,0 +1,71 @@
+package org.elm.lang.core.lookup
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.GlobalSearchScopesCore
+import org.elm.lang.core.psi.elements.ElmModuleDeclaration
+import org.elm.openapiext.findFileByPathTestAware
+import org.elm.workspace.ElmPackageProject
+import org.elm.workspace.ElmProject
+
+/**
+ * Describes the location from which a reference is resolved.
+ *
+ * Reference resolution depends on context. For instance, we need
+ * to know the containing Elm project in order to determine which
+ * `source-directories` are valid roots.
+ *
+ * Starting in Elm 0.19, the Elm project's `test-dependencies`
+ * are only "import-able" from within "$ProjectRoot/tests" directory.
+ *
+ * @property intellijProject The IntelliJ project
+ * @property elmProject The Elm project from which we want to look for something
+ * @property isInTestsDirectory True if the place we are searching from is within the "tests" directory
+ */
+interface ClientLocation {
+    val intellijProject: Project
+    val elmProject: ElmProject?
+    val isInTestsDirectory: Boolean
+
+
+    /**
+     * Returns `true` if [moduleDeclaration] can be seen from [this location][ClientLocation].
+     *
+     * @see [searchScope]
+     */
+    fun canSee(moduleDeclaration: ElmModuleDeclaration): Boolean =
+            searchScope().contains(moduleDeclaration.elmFile.originalFile.virtualFile)
+
+
+    /**
+     * Returns a [GlobalSearchScope] which includes all Elm files that belong to [elmProject]
+     * taking into consideration:
+     *
+     *  - which source roots the [ElmProject] defines
+     *  - which packages are visible from the client location's [ElmProject]
+     *  - whether "test" code (and dependencies) should be included
+     */
+    fun searchScope(): GlobalSearchScope {
+        val p = elmProject ?: return GlobalSearchScope.EMPTY_SCOPE
+
+        val sourceDirs = p.sourceDirsVisibleAt(this).mapNotNull { findFileByPathTestAware(it) }.toList()
+        val srcDirScope = GlobalSearchScopesCore.directoriesScope(intellijProject, true, *(sourceDirs.toTypedArray()))
+
+        val exposedDependencyFiles = p.dependenciesVisibleAt(this).flatMap { it.exposedFiles() }.toList()
+        val dependenciesScope = GlobalSearchScope.filesWithLibrariesScope(intellijProject, exposedDependencyFiles)
+
+        return srcDirScope.uniteWith(dependenciesScope)
+    }
+}
+
+/**
+ * Return the [VirtualFile] for each Elm module which is exposed by this package.
+ */
+private fun ElmPackageProject.exposedFiles(): Sequence<VirtualFile> =
+        exposedModules.mapNotNull { moduleName ->
+            val elmModuleRelativePath = moduleName.replace('.', '/') + ".elm"
+            absoluteSourceDirectories.mapNotNull { srcDirPath ->
+                findFileByPathTestAware(srcDirPath.resolve(elmModuleRelativePath))
+            }.firstOrNull()
+        }.asSequence()

--- a/src/main/kotlin/org/elm/lang/core/lookup/ClientLocation.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ClientLocation.kt
@@ -30,15 +30,6 @@ interface ClientLocation {
 
 
     /**
-     * Returns `true` if [moduleDeclaration] can be seen from [this location][ClientLocation].
-     *
-     * @see [searchScope]
-     */
-    fun canSee(moduleDeclaration: ElmModuleDeclaration): Boolean =
-            searchScope().contains(moduleDeclaration.elmFile.originalFile.virtualFile)
-
-
-    /**
      * Returns a [GlobalSearchScope] which includes all Elm files that belong to [elmProject]
      * taking into consideration:
      *

--- a/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
@@ -1,0 +1,39 @@
+package org.elm.lang.core.lookup
+
+import com.intellij.openapi.diagnostic.logger
+import org.elm.lang.core.psi.ElmNamedElement
+import org.elm.lang.core.stubs.index.ElmNamedElementIndex
+import org.elm.lang.core.types.moduleName
+
+/**
+ * Like [ElmNamedElementIndex] but takes context into account. Given that a single
+ * IntelliJ project can hold multiple Elm projects, it is important that we take into
+ * account the caller's Elm project structure when looking for things by name.
+ */
+object ElmLookup {
+
+    val log = logger<ElmLookup>()
+
+    /** Find the named element with [name] which is visible to [clientLocation] */
+    inline fun <reified T : ElmNamedElement> findByName(
+            name: String,
+            clientLocation: ClientLocation
+    ): List<T> {
+        if (clientLocation.elmProject == null) {
+            if (log.isDebugEnabled) log.debug("Cannot lookup '$name' when Elm project context is unknown")
+            return emptyList()
+        }
+        return ElmNamedElementIndex.find(name, clientLocation.intellijProject, clientLocation.searchScope())
+                .filterIsInstance<T>()
+    }
+
+
+    /** Find the named element with [name] declared in [module] and visible to [clientLocation] */
+    inline fun <reified T : ElmNamedElement> findByNameAndModule(
+            name: String,
+            module: String,
+            clientLocation: ClientLocation
+    ): T? =
+            findByName<T>(name, clientLocation)
+                    .find { it.moduleName == module }
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
 import org.elm.lang.core.ElmFileType
 import org.elm.lang.core.ElmLanguage
+import org.elm.lang.core.lookup.ClientLocation
 import org.elm.lang.core.stubs.*
 import org.elm.openapiext.pathAsPath
 import org.elm.workspace.ElmPackageProject
@@ -136,20 +137,3 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
 
 val VirtualFile.isElmFile
     get() = fileType == ElmFileType
-
-
-/**
- * Describes the location from which a reference is resolved.
- *
- * Reference resolution depends on context. For instance, we need
- * to know the containing Elm project in order to determine which
- * `source-directories` are valid roots.
- *
- * Starting in Elm 0.19, the Elm project's `test-dependencies`
- * are only "import-able" from within "$ProjectRoot/tests" directory.
- */
-interface ClientLocation {
-    val intellijProject: Project
-    val elmProject: ElmProject?
-    val isInTestsDirectory: Boolean
-}

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
@@ -7,11 +7,10 @@ import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
-import org.elm.lang.core.psi.ClientLocation
+import org.elm.lang.core.lookup.ClientLocation
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
 import org.elm.lang.core.stubs.ElmFileStub
 import org.elm.lang.core.stubs.ElmModuleDeclarationStub
-import org.elm.openapiext.findFileByPathTestAware
 import org.elm.workspace.ElmProject
 
 private val logger = Logger.getInstance(ElmModulesIndex::class.java)
@@ -36,31 +35,23 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
         /**
          * Returns an Elm module named [moduleName] which is visible to [clientLocation], if any
          */
-        fun get(moduleName: String, clientLocation: ClientLocation): ElmModuleDeclaration? {
-            val elmProject = clientLocation.elmProject ?: return null
-            val elmModules = rawGet(moduleName, clientLocation.intellijProject)
-            return elmModules.firstOrNull { elmProject.exposes(it, clientLocation) }
-        }
+        fun get(moduleName: String, clientLocation: ClientLocation): ElmModuleDeclaration? =
+                rawGet(moduleName, clientLocation.intellijProject, clientLocation.searchScope())
+                        .firstOrNull()
 
 
         /**
          * Returns all Elm modules which are visible to [clientLocation]
          */
-        fun getAll(clientLocation: ClientLocation): List<ElmModuleDeclaration> {
-            val elmProject = clientLocation.elmProject ?: return emptyList()
-            val allModules = rawGetAll(clientLocation.intellijProject)
-            return allModules.filter { elmProject.exposes(it, clientLocation) }
-        }
+        fun getAll(clientLocation: ClientLocation): List<ElmModuleDeclaration> =
+                rawGetAll(clientLocation.intellijProject, clientLocation.searchScope())
 
 
         /**
          * Returns all Elm modules whose names match an element in [moduleNames] and which are visible to [clientLocation]
          */
-        fun getAll(moduleNames: Collection<String>, clientLocation: ClientLocation): List<ElmModuleDeclaration> {
-            val elmProject = clientLocation.elmProject ?: return emptyList()
-            val allModules = rawGetAll(moduleNames, clientLocation.intellijProject)
-            return allModules.filter { elmProject.exposes(it, clientLocation) }
-        }
+        fun getAll(moduleNames: Collection<String>, clientLocation: ClientLocation): List<ElmModuleDeclaration> =
+                rawGetAll(moduleNames, clientLocation.intellijProject, clientLocation.searchScope())
 
 
         // INTERNALS
@@ -82,27 +73,23 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
 
 
         /**
-         * Returns all module declarations with name [moduleName]
+         * Returns all module declarations within [scope] with name [moduleName]
          */
-        private fun rawGet(moduleName: String, project: Project): List<ElmModuleDeclaration> {
+        private fun rawGet(moduleName: String, project: Project, scope: GlobalSearchScope): List<ElmModuleDeclaration> {
             val key = makeKey(moduleName)
-            return StubIndex.getElements(KEY, key, project,
-                    GlobalSearchScope.allScope(project),
-                    ElmModuleDeclaration::class.java).toList()
+            return StubIndex.getElements(KEY, key, project, scope, ElmModuleDeclaration::class.java).toList()
         }
 
 
         /**
-         * Returns all module declarations in [project] whose module name
-         * matches an item in [moduleNames]
+         * Returns all module declarations within [scope] whose module name matches an item in [moduleNames]
          */
-        private fun rawGetAll(moduleNames: Collection<String>, project: Project): List<ElmModuleDeclaration> {
+        private fun rawGetAll(moduleNames: Collection<String>, project: Project, scope: GlobalSearchScope): List<ElmModuleDeclaration> {
             val index = StubIndex.getInstance()
             val results = mutableListOf<ElmModuleDeclaration>()
 
             for (key in moduleNames) {
-                index.processElements(KEY, key, project, GlobalSearchScope.allScope(project),
-                        ElmModuleDeclaration::class.java) {
+                index.processElements(KEY, key, project, scope, ElmModuleDeclaration::class.java) {
                     results.add(it)
                 }
             }
@@ -111,59 +98,10 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
 
 
         /**
-         * Returns all module declarations in [project]
+         * Returns all module declarations within [scope]
          */
-        private fun rawGetAll(project: Project): List<ElmModuleDeclaration> {
-            return rawGetAll(StubIndex.getInstance().getAllKeys(KEY, project), project)
-        }
+        private fun rawGetAll(project: Project, scope: GlobalSearchScope): List<ElmModuleDeclaration> =
+                rawGetAll(StubIndex.getInstance().getAllKeys(KEY, project), project, scope)
 
     }
-}
-
-/**
- * Returns true if [moduleDeclaration] is visible within the receiver [ElmProject].
- */
-private fun ElmProject.exposes(moduleDeclaration: ElmModuleDeclaration, clientLocation: ClientLocation): Boolean {
-
-    val includeTestModules = clientLocation.isInTestsDirectory && !isElm18
-
-    // Check if the module is reachable from this project's source directories.
-    if (sourceDirectoryContains(moduleDeclaration, includeTestModules))
-        return true
-
-
-    // Check if the module is reachable from this project's dependencies
-    return dependenciesVisibleAt(clientLocation)
-            .filter { it.exposedModules.contains(moduleDeclaration.name) }
-            .any { it.sourceDirectoryContains(moduleDeclaration, includeTestDirectory = false) }
-}
-
-
-/**
- * Returns true if [moduleDeclaration] can be found in the receiver's source directories.
- */
-private fun ElmProject.sourceDirectoryContains(moduleDeclaration: ElmModuleDeclaration, includeTestDirectory: Boolean): Boolean {
-
-    val moduleDeclProject = moduleDeclaration.elmProject
-            ?: return false
-
-    val candidateSrcDirs = if (moduleDeclProject.manifestPath == manifestPath) {
-        // They belong to the same Elm project, all source dirs are candidates
-        absoluteSourceDirectories
-    } else {
-        // The module declaration does not belong to this Elm project.
-        //
-        // Normally this means that there's no match, but it is possible
-        // to have 2 Elm projects that share one-or-more source directories.
-        // There is no guarantee that they are mutually exclusive.
-        //
-        // The only valid candidates are those that are shared between the 2 projects.
-        sharedSourceDirs(moduleDeclProject)
-    }
-
-    val extraDirs = if (includeTestDirectory) listOf(testsDirPath) else emptyList()
-    val elmModuleRelativePath = moduleDeclaration.name.replace('.', '/') + ".elm"
-    return (candidateSrcDirs + extraDirs)
-            .mapNotNull { findFileByPathTestAware(it.resolve(elmModuleRelativePath)) }
-            .isNotEmpty()
 }

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmNamedElementIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmNamedElementIndex.kt
@@ -7,8 +7,15 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.stubs.ElmFileStub
-import org.elm.lang.core.types.moduleName
 
+/**
+ * An index of all Elm named things across the entire IntelliJ project.
+ *
+ * IMPORTANT: See [ElmLookup] for an alternative API that properly
+ * handles visibility of named things based on the Elm project which
+ * wants to access it.
+ *
+ */
 class ElmNamedElementIndex : StringStubIndexExtension<ElmNamedElement>() {
 
     override fun getVersion() =
@@ -32,15 +39,5 @@ class ElmNamedElementIndex : StringStubIndexExtension<ElmNamedElement>() {
          */
         fun getAllNames(project: Project): Collection<String> =
                 StubIndex.getInstance().getAllKeys(KEY, project)
-
-        /** Find the named element with [name] declared in [module] */
-        inline fun <reified T : ElmNamedElement> findElement(
-                name: String,
-                module: String,
-                project: Project,
-                scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
-        ): T? = find(name, project, scope)
-                .filterIsInstance<T>()
-                .find { it.moduleName == module }
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -8,13 +8,11 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import com.intellij.openapi.vfs.LocalFileSystem
-import org.elm.lang.core.psi.ClientLocation
+import org.elm.lang.core.lookup.ClientLocation
 import org.elm.workspace.ElmToolchain.Companion.ELM_LEGACY_JSON
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
-import java.nio.file.Files
-import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -65,6 +63,13 @@ sealed class ElmProject(
     val absoluteSourceDirectories: List<Path>
         get() = sourceDirectories.map { projectDirPath.resolve(it).normalize() }
 
+    val allSourceDirs: Sequence<Path>
+        get() = absoluteSourceDirectories.asSequence() + sequenceOf(testsDirPath)
+
+    fun sourceDirsVisibleAt(clientLocation: ClientLocation): Sequence<Path> =
+            if (clientLocation.isInTestsDirectory) allSourceDirs
+            else absoluteSourceDirectories.asSequence()
+
     /**
      * Returns all packages which this project depends on, whether it be for normal,
      * production code or for tests.
@@ -76,25 +81,8 @@ sealed class ElmProject(
      * Returns the packages which this project depends that are visible from the given [clientLocation].
      */
     fun dependenciesVisibleAt(clientLocation: ClientLocation): Sequence<ElmPackageProject> =
-            if (clientLocation.isInTestsDirectory) allResolvedDependencies else dependencies.asSequence()
-
-    /**
-     * Returns the absolute path of each source directory which is shared between the
-     * receiver and [otherProject].
-     */
-    fun sharedSourceDirs(otherProject: ElmProject): List<Path> {
-        val paths = mutableListOf<Path>()
-        for (a in absoluteSourceDirectories) {
-            for (b in otherProject.absoluteSourceDirectories) {
-                try {
-                    if (Files.isSameFile(a, b)) paths.add(a)
-                } catch (e: NoSuchFileException) {
-                    // ignore
-                }
-            }
-        }
-        return paths
-    }
+            if (clientLocation.isInTestsDirectory) allResolvedDependencies
+            else dependencies.asSequence()
 
     val isElm18: Boolean
         get() = when (this) {
@@ -217,7 +205,9 @@ class ElmApplicationProject(
         dependencies: List<ElmPackageProject>,
         testDependencies: List<ElmPackageProject>,
         sourceDirectories: List<Path>
-) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories) {
+
+}
 
 
 /**
@@ -232,7 +222,9 @@ class ElmPackageProject(
         val name: String,
         val version: Version,
         val exposedModules: List<String>
-) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories) {
+
+}
 
 
 private fun ExactDependenciesDTO.depsToPackages(toolchain: ElmToolchain) =

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -205,9 +205,7 @@ class ElmApplicationProject(
         dependencies: List<ElmPackageProject>,
         testDependencies: List<ElmPackageProject>,
         sourceDirectories: List<Path>
-) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories) {
-
-}
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
 
 
 /**
@@ -222,9 +220,7 @@ class ElmPackageProject(
         val name: String,
         val version: Version,
         val exposedModules: List<String>
-) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories) {
-
-}
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
 
 
 private fun ExactDependenciesDTO.depsToPackages(toolchain: ElmToolchain) =

--- a/src/test/kotlin/org/elm/TestClientLocation.kt
+++ b/src/test/kotlin/org/elm/TestClientLocation.kt
@@ -1,7 +1,7 @@
 package org.elm
 
 import com.intellij.openapi.project.Project
-import org.elm.lang.core.psi.ClientLocation
+import org.elm.lang.core.lookup.ClientLocation
 import org.elm.workspace.ElmProject
 
 /**

--- a/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
@@ -1,0 +1,108 @@
+package org.elm.lang.core.lookup
+
+import org.elm.TestClientLocation
+import org.elm.lang.core.psi.ElmNamedElement
+import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
+import org.elm.lang.core.types.moduleName
+import org.elm.workspace.CustomElmStdlibVariant
+import org.elm.workspace.ElmWorkspaceTestBase
+import org.elm.workspace.Version
+import org.elm.workspace.elmWorkspace
+import org.intellij.lang.annotations.Language
+
+
+class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
+
+    @Language("JSON")
+    private val standardElmAppProject = """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent()
+
+
+    fun `test find by name`() {
+        buildProject {
+            project("elm.json", standardElmAppProject)
+            dir("src") {
+                elm("Foo.elm", """
+                    type alias Foo = ()
+                """.trimIndent())
+            }
+        }
+        check(lookup<ElmTypeAliasDeclaration>("Foo").isNotEmpty())
+    }
+
+
+    fun `test find by name excludes things outside of the Elm project`() {
+        buildProject {
+            project("elm.json", standardElmAppProject)
+            dir("alien") {
+                elm("Bar.elm", """
+                    type alias Bar = ()
+                """.trimIndent())
+            }
+        }
+        check(lookup("Bar").isEmpty())
+    }
+
+
+    fun `test find by name excludes things which are part of unexposed modules in a package`() {
+
+        ensureElmStdlibInstalled(CustomElmStdlibVariant(mapOf("elm/parser" to Version(1, 0, 0))))
+
+        buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {
+                        "elm/parser": "1.0.0"
+                    },
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {}
+        }
+        /*
+         * elm/parser v1.0.0 includes 2 modules: "Parser" and "Parser.Advanced". However,
+         * "Parser.Advanced" is not exposed by the package's `elm.json` manifest. It is important
+         * that lookup only returns results belonging to exposed modules. In this case, both
+         * modules define a function named "chompWhile". But lookup should only find the type that is
+         * in the exposed module, "Parser".
+        */
+        check(lookup("chompWhile").single().moduleName == "Parser")
+    }
+
+
+    private fun lookup(name: String): Collection<ElmNamedElement> {
+        val elmProject = project.elmWorkspace.allProjects.single()
+        val clientLocation = TestClientLocation(project, elmProject)
+        return ElmLookup.findByName(name, clientLocation)
+    }
+
+    @JvmName("lookupWithType")
+    private inline fun <reified T : ElmNamedElement> lookup(name: String): Collection<T> =
+            lookup(name).filterIsInstance<T>()
+}

--- a/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
@@ -89,9 +89,9 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
          * elm/parser v1.0.0 includes 2 modules: "Parser" and "Parser.Advanced". However,
          * "Parser.Advanced" is not exposed by the package's `elm.json` manifest. It is important
          * that lookup only returns results belonging to exposed modules. In this case, both
-         * modules define a function named "chompWhile". But lookup should only find the type that is
-         * in the exposed module, "Parser".
-        */
+         * modules define a function named "chompWhile". But lookup should only find the function
+         * that is in the exposed module, "Parser".
+         */
         check(lookup("chompWhile").single().moduleName == "Parser")
     }
 


### PR DESCRIPTION
This overhauls how Elm module visibility works for both `ElmNamedElementIndex` and `ElmModulesIndex`. Previously we only took into consideration module visibility when querying `ElmModulesIndex` which led to bugs in the `MissingCaseBranchAdder`. Now we have a consolidated way of doing it by constructing a `GlobalSearchScope` based on `ClientLocation`. 

Bonus: the new way is a lot easier to understand than the old way.

Fixes #229 
Fixes #212 