### PR TITLE
Cache the ElmProject SearchScope

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/lookup/ClientLocation.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ClientLocation.kt
@@ -1,12 +1,6 @@
 package org.elm.lang.core.lookup
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.search.GlobalSearchScopesCore
-import org.elm.lang.core.psi.elements.ElmModuleDeclaration
-import org.elm.openapiext.findFileByPathTestAware
-import org.elm.workspace.ElmPackageProject
 import org.elm.workspace.ElmProject
 
 /**
@@ -27,36 +21,4 @@ interface ClientLocation {
     val intellijProject: Project
     val elmProject: ElmProject?
     val isInTestsDirectory: Boolean
-
-
-    /**
-     * Returns a [GlobalSearchScope] which includes all Elm files that belong to [elmProject]
-     * taking into consideration:
-     *
-     *  - which source roots the [ElmProject] defines
-     *  - which packages are visible from the client location's [ElmProject]
-     *  - whether "test" code (and dependencies) should be included
-     */
-    fun searchScope(): GlobalSearchScope {
-        val p = elmProject ?: return GlobalSearchScope.EMPTY_SCOPE
-
-        val sourceDirs = p.sourceDirsVisibleAt(this).mapNotNull { findFileByPathTestAware(it) }.toList()
-        val srcDirScope = GlobalSearchScopesCore.directoriesScope(intellijProject, true, *(sourceDirs.toTypedArray()))
-
-        val exposedDependencyFiles = p.dependenciesVisibleAt(this).flatMap { it.exposedFiles() }.toList()
-        val dependenciesScope = GlobalSearchScope.filesWithLibrariesScope(intellijProject, exposedDependencyFiles)
-
-        return srcDirScope.uniteWith(dependenciesScope)
-    }
 }
-
-/**
- * Return the [VirtualFile] for each Elm module which is exposed by this package.
- */
-private fun ElmPackageProject.exposedFiles(): Sequence<VirtualFile> =
-        exposedModules.mapNotNull { moduleName ->
-            val elmModuleRelativePath = moduleName.replace('.', '/') + ".elm"
-            absoluteSourceDirectories.mapNotNull { srcDirPath ->
-                findFileByPathTestAware(srcDirPath.resolve(elmModuleRelativePath))
-            }.firstOrNull()
-        }.asSequence()

--- a/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
@@ -1,9 +1,21 @@
 package org.elm.lang.core.lookup
 
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.GlobalSearchScopesCore
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.stubs.index.ElmNamedElementIndex
 import org.elm.lang.core.types.moduleName
+import org.elm.openapiext.findFileByPathTestAware
+import org.elm.workspace.ElmPackageProject
+import org.elm.workspace.ElmProject
+import org.elm.workspace.elmWorkspace
 
 /**
  * Like [ElmNamedElementIndex] but takes context into account. Given that a single
@@ -14,6 +26,13 @@ object ElmLookup {
 
     val log = logger<ElmLookup>()
 
+    private val projectCacheKey =
+            Key.create<CachedValue<GlobalSearchScope>>("ELM_PROJECT_SEARCH_SCOPE_KEY")
+
+    private val projectAndLibrariesCacheKey =
+            Key.create<CachedValue<GlobalSearchScope>>("ELM_PROJECT_SEARCH_SCOPE_KEY_WITH_TESTS")
+
+
     /** Find the named element with [name] which is visible to [clientLocation] */
     inline fun <reified T : ElmNamedElement> findByName(
             name: String,
@@ -23,7 +42,7 @@ object ElmLookup {
             if (log.isDebugEnabled) log.debug("Cannot lookup '$name' when Elm project context is unknown")
             return emptyList()
         }
-        return ElmNamedElementIndex.find(name, clientLocation.intellijProject, clientLocation.searchScope())
+        return ElmNamedElementIndex.find(name, clientLocation.intellijProject, ElmLookup.searchScopeAt(clientLocation))
                 .filterIsInstance<T>()
     }
 
@@ -36,4 +55,76 @@ object ElmLookup {
     ): T? =
             findByName<T>(name, clientLocation)
                     .find { it.moduleName == module }
+
+
+    /**
+     * Returns a [GlobalSearchScope] which includes all Elm files that belong to [elmProject]
+     * taking into consideration:
+     *
+     *  - which source roots the [ElmProject] defines
+     *  - which packages are visible from the client location's [ElmProject]
+     *  - whether "test" code (and dependencies) should be included
+     */
+    fun searchScopeAt(loc: ClientLocation): GlobalSearchScope {
+        val elmProject = loc.elmProject ?: return GlobalSearchScope.EMPTY_SCOPE
+
+        /*
+        Build (and cache) the search scope based on the ClientLocation.
+
+        The cache will be invalidated whenever the Elm workspace changes
+        (e.g. the user modifies an `elm.json` file)
+
+        You might be wondering why we don't just construct the search scope when
+        initializing the ElmProject value itself and store it in a property?
+        I don't want to do that because it would start to bring things like
+        VirtualFile into ElmProject. VirtualFile has multi-threading restrictions
+        (http://www.jetbrains.org/intellij/sdk/docs/basics/virtual_file_system.html)
+        that I'd rather not worry about when loading Elm projects on a background
+        thread. Maybe it'd be fine, but until I understand things better, I'm going
+        to keep them separated.
+        */
+
+        // We cannot close over the ClientLocation in the CachedValueProvider, so extract everything now.
+        val isInTestsDirectory = loc.isInTestsDirectory
+        val project = loc.intellijProject
+
+        val cacheKey = if (loc.isInTestsDirectory) projectAndLibrariesCacheKey else projectCacheKey
+        val manager = CachedValuesManager.getManager(project)
+        return manager.getCachedValue(elmProject, cacheKey, {
+            val scope = buildSearchScope(isInTestsDirectory, elmProject, project)
+            CachedValueProvider.Result.create(scope, project.elmWorkspace.changeTracker)
+        }, false)
+    }
 }
