### PR TITLE
Improve error reporting when path to Elm compiler is misconfigured

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -236,7 +236,7 @@ private fun File.isWrapperScript(): Boolean {
 
     return when (firstChars) {
         "#!/" -> true // hash-bang used by Unix scripts
-        "IF@" -> true // npm Windows batch script starts with `@IF EXIST "%~dp0\node.exe"`
+        "@IF" -> true // npm Windows batch script starts with `@IF EXIST "%~dp0\node.exe"`
         else -> false
     }
 }

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -28,7 +28,8 @@ interface ElmStdlibVariant {
      * @return An application Elm project which depends on the specified Stdlib packages
      */
     fun ensureElmStdlibInstalled(project: Project, toolchain: ElmToolchain): ElmProject {
-        val compilerVersion = toolchain.queryCompilerVersion()
+        val compilerVersion = toolchain.queryCompilerVersion().orNull()
+                ?: error("Could not query the Elm compiler version")
         require(compilerVersion != Version(0, 18, 0))
 
         val elm = toolchain.elmCompilerPath?.let { ElmCLI(it) }


### PR DESCRIPTION
Several users ran into problems where they were seeing the Elm version
reported as "0.0.0". The underlying problem was that the path to the
Elm compiler was pointing at a hash-bang wrapper script created by
npm/nvm/yarn/etc. Apparently those tools wrap native binaries with a
wrapper script, but this causes problems from the IntelliJ side.

Maybe we could do something smarter here to be able to invoke the
wrapper scripts themselves, but I suspect that it depends on shell
environment stuff which wouldn't be present inside IntelliJ.

I also added a suggested Elm binary path based on where nvm/yarn
apparently installs things.

Fixes #252 