### PR TITLE
 Make 'add import' intention generate aliased imports, as needed

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -7,7 +7,6 @@ import com.intellij.psi.PsiReference
 import org.elm.ide.intentions.AddImportIntention
 import org.elm.ide.intentions.MakeDeclarationIntention
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmTypeAnnotation
@@ -37,7 +36,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
     )
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        var refs = element.references.asSequence()
+        var refs = element.references.toMutableList()
 
         // Pre-processing: ignore any qualified value/type refs where the module qualifier could not be resolved.
         // This is necessary because a single Psi element like ElmValueExpr can return multiple references:
@@ -45,7 +44,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
         // then the latter is guaranteed not to resolve. And we don't want to double-report the error, so we will
         // instead filter them out.
         if (refs.any { it is ModuleNameQualifierReference<*> && it.resolve() == null }) {
-            refs = refs.filterNot { it is QualifiedTypeReference || it is QualifiedValueReference || it is QualifiedConstructorReference }
+            refs.removeIf { it is QualifiedReference }
         }
 
         // Give each handler a chance to deal with the unresolved ref before falling back on an error
@@ -105,20 +104,12 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
     // Elm prohibits the use of the original module name in qualified references.
     // So we will try to detect this condition and present a helpful error.
     private fun handleModuleHiddenByAlias(ref: PsiReference, element: PsiElement, holder: AnnotationHolder): Boolean {
+        if (ref !is QualifiedReference) return false
         if (element !is ElmValueExpr && element !is ElmTypeRef) return false
         val elmFile = element.containingFile as? ElmFile ?: return false
 
-        val qid: ElmQID = when (ref) {
-            is QualifiedValueReference -> ref.valueQID
-            is QualifiedConstructorReference -> ref.upperCaseQID
-            is QualifiedTypeReference -> ref.upperCaseQID
-            else -> return false
-        }
-
-        if (qid.qualifierPrefix.isEmpty()) return false
-
-        val moduleName = qid.qualifierPrefix
-        val importDecl = ModuleScope(elmFile).getImportDecls().find { it.moduleQID.text == moduleName } ?: return false
+        val importDecl = ModuleScope(elmFile).getImportDecls().find { it.moduleQID.text == ref.qualifierPrefix }
+                ?: return false
         val aliasName = importDecl.asClause?.upperCaseIdentifier?.text ?: return false
 
         val importScope = ImportScope.fromImportDecl(importDecl) ?: return false
@@ -127,15 +118,15 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
             is QualifiedValueReference -> importScope.getExposedValues()
             is QualifiedConstructorReference -> importScope.getExposedConstructors()
             is QualifiedTypeReference -> importScope.getExposedTypes()
-            else -> return false
+            else -> error("Unexpected qualified ref type: $ref")
         }
 
-        if (exposedNames.none { it.name == ref.canonicalText })
+        if (exposedNames.none { it.name == ref.nameWithoutQualifier })
             return false
 
         // Success! The reference would have succeeded were it not for the alias.
-        holder.createErrorAnnotation(element, "Unresolved reference '${ref.canonicalText}'. " +
-                "Module '$moduleName' is imported as '$aliasName' and so you must use the alias here.")
+        holder.createErrorAnnotation(element, "Unresolved reference '${ref.nameWithoutQualifier}'. " +
+                "Module '${ref.qualifierPrefix}' is imported as '$aliasName' and so you must use the alias here.")
         return true
     }
 }

--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -44,7 +44,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
         // one for the module name and the other for the value/type name. If the former reference cannot be resolved,
         // then the latter is guaranteed not to resolve. And we don't want to double-report the error, so we will
         // instead filter them out.
-        if (refs.any { it is QualifiedModuleNameReference<*> && it.resolve() == null }) {
+        if (refs.any { it is ModuleNameQualifierReference<*> && it.resolve() == null }) {
             refs = refs.filterNot { it is QualifiedTypeReference || it is QualifiedValueReference || it is QualifiedConstructorReference }
         }
 

--- a/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
@@ -9,7 +9,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.ui.ColoredListCellRenderer
 import org.elm.lang.core.lookup.ElmLookup
 import org.elm.lang.core.psi.*
-import org.elm.lang.core.psi.ElmTypes.*
 import org.elm.lang.core.psi.elements.*
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.QualifiedReference
@@ -105,14 +104,9 @@ class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Cont
         }
     }
 
