### PR TITLE
Improve record completion in functions with syntax errors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
         classpath "com.github.JetBrains:gradle-grammar-kit-plugin:2018.1.7"
     }
 }
@@ -29,7 +29,7 @@ repositories {
     maven { url 'http://dl.bintray.com/jetbrains/markdown' }
 }
 
-ext.kotlinVersion = '1.3.11'
+ext.kotlinVersion = '1.3.20'
 ext.junitVersion = '4.12'
 ext.jacksonVersion = '2.9.6'
 ext.markdownVersion = '0.1.31'

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordFieldSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordFieldSuggestor.kt
@@ -3,9 +3,15 @@ package org.elm.lang.core.completion
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
-import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ELM_IDENTIFIERS
+import org.elm.lang.core.psi.ElmFieldAccessTargetTag
+import org.elm.lang.core.psi.elementType
 import org.elm.lang.core.psi.elements.ElmFieldAccessExpr
-import org.elm.lang.core.types.*
+import org.elm.lang.core.psi.elements.ElmValueExpr
+import org.elm.lang.core.types.Ty
+import org.elm.lang.core.types.TyRecord
+import org.elm.lang.core.types.findTy
+import org.elm.lang.core.types.renderedText
 
 object ElmRecordFieldSuggestor : Suggestor {
 
@@ -17,13 +23,31 @@ object ElmRecordFieldSuggestor : Suggestor {
             // Infer the type of the record whose fields are being accessed
             // and suggest that record's fields as completion results.
 
-            val ty = parent.targetExpr.findTy() as? TyRecord ?: return
+            val targetExpr = parent.targetExpr
+            val ty = targetExpr.findTy() as? TyRecord ?: resolveTarget(targetExpr) ?: return
 
             // provide each field as a completion result
             ty.fields.forEach { fieldName, fieldTy ->
                 result.add(fieldName, fieldTy)
             }
         }
+    }
+
+    /**
+     * In partial programs, a function body might not be inferred. But it's common to complete
+     * fields on parameters, and in many cases the function's parameters are still inferred even if
+     * the body isn't.
+     */
+    private fun resolveTarget(targetExpr: ElmFieldAccessTargetTag): TyRecord? {
+        if (targetExpr is ElmValueExpr) {
+            val ref = targetExpr.reference.resolve() ?: return null
+            return ref.findTy() as? TyRecord
+        } else if (targetExpr is ElmFieldAccessExpr) {
+            val field = targetExpr.lowerCaseIdentifier?.text ?: return null
+            val base = resolveTarget(targetExpr.targetExpr) ?: return null
+            return base.fields[field] as? TyRecord
+        }
+        return null
     }
 }
 

--- a/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
@@ -59,3 +59,6 @@ interface ElmExposedItemTag : ElmPsiElement
 
 /** A named declaration which can be exposed by a module */
 interface ElmExposableTag : ElmPsiElement, ElmNameIdentifierOwner
+
+/** The element on the left side of the `=` in a value declaration */
+interface ElmValueAssigneeTag : ElmPsiElement

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
@@ -4,8 +4,15 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
-import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ElmExposableTag
+import org.elm.lang.core.psi.ElmFunctionParamTag
+import org.elm.lang.core.psi.ElmNameDeclarationPatternTag
+import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
+import org.elm.lang.core.psi.ElmValueAssigneeTag
+import org.elm.lang.core.psi.IdentifierCase
+import org.elm.lang.core.psi.directChildren
+import org.elm.lang.core.psi.isTopLevel
 import org.elm.lang.core.stubs.ElmFunctionDeclarationLeftStub
 
 
