### PR TITLE
Add support for generating a new Elm project

### DIFF
--- a/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
+++ b/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
@@ -1,0 +1,112 @@
+package org.elm.ide.project
+
+import com.intellij.ide.util.projectWizard.ModuleBuilder
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.projectRoots.SdkTypeId
+import com.intellij.openapi.roots.ModifiableRootModel
+import com.intellij.openapi.vfs.VfsUtil
+import org.elm.openapiext.pathAsPath
+import org.elm.workspace.asyncAutoDiscoverWorkspace
+import org.elm.workspace.elmToolchain
+import org.elm.workspace.elmWorkspace
+import org.intellij.lang.annotations.Language
+
+private val log = logger<ElmModuleBuilder>()
+
+
+/**
+ * Constructs a new IntelliJ [Module], which is quite different from a module in Elm.
+ */
+class ElmModuleBuilder : ModuleBuilder() {
+
+    override fun getModuleType(): ModuleType<*> =
+            ElmModuleType.INSTANCE
+
+    override fun isSuitableSdkType(sdkType: SdkTypeId?): Boolean =
+            true // we don't care about IntelliJ's concept of SDK
+
+    override fun setupRootModel(modifiableRootModel: ModifiableRootModel) {
+        log.info("Setting up a new Elm content root")
+        /*
+            NOTE: this is called on the EDT and we already have a write action
+         */
+        val root = doAddContentEntry(modifiableRootModel)?.file ?: return
+        modifiableRootModel.inheritSdk() // we don't care about SDKs, but IntelliJ does
+        val project = modifiableRootModel.project
+
+        VfsUtil.saveText(root.createChildData(this, "elm.json"), elmJson)
+        val srcDir = root.createChildDirectory(this, "src")
+        VfsUtil.saveText(srcDir.createChildData(this, "Main.elm"), elmMain)
+
+        // By this point, the important stuff has finished. Now we will
+        // try to auto-discover and configure some things for the user as
+        // a convenience. If it doesn't work, no big deal: the user will be
+        // prompted later to complete configuration.
+
+        if (project.elmToolchain == null) {
+            log.debug("Begin auto-discover the toolchain")
+            try {
+                asyncAutoDiscoverWorkspace(project, explicitRequest = true).get()
+            } catch (e: Exception) {
+                log.error("Auto-discover toolchain failed", e)
+            }
+            log.debug("Finished auto-discover: toolchain=${project.elmToolchain}")
+        }
+
+        if (project.elmToolchain != null) {
+            log.debug("Attempting to attach the Elm project")
+            // IMPORTANT: do *not* block on completion of the future (deadlock risk).
+            project.elmWorkspace.asyncAttachElmProject(root.pathAsPath.resolve("elm.json"))
+        }
+    }
+}
+
+
+/**
+ * As-of 2019-02-09, this is the standard `elm.json` file created by `elm init`.
+ * I would just run `elm init`, but it prompts the user for input, and there is
+ * no flag to override that behavior.
+ *
+ * TODO request that something like a `--yes` flag be added to `elm init` CLI
+ */
+@Language("JSON")
+val elmJson = """
+    {
+        "type": "application",
+        "source-directories": [
+            "src"
+        ],
+        "elm-version": "0.19.0",
+        "dependencies": {
+            "direct": {
+                "elm/browser": "1.0.1",
+                "elm/core": "1.0.2",
+                "elm/html": "1.0.0"
+            },
+            "indirect": {
+                "elm/json": "1.1.2",
+                "elm/time": "1.0.0",
+                "elm/url": "1.0.0",
+                "elm/virtual-dom": "1.0.2"
+            }
+        },
+        "test-dependencies": {
+            "direct": {},
+            "indirect": {}
+        }
+    }""".trimIndent()
+
+
+/**
+ * An empty Elm application to get started with.
+ */
+@Language("Elm")
+val elmMain = """
+    module Main exposing (main)
+
+    import Html exposing (text)
+
+    main = text "hi"
+    """.trimIndent()

--- a/src/main/kotlin/org/elm/ide/project/ElmModuleType.kt
+++ b/src/main/kotlin/org/elm/ide/project/ElmModuleType.kt
@@ -1,0 +1,25 @@
+package org.elm.ide.project
+
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.module.ModuleTypeManager
+import org.elm.ide.icons.ElmIcons
+import javax.swing.Icon
+
+class ElmModuleType : ModuleType<ElmModuleBuilder>(ID) {
+
+    override fun createModuleBuilder(): ElmModuleBuilder = ElmModuleBuilder()
+
+    override fun getName(): String = "Elm"
+
+    override fun getDescription(): String = "Elm module"
+
+    override fun getNodeIcon(isOpened: Boolean): Icon = ElmIcons.FILE
+
+    companion object {
+        val ID = "ELM_MODULE"
+        val INSTANCE: ElmModuleType by lazy {
+            ModuleTypeManager.getInstance().findByID(ID) as ElmModuleType
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -119,6 +119,8 @@
         <enterHandlerDelegate implementation="org.elm.ide.typing.ElmOnEnterSmartIndentHandler"/>
         <fileTypeFactory implementation="org.elm.lang.core.ElmFileTypeFactory"/>
         <internalFileTemplate name="Elm Module"/>
+        <moduleType id="ELM_MODULE" implementationClass="org.elm.ide.project.ElmModuleType"/>
+        <moduleBuilder builderClass="org.elm.ide.project.ElmModuleBuilder"/>
         <gotoSymbolContributor implementation="org.elm.ide.navigation.ElmGoToSymbolContributor"/>
         <lang.braceMatcher language="Elm" implementationClass="org.elm.ide.ElmPairedBraceMatcher"/>
         <lang.commenter language="Elm" implementationClass="org.elm.ide.commenter.ElmCommenter"/>


### PR DESCRIPTION
Fixes #30 

In the future we will show UI to allow the user to:
- configure the path to the Elm compiler
- configure the path to elm-format
- choose from different templates (e.g. maybe we should have a template like [example-elm-hot-webpack](https://github.com/klazuka/example-elm-hot-webpack))

Another thing that would be nice would be to automatically setup elm-test.