### PR TITLE
Unify type variables in function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@ The plugin can perform type inference on arbitrary expressions in your program. 
 
 The plugin also performs type checking, marking incompatible types in red.
 
-There are 2 limitations to the type system as currently implemented:
-
-1. it does not work if a function is missing a type annotation (typically not a problem)
-2. it does not work if type variables (such as `List a` or `Maybe a` are involved)
-
-We hope to remove the type variable limitation in the future.
+The current implementation of the type system does not infer the types of parameters of unannotated
+functions, but this limitation will be removed in the future.
 
 
 # Creating a new Elm project

--- a/src/main/kotlin/org/elm/lang/core/diagnostics/ElmDiagnostic.kt
+++ b/src/main/kotlin/org/elm/lang/core/diagnostics/ElmDiagnostic.kt
@@ -116,19 +116,6 @@ class TypeMismatchError(
     }
 }
 
-class RecordBaseTypeError(
-        element: PsiElement,
-        private val actual: Ty
-) : ElmDiagnostic(element, null) {
-    override val message: String
-        get() {
-            return "Type mismatch." +
-                    "<br>Required: record" +
-                    "<br>Found: ${actual.renderedText(false, false)}"
-        }
-
-}
-
 class TypeArgumentCountError(
         element: PsiElement,
         private val actual: Int,

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -23,8 +23,18 @@ sealed class Ty {
 class TyVar(val name: String) : Ty() {
     override val alias: AliasInfo? get() = null
     override fun withAlias(alias: AliasInfo): TyVar = this
-
     override fun toString(): String = "<TyVar $name>"
+}
+
+/**
+ * An implicit ("flexible") type variable (i.e. the type of parameters in unannotated functions)
+ *
+ * These types must be unified.
+ */
+data class TyInfer(val name: String) : Ty() {
+    override val alias: AliasInfo? get() = null
+    override fun withAlias(alias: AliasInfo): TyInfer = this
+    override fun toString(): String = "<TyInfer $name>"
 }
 
 /** A tuple type like `(Int, String)` */

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -107,6 +107,7 @@ data class TyFunction(
         else -> ret
     }
 
+
     override fun withAlias(alias: AliasInfo): TyFunction = copy(alias = alias)
 
     override fun toString(): String {

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -23,7 +23,7 @@ sealed class Ty {
 class TyVar(val name: String) : Ty() {
     override val alias: AliasInfo? get() = null
     override fun withAlias(alias: AliasInfo): TyVar = this
-    override fun toString(): String = "<TyVar $name>"
+    override fun toString(): String = "<$name>"
 }
 
 /** A tuple type like `(Int, String)` */
@@ -52,6 +52,9 @@ data class TyRecord(
     val isSubset: Boolean get() = baseTy != null
 
     override fun withAlias(alias: AliasInfo): TyRecord = copy(alias = alias)
+    override fun toString(): String {
+        return alias?.let { "{${it.name}}" } ?: baseTy?.let { "{$baseTy | $fields}" } ?: "{$fields}"
+    }
 }
 
 /** A type like `String` or `Maybe a` */
@@ -64,7 +67,7 @@ data class TyUnion(
     override fun withAlias(alias: AliasInfo): TyUnion = copy(alias = alias)
 
     override fun toString(): String {
-        return "<TyUnion ${listOf(module, name).joinToString(".")} ${parameters.joinToString(" ")}>"
+        return "(${listOf(module, name).joinToString(".")} ${parameters.joinToString(" ")})"
     }
 }
 
@@ -107,7 +110,7 @@ data class TyFunction(
     override fun withAlias(alias: AliasInfo): TyFunction = copy(alias = alias)
 
     override fun toString(): String {
-        return allTys.joinToString(" → ", prefix = "<TyFunction ", postfix = ">")
+        return allTys.joinToString(" → ", prefix = "(", postfix = ")")
     }
 }
 

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -107,6 +107,10 @@ data class TyFunction(
         else -> ret
     }
 
+    fun uncurry(): TyFunction = when (ret) {
+        is TyFunction -> TyFunction(parameters + ret.parameters, ret.ret)
+        else -> this
+    }
 
     override fun withAlias(alias: AliasInfo): TyFunction = copy(alias = alias)
 

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -19,22 +19,11 @@ sealed class Ty {
 }
 
 // vars are not a data class because they need to be compared by identity
-/** A declared ("rigid") type variable (e.g. `a` in `Maybe a`) */
+/** A type variable (e.g. `a` in `Maybe a`) */
 class TyVar(val name: String) : Ty() {
     override val alias: AliasInfo? get() = null
     override fun withAlias(alias: AliasInfo): TyVar = this
     override fun toString(): String = "<TyVar $name>"
-}
-
-/**
- * An implicit ("flexible") type variable (i.e. the type of parameters in unannotated functions)
- *
- * These types must be unified.
- */
-data class TyInfer(val name: String) : Ty() {
-    override val alias: AliasInfo? get() = null
-    override fun withAlias(alias: AliasInfo): TyInfer = this
-    override fun toString(): String = "<TyInfer $name>"
 }
 
 /** A tuple type like `(Int, String)` */
@@ -94,6 +83,10 @@ val TyShader = TyUnion("WebGL", "Shader", listOf(TyUnknown(), TyUnknown(), TyUnk
 fun TyList(elementTy: Ty) = TyUnion("List", "List", listOf(elementTy))
 
 val TyUnion.isTyList: Boolean get() = module == "List" && name == "List"
+val TyUnion.isTyInt: Boolean get() = module == TyInt.module && name == TyInt.name
+val TyUnion.isTyFloat: Boolean get() = module == TyFloat.module && name == TyFloat.name
+val TyUnion.isTyString: Boolean get() = module == TyString.module && name == TyString.name
+val TyUnion.isTyChar: Boolean get() = module == TyChar.module && name == TyChar.name
 
 data class TyFunction(
         val parameters: List<Ty>,

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -160,8 +160,7 @@ class TypeExpression(
         val last = segments.last()
         return when {
             segments.size == 1 -> last
-            last is TyFunction -> TyFunction(segments.dropLast(1) + last.parameters, last.ret)
-            else -> TyFunction(segments.dropLast(1), last)
+            else -> TyFunction(segments.dropLast(1), last).uncurry()
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -226,7 +226,7 @@ class TypeExpression(
             return declaredTy
         }
 
-        return TypeReplacement.replace(declaredTy, params, args)
+        return TypeReplacement.replace(declaredTy, params.zip(args).toMap())
     }
 
     private fun typeDeclarationType(declaration: ElmTypeDeclaration): TyUnion {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -228,7 +228,7 @@ private class InferenceScope(
             if (part is ElmOperator) {
                 val (ty, precedence) = inferOperatorAndPrecedence(part)
                 when {
-                    precedence == null || ty !is TyFunction || ty.parameters.size != 2 -> return TyUnknown()
+                    precedence == null || ty !is TyFunction || ty.parameters.size < 2 -> return TyUnknown()
                     precedence.associativity == NON && lastPrecedence?.associativity == NON -> {
                         // Non-associative operators can't be chained directly with other non-associative
                         // operators.

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -279,15 +279,15 @@ private class InferenceScope(
                 else -> error("unexpected operand type $operand")
             }
 
-    private fun inferFunctionCall(callExpr: ElmFunctionCallExpr): Ty {
-        val targetTy = inferAtom(callExpr.target)
-        val arguments = callExpr.arguments.toList()
+    private fun inferFunctionCall(expr: ElmFunctionCallExpr): Ty {
+        val targetTy = inferAtom(expr.target)
+        val arguments = expr.arguments.toList()
 
         // always infer the arguments so that they're added to expressionTypes
         val argTys = arguments.map { inferAtom(it) }
 
         fun argCountError(expected: Int): TyUnknown {
-            diagnostics += ArgumentCountError(callExpr, arguments.size, expected)
+            diagnostics += ArgumentCountError(expr, arguments.size, expected)
             return TyUnknown()
         }
 
@@ -307,7 +307,7 @@ private class InferenceScope(
         } else {
             TyUnknown()
         }
-        expressionTypes[callExpr] = resultTy
+        expressionTypes[expr] = resultTy
         return resultTy
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -984,12 +984,12 @@ private class InferenceScope(
                         || ty.isTyChar
                         || ty.isTyString
                         || ty.isTyList && ty.parameters.allComparable()
-                is TyVar -> ty.name.startsWith("number") || typeclassCompatable("appendable", tyVar.name, ty.name)
+                is TyVar -> ty.name.startsWith("number") || typeclassCompatable("comparable", tyVar.name, ty.name)
                 else -> false
             }
             tyVar.name.startsWith("compappend") -> when (ty) {
                 is TyUnion -> ty.isTyString || ty.isTyList && ty.parameters.allComparable()
-                is TyVar -> ty.name.startsWith("number") || typeclassCompatable("appendable", tyVar.name, ty.name)
+                is TyVar -> ty.name.startsWith("number") || typeclassCompatable("compappend", tyVar.name, ty.name)
                 else -> false
             }
             else -> true

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -259,7 +259,7 @@ private class InferenceScope(
                     val lAssignable = requireAssignable(l.start, l.ty, func.parameters[0], l.end, replacements)
                     val rAssignable = requireAssignable(r.start, r.ty, func.parameters[1], r.end, replacements)
                     val ty = when {
-                        lAssignable && rAssignable -> TypeReplacement.replace(func.ret, replacements)
+                        lAssignable && rAssignable -> TypeReplacement.deepReplace(func.ret, replacements)
                         else -> TyUnknown()
                     }
                     TyAndRange(l.start, r.end, ty)
@@ -312,7 +312,7 @@ private class InferenceScope(
         }
 
         val appliedTy = targetTy.partiallyApply(arguments.size)
-        val resultTy = if (ok) TypeReplacement.replace(appliedTy, replacements) else TyUnknown()
+        val resultTy = if (ok) TypeReplacement.deepReplace(appliedTy, replacements) else TyUnknown()
         expressionTypes[callExpr] = resultTy
         return resultTy
     }
@@ -838,7 +838,7 @@ private class InferenceScope(
     }
 
     //</editor-fold>
-    //<editor-fold desc="coercion">
+    //<editor-fold desc="unification">
 
     /*
      * These functions test that a Ty can be assigned to another Ty. The tests are lenient, so no
@@ -855,7 +855,7 @@ private class InferenceScope(
     ): Boolean {
         val assignable = assignable(ty1, ty2, replacements)
         if (!assignable) {
-            val t2 = replacements?.let { TypeReplacement.replace(ty2, it) } ?: ty2
+            val t2 = replacements?.let { TypeReplacement.deepReplace(ty2, it) } ?: ty2
             diagnostics += TypeMismatchError(element, ty1, t2, endElement)
         }
         return assignable

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -554,15 +554,11 @@ private class InferenceScope(
     }
 
     private fun inferNegateExpression(expr: ElmNegateExpr): Ty {
-        val subExpr = expr.expression
+        val subExpr = expr.expression ?: return TyUnknown()
         val subTy = inferExpression(subExpr)
-        // TODO [unification] restrict vars to only number
         return when {
-            subTy == TyInt || subTy == TyFloat || !isInferable(subTy) -> subTy
-            else -> {
-                diagnostics += TypeMismatchError(subExpr!!, subTy, TyVar("number"))
-                TyUnknown()
-            }
+            requireAssignable(subExpr, subTy, TyVar("number")) -> subTy
+            else -> TyUnknown()
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -259,7 +259,7 @@ private class InferenceScope(
                     val lAssignable = requireAssignable(l.start, l.ty, func.parameters[0], l.end, replacements)
                     val rAssignable = requireAssignable(r.start, r.ty, func.parameters[1], r.end, replacements)
                     val ty = when {
-                        lAssignable && rAssignable -> TypeReplacement.deepReplace(func.ret, replacements)
+                        lAssignable && rAssignable -> TypeReplacement.deepReplace(func.partiallyApply(2), replacements)
                         else -> TyUnknown()
                     }
                     TyAndRange(l.start, r.end, ty)

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -9,7 +9,6 @@ fun Ty.renderedText(linkify: Boolean, withModule: Boolean): String {
         is TyRecord -> renderedText(linkify, withModule)
         is TyTuple -> renderedText(linkify, withModule)
         is TyVar -> name
-        is TyInfer -> name
         is TyUnit -> "()"
         is TyUnknown, TyInProgressBinding -> "unknown"
         TyShader -> "shader"
@@ -65,7 +64,6 @@ fun Ty.renderParam(): String {
         is TyRecord -> "record"
         is TyTuple -> renderParam()
         is TyVar -> name
-        is TyInfer -> name
         is TyUnit -> "()"
         is TyUnknown, TyInProgressBinding -> "unknown"
         TyShader -> "shader"

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -26,7 +26,7 @@ fun TyUnion.renderedText(linkify: Boolean, withModule: Boolean): String {
     val type = when {
         parameters.isEmpty() -> name
         else -> parameters.joinToString(" ", prefix = "$name ") {
-            if (it is TyUnion && it.parameters.isNotEmpty()) {
+            if (it is TyFunction || it is TyUnion && it.parameters.isNotEmpty()) {
                 "(${it.renderedText(linkify, withModule)})"
             } else {
                 it.renderedText(linkify, withModule)

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -9,6 +9,7 @@ fun Ty.renderedText(linkify: Boolean, withModule: Boolean): String {
         is TyRecord -> renderedText(linkify, withModule)
         is TyTuple -> renderedText(linkify, withModule)
         is TyVar -> name
+        is TyInfer -> name
         is TyUnit -> "()"
         is TyUnknown, TyInProgressBinding -> "unknown"
         TyShader -> "shader"
@@ -64,6 +65,7 @@ fun Ty.renderParam(): String {
         is TyRecord -> "record"
         is TyTuple -> renderParam()
         is TyVar -> name
+        is TyInfer -> name
         is TyUnit -> "()"
         is TyUnknown, TyInProgressBinding -> "unknown"
         TyShader -> "shader"

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -29,7 +29,10 @@ class TypeReplacement(
         fun deepReplace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
             if (replacements.isEmpty()) return ty
             val tr = TypeReplacement(replacements)
-            return tr.replace(tr.replace(ty))
+            val ty1 = tr.replace(ty)
+            val ty2 = tr.replace(ty1)
+            val replace = tr.replace(ty2)
+            return replace
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -61,7 +61,7 @@ class TypeReplacement private constructor(
         is TyUnknown -> TyUnknown(replace(ty.alias))
         is TyUnion -> replaceUnion(ty)
         is TyRecord -> replaceRecord(ty)
-        is TyUnit, TyInProgressBinding -> ty
+        is TyUnit, TyInProgressBinding, is TyInfer -> ty
     }
 
     /*

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -16,11 +16,6 @@ class TypeReplacement(
             if (replacements.isEmpty()) return ty
             return TypeReplacement(replacements).replace(ty)
         }
-
-        fun replace(ty: Ty, params: List<TyVar>, args: List<Ty>): Ty {
-            require(params.size == args.size) { "params and args size differ: ${params.size}, ${args.size}" }
-            return replace(ty, params.zip(args).toMap())
-        }
     }
 
     private fun replace(ty: Ty): Ty = when (ty) {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -12,9 +12,24 @@ class TypeReplacement(
         private val replacements: Map<TyVar, Ty>
 ) {
     companion object {
+        /**
+         * Replace vars in [ty] according to [replacements].
+         */
         fun replace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
             if (replacements.isEmpty()) return ty
             return TypeReplacement(replacements).replace(ty)
+        }
+
+        /**
+         * Replace vars in [ty] according to [replacements].
+         *
+         * If the values of [replacements] can contain [TyVar]s that occur in the keys, use this
+         * rather than [replace].
+         */
+        fun deepReplace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
+            if (replacements.isEmpty()) return ty
+            val tr = TypeReplacement(replacements)
+            return tr.replace(tr.replace(ty))
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -29,10 +29,7 @@ class TypeReplacement(
         fun deepReplace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
             if (replacements.isEmpty()) return ty
             val tr = TypeReplacement(replacements)
-            val ty1 = tr.replace(ty)
-            val ty2 = tr.replace(ty1)
-            val replace = tr.replace(ty2)
-            return replace
+            return tr.replace(tr.replace(ty))
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -25,18 +25,42 @@ class TypeReplacement(
          *
          * If the values of [replacements] can contain [TyVar]s that occur in the keys, use this
          * rather than [replace].
+         *
+         * This will perform replacement several times until there is nothing left to replace. Then
+         * all remaining [TyVar]s in the type are replaced with new vars with the same name to
+         * enforce scoping.
          */
         fun deepReplace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
             if (replacements.isEmpty()) return ty
             val tr = TypeReplacement(replacements)
-            return tr.replace(tr.replace(ty))
+            var newTy = ty
+            repeat(5) {
+                val next = tr.replace(newTy)
+                if (next == newTy) {
+                    return freshenVars(newTy)
+                }
+                newTy = next
+            }
+            // exceeded the recursion threshold, don't replace anything
+            return ty
+        }
+
+        private fun freshenVars(ty: Ty): Ty {
+            return TypeReplacement(MutableMapWithDefault { TyVar(it.name) }).replace(ty)
         }
     }
 
     private fun replace(ty: Ty): Ty = when (ty) {
         is TyVar -> replacements[ty] ?: ty
         is TyTuple -> TyTuple(ty.types.map { replace(it) }, replace(ty.alias))
-        is TyFunction -> TyFunction(ty.parameters.map { replace(it) }, replace(ty.ret), replace(ty.alias))
+        is TyFunction -> {
+            val parameters = ty.parameters.map {
+                replace(it)
+            }
+            val ret = replace(ty.ret)
+            val alias = replace(ty.alias)
+            TyFunction(parameters, ret, alias)
+        }
         is TyUnknown -> TyUnknown(replace(ty.alias))
         is TyUnion -> replaceUnion(ty)
         is TyRecord -> replaceRecord(ty)
@@ -62,7 +86,7 @@ class TypeReplacement(
     }
 
     private fun replaceRecord(ty: TyRecord): Ty {
-        val replacedBase = replacements[ty.baseTy]
+        val replacedBase = if (ty.baseTy == null) null else replacements[ty.baseTy]
         val newBaseTy = when (replacedBase) {
             // If the base ty of the argument is a record, use it's base ty, which might be null.
             is TyRecord -> replacedBase.baseTy
@@ -79,3 +103,25 @@ class TypeReplacement(
     }
 }
 
+
+private class MutableMapWithDefault<K, V>(
+        val map: MutableMap<K, V> = mutableMapOf(),
+        private val default: (key: K) -> V
+) : MutableMap<K, V> {
+    override fun equals(other: Any?): Boolean = map.equals(other)
+    override fun hashCode(): Int = map.hashCode()
+    override fun toString(): String = map.toString()
+    override val size: Int get() = map.size
+    override fun isEmpty(): Boolean = map.isEmpty()
+    override fun containsKey(key: K): Boolean = map.containsKey(key)
+    override fun containsValue(value: @UnsafeVariance V): Boolean = map.containsValue(value)
+    override fun get(key: K): V? = map.getOrPut(key) { default(key) }
+    override val keys: MutableSet<K> get() = map.keys
+    override val values: MutableCollection<V> get() = map.values
+    override val entries: MutableSet<MutableMap.MutableEntry<K, V>> get() = map.entries
+
+    override fun put(key: K, value: V): V? = map.put(key, value)
+    override fun remove(key: K): V? = map.remove(key)
+    override fun putAll(from: Map<out K, V>) = map.putAll(from)
+    override fun clear() = map.clear()
+}

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -43,7 +43,7 @@ class TypeReplacement(
         is TyUnknown -> TyUnknown(replace(ty.alias))
         is TyUnion -> replaceUnion(ty)
         is TyRecord -> replaceRecord(ty)
-        is TyUnit, TyInProgressBinding, is TyInfer -> ty
+        is TyUnit, TyInProgressBinding -> ty
     }
 
     /*

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -59,7 +59,7 @@ class TypeReplacement(
             }
             val ret = replace(ty.ret)
             val alias = replace(ty.alias)
-            TyFunction(parameters, ret, alias)
+            TyFunction(parameters, ret, alias).uncurry()
         }
         is TyUnknown -> TyUnknown(replace(ty.alias))
         is TyUnion -> replaceUnion(ty)

--- a/src/test/kotlin/org/elm/ide/inspections/TypeDeclarationInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeDeclarationInspectionTest.kt
@@ -1,11 +1,6 @@
 package org.elm.ide.inspections
 
 class TypeDeclarationInspectionTest : ElmInspectionsTestBase(ElmTypeDeclarationInspection()) {
-    fun `test bad argument to aliased record extension`() = checkByText("""
-type alias R a = { a | foo : () }
-type alias S = R <error descr="Type mismatch.Required: recordFound: ()">()</error>
-""")
-
     fun `test bad self-recursion in type alias`() = checkByText("""
 <error descr="Infinite recursion">type alias A = A</error>
 """)
@@ -17,7 +12,7 @@ type alias S = R <error descr="Type mismatch.Required: recordFound: ()">()</erro
 
     fun `test good recursion in through union`() = checkByText("""
 type alias Alias = { value : Union }
-type Union = TUnion Alias
+type Union = Variant Alias
 """)
 
     // https://github.com/klazuka/intellij-elm/issues/188

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -53,6 +53,16 @@ main = -1.0
 main = -<error descr="Type mismatch.Required: numberFound: String">""</error>
 """)
 
+    fun `test negate from pattern match`() = checkByText("""
+type alias N = Float
+type Foo = Bar N
+
+main : Foo -> ()
+main foo =
+    <error descr="Type mismatch.Required: ()Found: N">case foo of
+        Bar n -> -n</error>
+""")
+
     fun `test mismatched tuple value type from missing field`() = checkByText("""
 main : ((), (), ())
 main = <error descr="Type mismatch.Required: ((), (), ())Found: ((), ())">((), ())</error>
@@ -1256,6 +1266,4 @@ main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">foo listStr listA listA</error>
 """)
-
-
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1124,4 +1124,12 @@ foo a = a
 main : Int
 main = <error descr="Type mismatch.Required: IntFound: String">foo ""</error>
 """)
+
+    fun `test mismatched return value from nested vars`() = checkByText("""
+foo : List a -> List a
+foo a = a
+
+main : List Int
+main = <error descr="Type mismatch.Required: List IntFound: List String">foo [""]</error>
+""")
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -489,6 +489,27 @@ main : () -> ()
 main = (\a -> a)
 """)
 
+    fun `test function with arguments returning lambda`() = checkByText("""
+foo a = \b -> b
+
+main : ()
+main = <error descr="Type mismatch.Required: ()Found: String">foo "" ""</error>
+""")
+
+    fun `test lambda returning lambda`() = checkByText("""
+foo = \a -> (\b -> b)
+
+main : ()
+main = <error descr="Type mismatch.Required: ()Found: String">foo "" ""</error>
+""")
+
+    fun `test lambda returning lambda returning lambda`() = checkByText("""
+foo = \a -> (\b -> (\c -> c))
+
+main : ()
+main = <error descr="Type mismatch.Required: ()Found: String">foo "" "" ""</error>
+""")
+
     fun `test record update in lambda`() = checkByText("""
 type alias R = {x : ()}
 main : R -> R
@@ -1529,6 +1550,6 @@ qux = Bar
 
 main : ()
 main =
-    <error descr="Type mismatch.Required: ()Found: Foo (String → (Float → f)) f">(foo (foo bar baz) qux)</error>
+    <error descr="Type mismatch.Required: ()Found: Foo (String → Float → f) f">(foo (foo bar baz) qux)</error>
 """)
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1326,6 +1326,15 @@ main =
     <error descr="Type mismatch.Required: ()Found: Float">foo 1 2.2</error>
 """)
 
+    fun `test constraint number number`() = checkByText("""
+foo : number -> number -> number
+foo a b = a
+
+main : number -> number -> ()
+main a b =
+    <error descr="Type mismatch.Required: ()Found: number">foo a b</error>
+""")
+
     fun `test constraint number mismatched`() = checkByText("""
 foo : number -> number -> number
 foo a b = a
@@ -1350,6 +1359,15 @@ foo a b = a
 main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: List a">foo [] []</error>
+""")
+
+    fun `test constraint appendable appendable`() = checkByText("""
+foo : appendable -> appendable -> appendable
+foo a b = a
+
+main : appendable -> appendable -> ()
+main a b =
+    <error descr="Type mismatch.Required: ()Found: appendable">foo a b</error>
 """)
 
     fun `test constraint appendable string and list mismatch`() = checkByText("""
@@ -1439,6 +1457,15 @@ main =
     foo ("", "") <error descr="Type mismatch.Required: (String, String)Found: (String, Float)">("", 1.1)</error>
 """)
 
+    fun `test constraint comparable comparable`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : comparable -> comparable -> ()
+main a b =
+    <error descr="Type mismatch.Required: ()Found: comparable">foo a b</error>
+""")
+
     fun `test constraint compappend string`() = checkByText("""
 foo : comappend -> comappend -> comappend
 foo a b = a
@@ -1455,6 +1482,15 @@ foo a b = a
 main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: List String">foo [""] []</error>
+""")
+
+    fun `test constraint compappend compappend`() = checkByText("""
+foo : compappend -> compappend -> compappend
+foo a b = a
+
+main : compappend -> compappend -> ()
+main a b =
+    <error descr="Type mismatch.Required: ()Found: compappend">foo a b</error>
 """)
 
     fun `test numbered constraint appendable`() = checkByText("""

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1510,4 +1510,25 @@ main : ()
 main =
     foo "" [""] <error descr="Type mismatch.Required: StringFound: List String">[""]</error>
 """)
+
+    fun `test calling function with its own return value`() = checkByText("""
+type Foo a b = Foo
+type Bar c = Bar
+
+foo : Foo d (e -> f) -> Bar e -> Foo d f
+foo a = Debug.todo ""
+
+bar : Foo g g
+bar = Foo
+
+baz : Bar String
+baz = Bar
+
+qux : Bar Float
+qux = Bar
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: Foo (String → (Float → f)) f">(foo (foo bar baz) qux)</error>
+""")
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1162,4 +1162,17 @@ main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: String">List.head [""] |> Maybe.withDefault ""</error>
 """)
+
+    fun `test passing function type with vars`() = checkByText("""
+map : (c -> d) -> List c -> List d
+map f xs = []
+
+foo : String -> String
+foo s = s
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String → List String">map foo</error>
+""")
+
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1266,4 +1266,180 @@ main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">foo listStr listA listA</error>
 """)
+
+    fun `test constraint number int literals`() = checkByText("""
+foo : number -> number -> number
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: number">foo 1 2</error>
+""")
+
+    fun `test constraint number float literals`() = checkByText("""
+foo : number -> number -> number
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: Float">foo 1.1 2.2</error>
+""")
+
+    fun `test constraint number int and float literal`() = checkByText("""
+foo : number -> number -> number
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: Float">foo 1 2.2</error>
+""")
+
+    fun `test constraint number mismatched`() = checkByText("""
+foo : number -> number -> number
+foo a b = a
+
+main =
+    foo 1 <error descr="Type mismatch.Required: numberFound: ()">()</error>
+""")
+
+    fun `test constraint appendable string`() = checkByText("""
+foo : appendable -> appendable -> appendable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: String">foo "" ""</error>
+""")
+
+    fun `test constraint appendable list`() = checkByText("""
+foo : appendable -> appendable -> appendable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List a">foo [] []</error>
+""")
+
+    fun `test constraint appendable string and list mismatch`() = checkByText("""
+foo : appendable -> appendable -> appendable
+foo a b = a
+
+main =
+    foo "" <error descr="Type mismatch.Required: StringFound: List a">[]</error>
+""")
+
+    fun `test constraint appendable list mismatch`() = checkByText("""
+foo : appendable -> appendable -> appendable
+foo a b = a
+
+main =
+    foo [""] <error descr="Type mismatch.Required: List StringFound: List ()">[()]</error>
+""")
+
+    fun `test constraint appendable number mismatch`() = checkByText("""
+foo : appendable -> appendable
+foo a = a
+
+main =
+    foo <error descr="Type mismatch.Required: appendableFound: number">1</error>
+""")
+
+    fun `test constraint comparable int`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : Int -> ()
+main a =
+    <error descr="Type mismatch.Required: ()Found: Int">foo a a</error>
+""")
+
+    fun `test constraint comparable float`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: Float">foo 1.1 2.2</error>
+""")
+
+    fun `test constraint comparable char`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: Char">foo 'a' 'b'</error>
+""")
+
+    fun `test constraint comparable string`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: String">foo "a" "b"</error>
+""")
+
+    fun `test constraint comparable list string`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String">foo ["a"] []</error>
+""")
+
+    fun `test constraint comparable tuple float`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: (Float, Float)">foo (1.1, 2.2) (3.3, 4.4)</error>
+""")
+
+    fun `test constraint comparable tuple mismatch`() = checkByText("""
+foo : comparable -> comparable -> comparable
+foo a b = a
+
+main : ()
+main =
+    foo ("", "") <error descr="Type mismatch.Required: (String, String)Found: (String, Float)">("", 1.1)</error>
+""")
+
+    fun `test constraint compappend string`() = checkByText("""
+foo : comappend -> comappend -> comappend
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: String">foo "" ""</error>
+""")
+
+    fun `test constraint compappend list string`() = checkByText("""
+foo : comappend -> comappend -> comappend
+foo a b = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String">foo [""] []</error>
+""")
+
+    fun `test numbered constraint appendable`() = checkByText("""
+foo : appendable1 -> appendable2 -> appendable3 -> appendable2
+foo a b c = b
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String">foo "" [""] [()]</error>
+""")
+
+    fun `test numbered constraint appendable mismatch`() = checkByText("""
+foo : appendable1 -> appendable2 -> appendable1 -> appendable2
+foo a b c = b
+
+main : ()
+main =
+    foo "" [""] <error descr="Type mismatch.Required: StringFound: List String">[""]</error>
+""")
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1116,4 +1116,12 @@ directChildren tree =
         Tree _ children ->
             children</error>
 """)
+
+    fun `test mismatched return value from rigid vars`() = checkByText("""
+foo : a -> a
+foo a = a
+
+main : Int
+main = <error descr="Type mismatch.Required: IntFound: String">foo ""</error>
+""")
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1132,4 +1132,28 @@ foo a = a
 main : List Int
 main = <error descr="Type mismatch.Required: List IntFound: List String">foo [""]</error>
 """)
+
+    fun `test mismatched return value from multiple rigid vars`() = checkByText("""
+foo : List a -> List b -> List b
+foo a b = b
+
+main : List Int
+main = <error descr="Type mismatch.Required: List IntFound: List String">foo [1] [""]</error>
+""")
+
+    fun `test mismatched return value from doubly nested vars`() = checkByText("""
+foo : List (List a) -> List (List a)
+foo a = a
+
+main : List (List Int)
+main = <error descr="Type mismatch.Required: List (List Int)Found: List (List String)">foo [[""]]</error>
+""")
+
+    fun `test mismatched arg to var`() = checkByText("""
+foo : List a -> List a -> List a
+foo a b = a
+
+main : List String
+main = foo [""] <error descr="Type mismatch.Required: List StringFound: List (List a)">[[]]</error>
+""")
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -40,10 +40,12 @@ main = <error descr="Type mismatch.Required: ()Found: Float">1.0</error>
 """)
 
     fun `test matched int negation`() = checkByText("""
+main : Int
 main = -1
 """)
 
     fun `test matched float negation`() = checkByText("""
+main : Float
 main = -1.0
 """)
 
@@ -1205,4 +1207,55 @@ main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">map <: foo</error>
 """)
+
+
+    fun `test multiple empty lists`() = checkByText("""
+foo : z -> z -> z -> z
+foo a b c = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String">foo [] [] [""]</error>
+""")
+
+    fun `test multiple mismatched lists`() = checkByText("""
+foo : z -> z -> z -> z -> z
+foo a b c d = a
+
+main : ()
+main =
+    foo [] [] [""] <error descr="Type mismatch.Required: List StringFound: List ()">[()]</error>
+""")
+
+    fun `test multiple empty list functions ending with concrete type`() = checkByText("""
+foo : z -> z -> z -> z
+foo a b c = a
+
+listA : List b -> List b
+listA a = a
+
+listStr : List String -> List String
+listStr a = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String → List String">foo listA listA listStr</error>
+""")
+
+    fun `test multiple empty list functions starting with concrete type`() = checkByText("""
+foo : z -> z -> z -> z
+foo a b c = a
+
+listA : List b -> List b
+listA a = a
+
+listStr : List String -> List String
+listStr a = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String → List String">foo listStr listA listA</error>
+""")
+
+
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1218,6 +1218,21 @@ main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">map <: foo</error>
 """)
 
+    fun `test passing record constructor to operator`() = checkByText("""
+appR : a -> (a -> b) -> b
+appR x f = f x
+infix left 0 (:>) = appR
+
+map : (c -> d) -> List c -> List d
+map f xs = []
+
+type alias Rec = { field : () }
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List () → List Rec">Rec :> map</error>
+""")
+
     fun `test non function to composition operator`() = checkByText("""
 compo : (b -> c) -> (a -> b) -> (a -> c)
 compo g f x = g (f x)

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1294,6 +1294,11 @@ main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">foo listStr listA listA</error>
 """)
 
+    fun `test function composition`() = checkByText("""
+main : ()
+main = <error descr="Type mismatch.Required: ()Found: String → Bool">String.isEmpty >> not</error>
+""")
+
     fun `test constraint number int literals`() = checkByText("""
 foo : number -> number -> number
 foo a b = a

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1149,11 +1149,17 @@ main : List (List Int)
 main = <error descr="Type mismatch.Required: List (List Int)Found: List (List String)">foo [[""]]</error>
 """)
 
-    fun `test mismatched arg to var`() = checkByText("""
+    fun `test fixing var value at first occurrence`() = checkByText("""
 foo : List a -> List a -> List a
 foo a b = a
 
 main : List String
 main = foo [""] <error descr="Type mismatch.Required: List StringFound: List (List a)">[[]]</error>
+""")
+
+    fun `test passing vars through operator`() = checkByText("""
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: String">List.head [""] |> Maybe.withDefault ""</error>
 """)
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1175,4 +1175,34 @@ main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">map foo</error>
 """)
 
+    fun `test passing function type with vars to function`() = checkByText("""
+appL : (a -> b) -> a -> b
+appL f x = f x
+
+map : (c -> d) -> List c -> List d
+map f xs = []
+
+foo : String -> String
+foo s = s
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String → List String">appL map foo</error>
+""")
+
+    fun `test passing function type with vars to operator`() = checkByText("""
+appL : (a -> b) -> a -> b
+appL f x = f x
+infix right 0 (<:) = appL
+
+map : (c -> d) -> List c -> List d
+map f xs = []
+
+foo : String -> String
+foo s = s
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String → List String">map <: foo</error>
+""")
 }

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1218,6 +1218,18 @@ main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">map <: foo</error>
 """)
 
+    fun `test non function to composition operator`() = checkByText("""
+compo : (b -> c) -> (a -> b) -> (a -> c)
+compo g f x = g (f x)
+infix left  9 (<<<) = compo
+
+foo : d -> d
+foo a = a
+
+main =
+    foo <<< <error descr="Type mismatch.Required: a → dFound: String">""</error>
+""")
+
 
     fun `test multiple empty lists`() = checkByText("""
 foo : z -> z -> z -> z


### PR DESCRIPTION
This PR adds a limited form of unification to function call and operator expressions. It also implements the constraints of the built-in type classes, as well as a few assorted fixes to type inference.

I removed the diagnostic that checked that a type expression argument is a record when passed to a record extension type alias. This is neither a compile time nor runtime error in Elm (although it can cause a crash in some circumstances), and complicated the `TypeReplacement` code quite a bit.

![untitled](https://user-images.githubusercontent.com/1109214/52448980-8d216280-2aea-11e9-8c62-967a15792cc9.png)

![untitled2](https://user-images.githubusercontent.com/1109214/52448994-93afda00-2aea-11e9-88a5-e047f2069c48.png)

Fixes #264 
Fixes #268 
Fixes #122 