### PR TITLE
Improve guessIndent heuristic

### DIFF
--- a/src/main/kotlin/org/elm/ide/typing/ElementUtils.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElementUtils.kt
@@ -1,9 +1,26 @@
 package org.elm.ide.typing
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.ancestors
+import org.elm.lang.core.psi.elements.*
 
 /** Return the string that should indent an element based on the number of ancestors it has */
-fun guessIndent(element: PsiElement, offset: Int = -1): String =
-        "    ".repeat(element.ancestors.takeWhile { it !is ElmFile }.count() + offset)
+fun guessIndent(element: PsiElement, offset: Int = 0): String {
+    var current: PsiElement? = element
+    var count = 0
+
+    while (current != null && current !is PsiFile) {
+        val next = current.parent
+        when (next) {
+            is ElmCaseOfExpr, is ElmCaseOfBranch,
+            is ElmValueDeclaration, is ElmIfElseExpr -> count += 1
+            // the expression part of a let-in is at the same indentation as its parent
+            is ElmLetInExpr -> if (next.expression != current) count += 1
+        }
+
+        current = next
+    }
+
+    return "    ".repeat(count + offset)
+}

--- a/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
@@ -132,8 +132,8 @@ private class IfElseFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterPro
         // chained `if` expressions aren't parsed as a group if they're missing anything before the final else
         val elementPrev = element.prevSiblings.withoutWs.firstOrNull()
         val indentOffset = when {
-            elementPrev?.elementType == ElmTypes.ELSE -> -2
-            else -> -1
+            elementPrev?.elementType == ElmTypes.ELSE -> -1
+            else -> 0
         }
 
         val indent = guessIndent(element, indentOffset)

--- a/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
@@ -207,6 +207,29 @@ foo it =
         ()
 """)
 
+    fun `test nesting in let-in`() = checkFixByText("Add missing case branches", """
+type Foo = Bar
+
+foo : Foo -> ()
+foo it =
+    let
+        bar = ()
+    in
+    <error>case{-caret-}</error> it of
+""", """
+type Foo = Bar
+
+foo : Foo -> ()
+foo it =
+    let
+        bar = ()
+    in
+    case it of
+        Bar ->
+            --EOL
+""")
+
+
     fun `test nesting in case`() = checkFixByText("Add missing case branches", """
 type Foo = Bar
 


### PR DESCRIPTION
In certain types of nested expressions, `guessIndent` would produce incorrect results. This PR improves it from a simple ancestor count to a more detailed walk up the psi tree.