### PR TITLE
Fix false positive type error in referenced pattern declarations

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -112,7 +112,7 @@ private class InferenceScope(
             requireAssignable(errorExpr, bodyTy, expected)
         }
 
-        val ty = if (declaredTy === TyUnknown()) bodyTy else declaredTy
+        val ty = if (declaredTy is TyUnknown) bodyTy else declaredTy
         return InferenceResult(expressionTypes, diagnostics, ty)
     }
 

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -94,6 +94,13 @@ main : () -> Foo
 main a = <error descr="Type mismatch.Required: FooFound: Float">1.0</error>
 """)
 
+    fun `test mismatched value type from function without annotation`() = checkByText("""
+foo = ()
+main : String
+main = <error descr="Type mismatch.Required: StringFound: ()">foo</error>
+""")
+
+
     fun `test correct value type from record`() = checkByText("""
 main : {x: (), y: ()}
 main = {x = (), y = ()}

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -537,7 +537,7 @@ main : Foo -> ()
 main {bar} = <error descr="Type mismatch.Required: ()Found: Int">bar</error>
 """)
 
-    // issue #122
+    // https://github.com/klazuka/intellij-elm/issues/122
     fun `test matched record pattern from extension alias`() = checkByText("""
 type alias Foo a = { a | foo : ()}
 type alias Bar = { bar : () }
@@ -581,7 +581,7 @@ main =
         foo
 """)
 
-    // issue #153
+    // https://github.com/klazuka/intellij-elm/issues/153
     fun `test let-in with tuple with too small arity`() = checkByText("""
 main : ()
 main =
@@ -754,7 +754,7 @@ main : ()
 <error descr="Infinite recursion">main = main</error>
 """)
 
-    // Issue #142
+    // #https://github.com/klazuka/intellij-elm/issues/142
     // this tests for infinite recursion; the diagnostic is tested in TypeDeclarationInspectionTest
     fun `test bad self-recursion in type alias`() = checkByText("""
 type alias A = A
@@ -828,7 +828,7 @@ main =
         _ -> ()
 """)
 
-    // issue #113
+    // https://github.com/klazuka/intellij-elm/issues/113
     fun `test case branches with union value call`() = checkByText("""
 foo : Maybe (List a)
 foo = Nothing
@@ -839,7 +839,7 @@ main =
        _ -> ()
 """)
 
-    // issue #113
+    // https://github.com/klazuka/intellij-elm/issues/113
     fun `test field access on field subset`() = checkByText("""
 type alias Subset a =
     { a | extra : () }
@@ -967,6 +967,31 @@ foo = b
 bar : ()
 bar = x
 """)
+
+    // https://github.com/klazuka/intellij-elm/issues/247
+    fun `test nested destructuring`() = checkByText("""
+main : ()
+main =
+    let
+        (a, b) =
+            let
+                (c, d) = ("", "")
+            in
+                (c, d)
+    in
+        <error descr="Type mismatch.Required: ()Found: String">a</error>
+""")
+
+    fun `test forward reference to destructured pattern`() = checkByText("""
+main : ()
+main =
+    let
+        a = b
+        (b, c) = ("", "")
+    in
+       <error descr="Type mismatch.Required: ()Found: String">a</error>
+""")
+
 
     fun `test nested forward references`() = checkByText("""
 main : () -> ()


### PR DESCRIPTION
This was a tricky one. There were several behaviors that came together to produce this false positive.

1. Like all unannotated declarations, the `InferenceResult.ty` for pattern declarations is the ty of the declaration body. This type isn't useful for pattern declarations, but it's never used, so that's fine.
2. Except it _was_ used. This was the first bug. When inferring the type of a reference to a name bound in a pattern declaration, we returning the type of the entire declaration, rather than the bound parameter.
3. `InferenceScope` has a local cache of `resolvedDeclarations` to avoid repeating work of inferring nested declarations. We don't use the `CachedValuesManager` for nested declarations because, unlike top level declarations, they can close over bound function parameters. Caching is also important because, although inference itself is idempotent, we store its generated diagnostics, and we don't want to generate duplicate diagnostics.
4. When we infer a nested pattern declaration, we save the bound names in the `bindings` map in the current scope. This allows us to look up the bound names when they're reference. 
5. In order to bind a pattern declaration, we need to know the type of its body. This is the opposite of function declarations, in which we need to know the parameter types in order to infer the body.
6. The second bug: We used the same code path for all value declarations, checking that the body matches the annotation. This meant that for pattern declarations, the body was inferred twice. This only caused a problem because, when inferring a nested scope, `resolvedDeclarations` is copied from the parent, but `bindings` is not (since child scopes can shadow names). So looking up a bound pattern the _second_ time we inferred the body would fail. The declaration was already cached, so we didn't infer it again, but that meant that we didn't bind the pattern names.
7. These two bugs were almost always hidden by bug 3:  When `TyUnknown` was changed from an object to a class, I didn't change the last line of `beginDeclarationInference`, which was still comparing it by equality, resulting in all declarations without annotations being inferred as unknown.

Fixes #247