### PR TITLE
Add an action for invoking elm-format

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -1,0 +1,72 @@
+package org.elm.ide.actions
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import org.elm.ide.notifications.showBalloon
+import org.elm.lang.core.psi.ElmFile
+import org.elm.openapiext.isUnitTestMode
+import org.elm.workspace.*
+
+
+class ElmExternalFormatAction : AnAction() {
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabled = getContext(e) != null
+    }
+
+    private fun getContext(e: AnActionEvent): Context? {
+        val project = e.project ?: return null
+        val toolchain = project.elmToolchain ?: return null
+        val file = e.getData(CommonDataKeys.PSI_FILE) ?: return null
+        if (!file.virtualFile.isInLocalFileSystem) return null
+        if (file !is ElmFile) return null
+        val elmVersion = when (val elmProject = file.elmProject) {
+            is ElmApplicationProject -> elmProject.elmVersion
+            is ElmPackageProject -> elmProject.elmVersion.low
+            else -> return null
+        }
+        return Context(project, toolchain, file, elmVersion)
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val ctx = getContext(e) ?: return
+        val project = ctx.project
+        val virtualFile = ctx.elmFile.virtualFile
+        val elmFormat = ctx.toolchain.elmFormat
+        if (elmFormat == null) {
+            project.showBalloon("could not find elm-format", NotificationType.ERROR)
+            return
+        }
+
+        FileDocumentManager.getInstance().saveAllDocuments()
+        try {
+            ProgressManager.getInstance().runProcessWithProgressSynchronously<ProcessOutput, ExecutionException>({
+                elmFormat.reformatFile(project, ctx.elmVersion, virtualFile)
+            }, "Running elm-format on current file...", true, project)
+            // We want to refresh file synchronously only in unit test
+            // to get new text right after `reformatFile` call
+            VfsUtil.markDirtyAndRefresh(!isUnitTestMode, true, true, virtualFile)
+        } catch (e: ExecutionException) {
+            if (isUnitTestMode) throw e
+            val message = e.message ?: "something went wrong running elm-format"
+            project.showBalloon(message, NotificationType.ERROR)
+        }
+    }
+
+    private data class Context(
+            val project: Project,
+            val toolchain: ElmToolchain,
+            val elmFile: ElmFile,
+            val elmVersion: Version
+    )
+}
+

--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -23,6 +23,7 @@ class ElmExternalFormatAction : AnAction() {
         e.presentation.isEnabled = getContext(e) != null
     }
 
+
     private fun getContext(e: AnActionEvent): Context? {
         val project = e.project ?: return null
         val toolchain = project.elmToolchain ?: return null
@@ -36,6 +37,7 @@ class ElmExternalFormatAction : AnAction() {
         }
         return Context(project, toolchain, file, elmVersion)
     }
+
 
     override fun actionPerformed(e: AnActionEvent) {
         val ctx = getContext(e) ?: return
@@ -61,6 +63,7 @@ class ElmExternalFormatAction : AnAction() {
             project.showBalloon(message, NotificationType.ERROR)
         }
     }