+
+
+private fun buildSearchScope(includeTests: Boolean, p: ElmProject, intellijProject: Project): GlobalSearchScope {
+    /*
+     *  NOTE: if the inputs to this function change (e.g. adding a parameter),
+     *        you must take that into account when retrieving the cached value.
+     */
+    val (srcDirPaths, dependencies) = if (includeTests)
+        Pair(p.allSourceDirs, p.allResolvedDependencies)
+    else
+        Pair(p.absoluteSourceDirectories.asSequence(), p.dependencies.asSequence())
+
+    val srcDirs = srcDirPaths.mapNotNull { findFileByPathTestAware(it) }.toList()
+    val srcDirScope = GlobalSearchScopesCore.directoriesScope(intellijProject, true, *(srcDirs.toTypedArray()))
+
+    val exposedDependencyFiles = dependencies.flatMap { it.exposedFiles() }.toList()
+    val dependenciesScope = GlobalSearchScope.filesWithLibrariesScope(intellijProject, exposedDependencyFiles)
+
+    return srcDirScope.uniteWith(dependenciesScope)
+}
+
+
+/**
+ * Return the [VirtualFile] for each Elm module which is exposed by this package.
+ */
+private fun ElmPackageProject.exposedFiles(): Sequence<VirtualFile> =
+        exposedModules.mapNotNull { moduleName ->
+            val elmModuleRelativePath = moduleName.replace('.', '/') + ".elm"
+            absoluteSourceDirectories.mapNotNull { srcDirPath ->
+                findFileByPathTestAware(srcDirPath.resolve(elmModuleRelativePath))
+            }.firstOrNull()
+        }.asSequence()

--- a/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/index/ElmModulesIndex.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import org.elm.lang.core.lookup.ClientLocation
+import org.elm.lang.core.lookup.ElmLookup
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
 import org.elm.lang.core.stubs.ElmFileStub
 import org.elm.lang.core.stubs.ElmModuleDeclarationStub
@@ -36,7 +37,7 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
          * Returns an Elm module named [moduleName] which is visible to [clientLocation], if any
          */
         fun get(moduleName: String, clientLocation: ClientLocation): ElmModuleDeclaration? =
-                rawGet(moduleName, clientLocation.intellijProject, clientLocation.searchScope())
+                rawGet(moduleName, clientLocation.intellijProject, ElmLookup.searchScopeAt(clientLocation))
                         .firstOrNull()
 
 
@@ -44,14 +45,14 @@ class ElmModulesIndex : StringStubIndexExtension<ElmModuleDeclaration>() {
          * Returns all Elm modules which are visible to [clientLocation]
          */
         fun getAll(clientLocation: ClientLocation): List<ElmModuleDeclaration> =
-                rawGetAll(clientLocation.intellijProject, clientLocation.searchScope())
+                rawGetAll(clientLocation.intellijProject, ElmLookup.searchScopeAt(clientLocation))
 
 
         /**
          * Returns all Elm modules whose names match an element in [moduleNames] and which are visible to [clientLocation]
          */
         fun getAll(moduleNames: Collection<String>, clientLocation: ClientLocation): List<ElmModuleDeclaration> =
-                rawGetAll(moduleNames, clientLocation.intellijProject, clientLocation.searchScope())
+                rawGetAll(moduleNames, clientLocation.intellijProject, ElmLookup.searchScopeAt(clientLocation))
 
 
         // INTERNALS

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.util.EmptyRunnable
+import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.util.Consumer
@@ -69,8 +70,17 @@ class ElmWorkspaceService(
         }
     }
 
+    /**
+     * Increments whenever the workspace and/or settings change.
+     *
+     * This is provided as an alternative to listening to the message bus for changes.
+     * You should use either one or the other, depending on your situation.
+     */
+    val changeTracker = SimpleModificationTracker()
+
 
     // SETTINGS AND TOOLCHAIN
+
 
     /* A nice view of the settings to the outside world */
     data class Settings(val toolchain: ElmToolchain?)
@@ -370,6 +380,7 @@ class ElmWorkspaceService(
 
     private fun notifyDidChangeWorkspace() {
         if (intellijProject.isDisposed) return
+        changeTracker.incModificationCount()
         ApplicationManager.getApplication().invokeAndWait {
             runWriteAction {
                 ProjectRootManagerEx.getInstanceEx(intellijProject)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -182,8 +182,7 @@
 
 
         <!-- ELM PROJECTS, PACKAGES AND DEPENDENCIES -->
-        <projectService serviceInterface="org.elm.workspace.ElmWorkspaceService"
-                        serviceImplementation="org.elm.workspace.ElmWorkspaceService"/>
+        <projectService serviceImplementation="org.elm.workspace.ElmWorkspaceService"/>
         <additionalLibraryRootsProvider implementation="org.elm.workspace.ElmAdditionalLibraryRootsProvider"/>
         <projectConfigurable instance="org.elm.workspace.ui.ElmWorkspaceConfigurable" displayName="Elm"
                              groupId="language"/>


### PR DESCRIPTION
We were constructing this `ElmProject`-specific search scope value a lot, and it was dominating the CPU profiler traces. Now we cache 2 flavors of the search scope for each Elm project: 

1. just the project files
2. the project files plus the "tests" directory as well as the "test-dependencies".

Fixes #246 