-    private val topLevelDeclarationTypes = tokenSetOf(
-            TYPE_DECLARATION, TYPE_ALIAS_DECLARATION, VALUE_DECLARATION,
-            TYPE_ANNOTATION, PORT_ANNOTATION
-    )
-
     private fun prepareInsertInNewSection(sourceFile: ElmFile): ASTNode {
         // prepare for insert immediately before the first top-level declaration
-        return sourceFile.node.findChildByType(topLevelDeclarationTypes)!!
+        return sourceFile.node.findChildByType(ELM_TOP_LEVEL_DECLARATIONS)!!
     }
 
     private fun getSortedInsertPosition(moduleName: String, existingImports: List<ElmImportClause>): ASTNode {

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -118,24 +118,16 @@ class ElmPsiFactory(private val project: Project) {
             createFromText("foo = x $text y", OPERATOR_IDENTIFIER)
                     ?: error("Failed to create operator identifier: `$text`")
 
-    fun createImport(moduleName: String) =
-            "import $moduleName"
-                    .let { createFromText<ElmImportClause>(it) }
-                    ?: error("Failed to create import of $moduleName")
+    fun createImport(moduleName: String, alias: String?): ElmImportClause {
+        val asClause = if (alias != null) " as $alias" else ""
+        return createFromText<ElmImportClause>("import $moduleName$asClause")
+                ?: error("Failed to create import of $moduleName")
+    }
 
     fun createImportExposing(moduleName: String, exposedNames: List<String>) =
             "import $moduleName exposing (${exposedNames.joinToString(", ")})"
                     .let { createFromText<ElmImportClause>(it) }
                     ?: error("Failed to create import of $moduleName exposing $exposedNames")
-
-    fun createValueDeclaration(name: String, argNames: List<String>): ElmValueDeclaration {
-        val s = if (argNames.isEmpty())
-            "$name = "
-        else
-            "$name ${argNames.joinToString(" ")} = "
-        return createFromText(s)
-                ?: error("Failed to create value declaration named $name")
-    }
 
     fun createCaseOfBranches(indent: String, patterns: List<String>): List<ElmCaseOfBranch> =
             patterns.joinToString("\n\n$indent", prefix = "foo = case 1 of\n\n$indent") { "$it ->\n$indent    " }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmTokenType.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmTokenType.kt
@@ -46,6 +46,16 @@ val ELM_IDENTIFIERS = tokenSetOf(
         LOWER_CASE_IDENTIFIER
 )
 
+/**
+ * The tokens corresponding to top-level code declarations.
+ *
+ * NOTE: this **excludes** module declarations and import statements
+ */
+val ELM_TOP_LEVEL_DECLARATIONS = tokenSetOf(
+        TYPE_DECLARATION, TYPE_ALIAS_DECLARATION, VALUE_DECLARATION,
+        TYPE_ANNOTATION, PORT_ANNOTATION
+)
+
 /** the virtual tokens which can be synthesized by [ElmLayoutLexer] */
 val ELM_VIRTUAL_TOKENS = tokenSetOf(
         VIRTUAL_OPEN_SECTION,

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeRef.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeRef.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReference
-import org.elm.lang.core.resolve.reference.QualifiedModuleNameReference
+import org.elm.lang.core.resolve.reference.ModuleNameQualifierReference
 import org.elm.lang.core.resolve.reference.QualifiedTypeReference
 import org.elm.lang.core.resolve.reference.SimpleTypeReference
 
@@ -47,7 +47,7 @@ class ElmTypeRef(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElement, 
     override fun getReferences(): Array<ElmReference> {
         return if (upperCaseQID.upperCaseIdentifierList.size > 1) {
             arrayOf(QualifiedTypeReference(this, upperCaseQID),
-                    QualifiedModuleNameReference(this, upperCaseQID))
+                    ModuleNameQualifierReference(this, upperCaseQID))
         } else {
             arrayOf(SimpleTypeReference(this))
         }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionPattern.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUnionPattern.kt
@@ -6,8 +6,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReference
+import org.elm.lang.core.resolve.reference.ModuleNameQualifierReference
 import org.elm.lang.core.resolve.reference.QualifiedConstructorReference
-import org.elm.lang.core.resolve.reference.QualifiedModuleNameReference
 import org.elm.lang.core.resolve.reference.SimpleUnionConstructorReference
 
 
@@ -42,7 +42,7 @@ class ElmUnionPattern(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElem
     override fun getReferences(): Array<ElmReference> =
             if (upperCaseQID.isQualified)
                 arrayOf(QualifiedConstructorReference(this, upperCaseQID),
-                        QualifiedModuleNameReference(this, upperCaseQID))
+                        ModuleNameQualifierReference(this, upperCaseQID))
             else
                 arrayOf(SimpleUnionConstructorReference(this))
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueExpr.kt
@@ -75,11 +75,11 @@ class ElmValueExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElement
             when (flavor) {
                 QualifiedValue -> arrayOf(
                         QualifiedValueReference(this, valueQID!!),
-                        QualifiedModuleNameReference(this, valueQID!!)
+                        ModuleNameQualifierReference(this, valueQID!!)
                 )
                 QualifiedConstructor -> arrayOf(
                         QualifiedConstructorReference(this, upperCaseQID!!),
-                        QualifiedModuleNameReference(this, upperCaseQID!!)
+                        ModuleNameQualifierReference(this, upperCaseQID!!)
                 )
                 BareValue -> arrayOf(LexicalValueReference(this))
                 BareConstructor -> arrayOf(SimpleUnionOrRecordConstructorReference(this))

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ModuleNameQualifierReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ModuleNameQualifierReference.kt
@@ -14,21 +14,28 @@ import org.elm.lang.core.resolve.scope.ModuleScope
 import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 /**
- * Qualified module-name reference from the value or type namespaces.
+ * A module-name (or alias) reference which qualifies a name from the value or type namespaces.
  *
  * e.g. `Data.User` in the expression `Data.User.name defaultUser`
+ *
+ * e.g. the `DU` alias in the expression `DU.name` in the program:
+ * ```
+ * import Data.User as DU
+ * f x = DU.name x
+ * ```
  *
  * @param elem the Psi element which owns the reference
  * @param elementQID the QID (qualified ID) element within `elem`
  */
-class QualifiedModuleNameReference<T : ElmReferenceElement>(
+class ModuleNameQualifierReference<T : ElmReferenceElement>(
         elem: T,
-        val elementQID: ElmQID
+        private val elementQID: ElmQID
 ) : ElmReferenceCached<T>(elem), ElmReference {
+
+    private val refText: String = elementQID.qualifierPrefix
 
     override fun resolveInner(): ElmNamedElement? {
         val clientFile = element.elmFile
-
         val importDecls = ModuleScope(clientFile).getImportDecls()
 
         // First, check to see if it resolves to an aliased import
@@ -54,9 +61,6 @@ class QualifiedModuleNameReference<T : ElmReferenceElement>(
         // Instead, see `ElmCompletionProvider`
         return emptyArray()
     }
-
-    val refText: String
-        get() = elementQID.text.split(".").dropLast(1).joinToString(".")
 
     override fun calculateDefaultRangeInElement(): TextRange {
         val startOffset = elementQID.offsetIn(element)

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedConstructorReference.kt
@@ -9,17 +9,18 @@ import org.elm.lang.core.resolve.scope.ImportScope
  * Qualified reference to a union constructor or record constructor
  */
 class QualifiedConstructorReference(referenceElement: ElmReferenceElement, val upperCaseQID: ElmUpperCaseQID
-) : ElmReferenceCached<ElmReferenceElement>(referenceElement) {
+) : ElmReferenceCached<ElmReferenceElement>(referenceElement), QualifiedReference {
 
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+            getCandidates().find { it.name == nameWithoutQualifier }
+
+    override val qualifierPrefix = upperCaseQID.qualifierPrefix
+    override val nameWithoutQualifier = element.referenceName
 
     private fun getCandidates(): Array<ElmNamedElement> {
-        val qualifierPrefix = upperCaseQID.qualifierPrefix
-
         // TODO [kl] depending on context, we may need to restrict the variants to just union constructors
         return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
                 .flatMap { it.getExposedConstructors() }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedReference.kt
@@ -1,0 +1,12 @@
+package org.elm.lang.core.resolve.reference
+
+/**
+ * A reference which is qualified by a module name (or an imported module's alias)
+ *
+ * @property qualifierPrefix the module name or alias (e.g. `Foo` in `Foo.bar`)
+ * @property nameWithoutQualifier the bare, unqualified name (e.g. `bar` in `Foo.bar`)
+ */
+interface QualifiedReference : ElmReference {
+    val qualifierPrefix: String
+    val nameWithoutQualifier: String
+}

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedTypeReference.kt
@@ -10,17 +10,19 @@ import org.elm.lang.core.resolve.scope.ImportScope
  */
 class QualifiedTypeReference(
         element: ElmReferenceElement,
-        val upperCaseQID: ElmUpperCaseQID)
-    : ElmReferenceCached<ElmReferenceElement>(element) {
+        val upperCaseQID: ElmUpperCaseQID
+) : ElmReferenceCached<ElmReferenceElement>(element), QualifiedReference {
 
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+            getCandidates().find { it.name == nameWithoutQualifier }
+
+    override val qualifierPrefix = upperCaseQID.qualifierPrefix
+    override val nameWithoutQualifier = element.referenceName
 
     private fun getCandidates(): List<ElmNamedElement> {
-        val qualifierPrefix = upperCaseQID.qualifierPrefix
         return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
                 .flatMap { it.getExposedTypes() }
     }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedValueReference.kt
@@ -10,16 +10,18 @@ import org.elm.lang.core.resolve.scope.ImportScope
  * Qualified reference to a value in an expression scope
  */
 class QualifiedValueReference(element: ElmReferenceElement, val valueQID: ElmValueQID
-) : ElmReferenceCached<ElmReferenceElement>(element) {
+) : ElmReferenceCached<ElmReferenceElement>(element), QualifiedReference {
 
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+            getCandidates().find { it.name == nameWithoutQualifier }
+
+    override val qualifierPrefix = valueQID.qualifierPrefix
+    override val nameWithoutQualifier = element.referenceName
 
     private fun getCandidates(): Array<ElmNamedElement> {
-        val qualifierPrefix = valueQID.qualifierPrefix
         return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
                 .flatMap { it.getExposedValues() }
                 .toTypedArray()

--- a/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
@@ -96,6 +96,20 @@ main = BarVariant
 """)
 
 
+    fun `test qualified value using an import alias`() = check(
+            """
+--@ main.elm
+main = Foo.bar{-caret-}
+--@ FooTooLongToType.elm
+module FooTooLongToType exposing (bar)
+bar = 42
+""",
+            """
+import FooTooLongToType as Foo
+main = Foo.bar
+""")
+
+
     fun `test binary infix operator`() = check(
             """
 --@ main.elm
@@ -231,8 +245,28 @@ main = bar + quux
 --@ main.elm
 main = bar{-caret-}
 --@ Foo.elm
-module Foo exposing ()
+module Foo exposing (quux)
 bar = 42
+quux = 0
+""")
+
+    fun `test verify unavailable when value not exposed (qualified ref)`() = verifyUnavailable(
+            """
+--@ main.elm
+main = Foo.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (quux)
+bar = 42
+quux = 0
+""")
+
+    fun `test verify unavailable when qualified ref alias is not possible`() = verifyUnavailable(
+            """
+--@ main.elm
+main = Foo.Bogus.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 0
 """)
 
     fun `test verify unavailable on type annotation when local function hides external name`() = verifyUnavailable(

--- a/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
@@ -51,6 +51,36 @@ main = Foo.bar
 """)
 
 
+    fun `test qualified type`() = check(
+            """
+--@ main.elm
+f : Foo.Bar{-caret-} -> ()
+f bar = ()
+--@ Foo.elm
+module Foo exposing (Bar)
+type Bar = BarVariant
+""",
+            """
+import Foo
+f : Foo.Bar -> ()
+f bar = ()
+""")
+
+
+    fun `test qualified union constructor`() = check(
+            """
+--@ main.elm
+main = Foo.BarVariant{-caret-}
+--@ Foo.elm
+module Foo exposing (Bar(..))
+type Bar = BarVariant
+""",
+            """
+import Foo
+main = Foo.BarVariant
+""")
+
+
     // see https://github.com/klazuka/intellij-elm/issues/77
     fun `test importing a union variant constructor exposes all variants`() = check(
             """


### PR DESCRIPTION
It has always annoyed me that the 'add import' intention was not smart enough to generate an aliased import. I frequently do stuff like `import Json.Decode as Decode`. But the 'add import' intention couldn't generate the aliased import for me.

Now if you have an unresolved reference like `Decode.succeed` and you invoke the 'add import' intention, it will import the `Json.Decode` module using the alias `Decode`.

I also cleaned up a lot of code related to qualified references.