+
 
     private data class Context(
             val project: Project,

--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -1,0 +1,119 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elm.openapiext
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Disposer
+import com.intellij.util.io.systemIndependentPath
+import java.nio.file.Path
+
+private val log = Logger.getInstance("org.elm.openapiext.Subprocesses")
+
+@Suppress("FunctionName")
+fun GeneralCommandLine(path: Path, vararg args: String) =
+        GeneralCommandLine(path.systemIndependentPath, *args)
+
+fun GeneralCommandLine.withWorkDirectory(path: Path?) =
+        withWorkDirectory(path?.systemIndependentPath)
+
+
+fun GeneralCommandLine.execute(timeoutInMilliseconds: Int? = 1000): ProcessOutput? {
+    val output = try {
+        val handler = CapturingProcessHandler(this)
+
+        log.debug("Executing `$commandLineString`")
+        if (timeoutInMilliseconds != null)
+            handler.runProcess(timeoutInMilliseconds)
+        else
+            handler.runProcess()
+    } catch (e: ExecutionException) {
+        log.warn("Failed to run executable", e)
+        return null
+    }
+
+    if (!output.isSuccess) {
+        log.warn(errorMessage(this, output))
+    }
+
+    return output
+}
+
+@Throws(ExecutionException::class)
+fun GeneralCommandLine.execute(
+        owner: Disposable,
+        ignoreExitCode: Boolean = false
+): ProcessOutput {
+
+    val handler = CapturingProcessHandler(this)
+    val processKiller = Disposable {
+        handler.destroyProcess()
+    }
+
+    val alreadyDisposed = runReadAction {
+        if (Disposer.isDisposed(owner)) {
+            true
+        } else {
+            Disposer.register(owner, processKiller)
+            false
+        }
+    }
+
+    if (alreadyDisposed) {
+        if (ignoreExitCode) {
+            return ProcessOutput().apply { setCancelled() }
+        } else {
+            throw ExecutionException("External command failed to start")
+        }
+    }
+
+    val output = try {
+        handler.runProcess()
+    } finally {
+        Disposer.dispose(processKiller)
+    }
+
+    if (!ignoreExitCode && output.exitCode != 0) {
+        throw ExecutionException(errorMessage(this, output))
+    }
+    return output
+}
+
+private fun errorMessage(commandLine: GeneralCommandLine, output: ProcessOutput): String = """
+        Execution failed (exit code ${output.exitCode}).
+        ${commandLine.commandLineString}
+        stdout : ${output.stdout}
+        stderr : ${output.stderr}
+    """.trimIndent()
+
+val ProcessOutput.isSuccess: Boolean
+    get() = !isTimeout && !isCancelled && exitCode == 0

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -7,7 +7,6 @@
 
 package org.elm.openapiext
 
-import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
@@ -31,7 +30,6 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
-import com.intellij.util.io.systemIndependentPath
 import org.jdom.Element
 import org.jdom.input.SAXBuilder
 import java.nio.file.Path
@@ -110,11 +108,6 @@ fun VirtualFile.toPsiFile(project: Project): PsiFile? =
 fun Editor.toPsiFile(project: Project): PsiFile? =
         PsiDocumentManager.getInstance(project).getPsiFile(document)
 
-
-@Suppress("FunctionName")
-fun GeneralCommandLine(path: Path, vararg args: String) = GeneralCommandLine(path.systemIndependentPath, *args)
-
-fun GeneralCommandLine.withWorkDirectory(path: Path?) = withWorkDirectory(path?.systemIndependentPath)
 
 
 inline fun <Key, reified Psi : PsiElement> getElements(

--- a/src/main/kotlin/org/elm/workspace/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmCLI.kt
@@ -1,13 +1,9 @@
 package org.elm.workspace
 
-import com.intellij.execution.ExecutionException
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.runReadAction
-import com.intellij.openapi.util.Disposer
 import org.elm.openapiext.GeneralCommandLine
+import org.elm.openapiext.execute
 import org.elm.openapiext.withWorkDirectory
 import java.nio.file.Path
 
@@ -17,60 +13,20 @@ class ElmCLI(private val elmExecutablePath: Path) {
 
     fun make(owner: Disposable, elmProject: ElmProject): ProcessOutput {
         val workDir = elmProject.manifestPath.parent
-        val commandLine = GeneralCommandLine(elmExecutablePath)
+        return GeneralCommandLine(elmExecutablePath)
                 .withWorkDirectory(workDir)
                 .withParameters("make", "src/Main.elm", "--output=/dev/null")
-        return execute(commandLine, owner, ignoreExitCode = true)
+                .execute(owner, ignoreExitCode = true)
     }
 
     fun installDeps(owner: Disposable, elmProjectManifestPath: Path): ProcessOutput {
         // Elm 0.19 does not have a way to install dependencies directly,
         // so we have to compile an empty file to make it work.
         val workDir = elmProjectManifestPath.parent
-        val commandLine = GeneralCommandLine(elmExecutablePath)
+        return GeneralCommandLine(elmExecutablePath)
                 .withWorkDirectory(workDir)
                 .withParameters("make", "./Main.elm", "--output=/dev/null")
-        return execute(commandLine, owner, ignoreExitCode = false)
+                .execute(owner, ignoreExitCode = false)
     }
 
-    private fun execute(cmdLine: GeneralCommandLine, owner: Disposable, ignoreExitCode: Boolean = false): ProcessOutput {
-        val handler = CapturingProcessHandler(cmdLine)
-        val processKiller = Disposable {
-            handler.destroyProcess()
-        }
-
-        val alreadyDisposed = runReadAction {
-            if (Disposer.isDisposed(owner)) {
-                true
-            } else {
-                Disposer.register(owner, processKiller)
-                false
-            }
-        }
-
-        if (alreadyDisposed) {
-            if (ignoreExitCode) {
-                return ProcessOutput().apply { setCancelled() }
-            } else {
-                throw ExecutionException("Cargo command failed to start")
-            }
-        }
-
-        val output = try {
-            handler.runProcess()
-        } finally {
-            Disposer.dispose(processKiller)
-        }
-
-        if (!ignoreExitCode && output.exitCode != 0) {
-            throw ExecutionException("""
-                    Failed to execute external program (exit code ${output.exitCode}).
-                    ${cmdLine.commandLineString}
-                    stdout : ${output.stdout}
-                    stderr : ${output.stderr}
-                    """.trimIndent()
-            )
-        }
-        return output
-    }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmFormatCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmFormatCLI.kt
@@ -1,0 +1,27 @@
+package org.elm.workspace
+
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.elm.openapiext.GeneralCommandLine
+import org.elm.openapiext.execute
+import org.elm.openapiext.pathAsPath
+import org.elm.openapiext.withWorkDirectory
+import java.nio.file.Path
+
+class ElmFormatCLI(private val elmFormatExecutablePath: Path) {
+
+    fun reformatFile(project: Project, elmVersion: Version, file: VirtualFile, owner: Disposable = project): ProcessOutput {
+        val arguments = listOf(
+                "--yes",
+                "--elm-version",
+                "${elmVersion.x}.${elmVersion.y}",
+                file.path
+        )
+        return GeneralCommandLine(elmFormatExecutablePath)
+                .withWorkDirectory(file.parent.pathAsPath)
+                .withParameters(arguments)
+                .execute(owner)
+    }
+}

--- a/src/main/kotlin/org/elm/workspace/ElmFormatCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmFormatCLI.kt
@@ -10,7 +10,7 @@ import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.withWorkDirectory
 import java.nio.file.Path
 
-class ElmFormatCLI(private val elmFormatExecutablePath: Path) {
+class ElmFormatCLI(val elmFormatExecutablePath: Path) {
 
     fun reformatFile(project: Project, elmVersion: Version, file: VirtualFile, owner: Disposable = project): ProcessOutput {
         val arguments = listOf(

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -59,10 +59,16 @@ data class ElmToolchain(val binDirPath: Path) {
         }
 
     val elmCompilerPath: Path? get() {
-        return elmCompilerNameSuggestions()
+        return executableNameSuggestionsFor("elm")
                 .map { binDirPath.resolve(it) }
                 .firstOrNull { Files.isExecutable(it) }
     }
+
+    val elmFormat: ElmFormatCLI?
+        get() = executableNameSuggestionsFor("elm-format")
+                .map { binDirPath.resolve(it) }
+                .firstOrNull { Files.isExecutable(it) }
+                ?.let { ElmFormatCLI(it) }
 
     fun looksLikeValidToolchain(): Boolean = elmCompilerPath != null
 
@@ -141,9 +147,9 @@ data class ElmToolchain(val binDirPath: Path) {
 }
 
 // Look for both installed and npm versions of the binary
-private fun elmCompilerNameSuggestions() =
-        if (SystemInfo.isWindows) sequenceOf("elm.exe", "elm.cmd", "elm")
-        else sequenceOf("elm")
+private fun executableNameSuggestionsFor(name: String) =
+        if (SystemInfo.isWindows) sequenceOf("$name.exe", "$name.cmd", name)
+        else sequenceOf(name)
 
 private fun binDirSuggestions(project: Project) =
         sequenceOf(

--- a/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
+++ b/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
@@ -24,11 +24,13 @@ class ElmWorkspaceConfigurable(
             "Select directory containing the 'elm' binary") { update() }
 
     private val elmVersionLabel = JLabel()
+    private val elmFormatLabel = JLabel()
 
     override fun createComponent(): JComponent =
             panel {
                 row("Directory containing 'elm' binary:") { pathToToolchainField(CCFlags.pushX) }
                 row("Elm version:") { elmVersionLabel() }
+                row("elm-format:") { elmFormatLabel() }
             }
 
     private fun update() {
@@ -57,6 +59,16 @@ class ElmWorkspaceConfigurable(
                     }
                 }
         )
+        when (val fmt = ElmToolchain(pathToToolchain).elmFormat) {
+            null -> {
+                elmFormatLabel.text = "not found"
+                elmFormatLabel.foreground = JBColor.RED
+            }
+            else -> {
+                elmFormatLabel.text = fmt.elmFormatExecutablePath.toString()
+                elmFormatLabel.foreground = JBColor.foreground()
+            }
+        }
     }
 
     override fun dispose() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -247,6 +247,11 @@
                 icon="AllIcons.Toolwindows.ToolWindowBuild"/>
         -->
 
+        <action id="Elm.RunExternalElmFormat"
+                class="org.elm.ide.actions.ElmExternalFormatAction"
+                text="Run elm-format on current file">
+            <add-to-group group-id="CodeMenu" anchor="last"/>
+        </action>
 
         <group id="Elm.WorkspaceToolsGroup" text="Elm" popup="true">
             <reference id="Elm.RefreshElmProjects"/>

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -1,0 +1,127 @@
+package org.elm.ide.actions
+
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.MapDataContext
+import com.intellij.testFramework.TestActionEvent
+import junit.framework.TestCase
+import org.elm.workspace.ElmWorkspaceTestBase
+
+class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
+
+    override fun runTest() {
+        if (toolchain?.elmFormat == null) {
+            // TODO in the future maybe we should install elm-format in the CI build environment
+            System.err.println("SKIP $name: elm-format not found")
+            return
+        }
+        super.runTest()
+    }
+
+
+    fun `test elm-format action with elm 19`() {
+        val fileWithCaret = buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", """
+                    module Main exposing (f)
+
+
+                    f x = x{-caret-}
+
+                """.trimIndent())
+            }
+        }.fileWithCaret
+
+        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val document = FileDocumentManager.getInstance().getDocument(file)!!
+        reformat(PsiManager.getInstance(project).findFile(file)!!)
+        val expected = """
+                    module Main exposing (f)
+
+
+                    f x =
+                        x
+
+                """.trimIndent()
+        TestCase.assertEquals(expected, document.text)
+    }
+
+
+    // TODO [drop 0.18] remove this test
+    fun `test elm-format action with elm 18`() {
+        val fileWithCaret = buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.18.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", """
+                    module Main exposing (f)
+
+
+                    f x = x{-caret-}
+
+                """.trimIndent())
+            }
+        }.fileWithCaret
+
+        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val document = FileDocumentManager.getInstance().getDocument(file)!!
+        reformat(PsiManager.getInstance(project).findFile(file)!!)
+        val expected = """
+                    module Main exposing (f)
+
+
+                    f x =
+                        x
+
+                """.trimIndent()
+        TestCase.assertEquals(expected, document.text)
+    }
+
+    private fun reformat(file: PsiFile) {
+        val dataContext = MapDataContext(mapOf(
+                CommonDataKeys.PROJECT to project,
+                CommonDataKeys.PSI_FILE to file
+        ))
+        val action = ElmExternalFormatAction()
+        val e = TestActionEvent(dataContext, action)
+        action.beforeActionPerformedUpdate(e)
+        check(e.presentation.isEnabledAndVisible) {
+            "The elm-format action should be enabled in this context"
+        }
+        action.actionPerformed(e)
+    }
+}

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture
 abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBuilder<*>>() {
 
 
-    private var toolchain: ElmToolchain? = null
+    protected var toolchain: ElmToolchain? = null
     private var originalToolchain: ElmToolchain? = null
 
 


### PR DESCRIPTION
Adds a 'Run elm-format on current file' action to IntelliJ's "Code" menu. This allows us to simplify the "elm-format" integration instructions. All the user will need to do is setup a key-binding.

The path to `elm-format` is currently derived based on the Elm compiler path. This is good enough for now, but we will want to be able to override the elm-format path in the very near future.

@FloWi I know you're interested in a few enhancements such as making the undo behavior nicer and adding an option to automatically run elm-format whenever Save happens. I'll leave that part up to you.

I'm going to hold off on updating the integration docs until the rest of the work is finished.