### PR TITLE
Clear the PsiReference cache whenever the Elm workspace changes

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
@@ -9,7 +9,6 @@ package org.elm.lang.core.psi
 
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.*
 import com.intellij.psi.impl.PsiTreeChangeEventImpl
@@ -70,5 +69,5 @@ class ElmPsiManager(val project: Project) : ProjectComponent {
 private val Project.elmPsiManager: ElmPsiManager
     get() = getComponent(ElmPsiManager::class.java)
 
-val Project.modificationTracker: ModificationTracker
+val Project.modificationTracker: SimpleModificationTracker
     get() = elmPsiManager.modificationTracker

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -28,6 +28,7 @@ import com.intellij.util.io.exists
 import com.intellij.util.io.systemIndependentPath
 import com.intellij.util.messages.Topic
 import org.elm.ide.notifications.showBalloon
+import org.elm.lang.core.psi.modificationTracker
 import org.elm.openapiext.findFileBreadthFirst
 import org.elm.openapiext.findFileByPathTestAware
 import org.elm.openapiext.modules
@@ -381,10 +382,14 @@ class ElmWorkspaceService(
 
     private fun notifyDidChangeWorkspace() {
         if (intellijProject.isDisposed) return
-        changeTracker.incModificationCount()
-        ResolveCache.getInstance(intellijProject).clearCache(true)
         ApplicationManager.getApplication().invokeAndWait {
             runWriteAction {
+                // Invalidate caches
+                ResolveCache.getInstance(intellijProject).clearCache(true) // PsiReference resolve
+                intellijProject.modificationTracker.incModificationCount() // CachedValuesManager: Elm Psi content
+                changeTracker.incModificationCount()                       // CachedValuesManager: Elm workspace/settings
+
+                // Refresh library roots
                 ProjectRootManagerEx.getInstanceEx(intellijProject)
                         .makeRootsChange(EmptyRunnable.getInstance(), false, true)
             }

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.util.EmptyRunnable
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.util.Consumer
 import com.intellij.util.io.exists
 import com.intellij.util.io.systemIndependentPath
@@ -381,6 +382,7 @@ class ElmWorkspaceService(
     private fun notifyDidChangeWorkspace() {
         if (intellijProject.isDisposed) return
         changeTracker.incModificationCount()
+        ResolveCache.getInstance(intellijProject).clearCache(true)
         ApplicationManager.getApplication().invokeAndWait {
             runWriteAction {
                 ProjectRootManagerEx.getInstanceEx(intellijProject)


### PR DESCRIPTION
The PsiReference cache is automatically cleared by IntelliJ whenever
a change occurs to any Psi in your project (e.g. typing some code).
And that's good. But we also need to be able to clear the cache
whenever an external change to the ElmProject occurs.

For instance, a user might have some imports with unresolved references
to packages which have not yet been installed. They switch over to their
terminal and use Elm's package installer to install the packages. Elm
updates the `elm.json` file, and our plugin notices the change and loads
the new dependency. Now the import which was unresolved should be able
to be resolved. But the old ref result was cached, so we need to clear
the cache.

Fixes #270 