@@ -25,7 +32,7 @@ import org.elm.lang.core.stubs.ElmFunctionDeclarationLeftStub
  *      foo = 42
  *  in ...`
  */
-class ElmFunctionDeclarationLeft : ElmStubbedNamedElementImpl<ElmFunctionDeclarationLeftStub>, ElmExposableTag {
+class ElmFunctionDeclarationLeft : ElmStubbedNamedElementImpl<ElmFunctionDeclarationLeftStub>, ElmExposableTag, ElmValueAssigneeTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.LOWER)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
@@ -8,6 +8,7 @@ import org.elm.lang.core.psi.ElmExposableTag
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
 import org.elm.lang.core.psi.ElmTypes.OPERATOR_IDENTIFIER
+import org.elm.lang.core.psi.ElmValueAssigneeTag
 import org.elm.lang.core.psi.IdentifierCase
 import org.elm.lang.core.stubs.ElmOperatorDeclarationLeftStub
 
@@ -20,7 +21,7 @@ import org.elm.lang.core.stubs.ElmOperatorDeclarationLeftStub
  *
  * @see [ElmFunctionDeclarationLeft]
  */
-class ElmOperatorDeclarationLeft : ElmStubbedNamedElementImpl<ElmOperatorDeclarationLeftStub>, ElmExposableTag {
+class ElmOperatorDeclarationLeft : ElmStubbedNamedElementImpl<ElmOperatorDeclarationLeftStub>, ElmExposableTag, ElmValueAssigneeTag {
 
     constructor(node: ASTNode) :
             super(node, IdentifierCase.OPERATOR)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmPattern.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmPattern.kt
@@ -1,10 +1,14 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
-import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ElmFunctionParamTag
+import org.elm.lang.core.psi.ElmPatternChildTag
+import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.ElmUnionPatternChildTag
+import org.elm.lang.core.psi.ElmValueAssigneeTag
 
 
-class ElmPattern(node: ASTNode) : ElmPsiElementImpl(node), ElmFunctionParamTag, ElmPatternChildTag, ElmUnionPatternChildTag {
+class ElmPattern(node: ASTNode) : ElmPsiElementImpl(node), ElmFunctionParamTag, ElmPatternChildTag, ElmUnionPatternChildTag, ElmValueAssigneeTag {
 
     /**
      * The actual type of this pattern.

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -48,6 +48,9 @@ class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub>, ElmDocTa
     val pattern: ElmPattern?
         get() = findChildByClass(ElmPattern::class.java)
 
+    /** The element on the left-hand side of the `=` */
+    val assignee: ElmValueAssigneeTag?
+        get() = PsiTreeUtil.getStubChildOfType(this, ElmValueAssigneeTag::class.java) ?: pattern
 
     /**
      * The 'body' of the declaration. This is the right-hand side which is bound

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordCompletionTest.kt
@@ -2,7 +2,6 @@ package org.elm.lang.core.completion
 
 class ElmRecordCompletionTest : ElmCompletionTestBase() {
 
-
     fun `test access name field from one letter`() = doSingleCompletion(
             """
 type alias Foo = { name : String }
@@ -46,4 +45,69 @@ f foo =
     foo.name.first{-caret-}
 """)
 
+    // partial program tests
+
+    fun `test incomplete case expression`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo -> String
+f r =
+    case r.{-caret-}
+""", """
+type alias Foo = { name : String }
+
+f : Foo -> String
+f r =
+    case r.name{-caret-}
+""")
+
+    fun `test unresolved reference`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo -> String
+f r =
+    foo r.{-caret-}
+""", """
+type alias Foo = { name : String }
+
+f : Foo -> String
+f r =
+    foo r.name{-caret-}
+""")
+
+    fun `test too many arguments`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo -> Int
+f r = 1
+
+g : Foo -> Int
+g r = f 1 r.{-caret-}
+""", """
+type alias Foo = { name : String }
+
+f : Foo -> Int
+f r = 1
+
+g : Foo -> Int
+g r = f 1 r.name{-caret-}
+""")
+
+    fun `test incomplete case expression with chained access`() = doSingleCompletion(
+            """
+type alias Foo = { name : { first: String } }
+
+f : Foo -> String
+f r =
+    case r.name.fir{-caret-}
+""", """
+type alias Foo = { name : { first: String } }
+
+f : Foo -> String
+f r =
+    case r.name.first{-caret-}
+""")
 }


### PR DESCRIPTION
In the large majority of cases when trying to complete record fields, the target is a simple value reference, usually to a function parameter. If we resolve that reference, it often resolves to an element for which we can infer the type. In the case of chained field access, we can resolve the base type and walk the `TyRecord` to get the final field ty.

We now bind function parameters as long as there are no syntax errors in the parameters themselves, even if there are errors in the function body.


Fixes #238
