### PR TITLE
create projectComponent that calls elm-format on save

### DIFF
--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -1,0 +1,42 @@
+package org.elm.ide.components
+
+import com.intellij.AppTopics
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileDocumentManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import org.elm.lang.core.psi.isElmFile
+import org.elm.workspace.ElmFormatCLI
+import org.elm.workspace.elmSettings
+import org.elm.workspace.elmToolchain
+
+class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
+
+    override fun initComponent() {
+        val application = ApplicationManager.getApplication()
+        val bus = application.messageBus
+
+        bus.connect().subscribe(
+                AppTopics.FILE_DOCUMENT_SYNC,
+                object : FileDocumentManagerListener {
+                    override fun beforeDocumentSaving(document: Document) {
+
+                        if (project.elmSettings.toolchain?.isElmFormatOnSaveEnabled != true) return
+
+                        val vFile = FileDocumentManager.getInstance().getFile(document) ?: return
+                        if (!vFile.isElmFile) return
+
+                        val elmVersion = ElmFormatCLI.getElmVersion(project, vFile) ?: return
+                        val elmFormat = project.elmToolchain?.elmFormat ?: return
+
+                        elmFormat.formatDocumentAndSetText(project, document, elmVersion)
+                    }
+                }
+        )
+    }
+}

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -7,9 +7,6 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.vfs.VirtualFile
 import org.elm.lang.core.psi.isElmFile
 import org.elm.workspace.ElmFormatCLI
 import org.elm.workspace.elmSettings
@@ -21,7 +18,7 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
         val application = ApplicationManager.getApplication()
         val bus = application.messageBus
 
-        bus.connect().subscribe(
+        bus.connect(project).subscribe(
                 AppTopics.FILE_DOCUMENT_SYNC,
                 object : FileDocumentManagerListener {
                     override fun beforeDocumentSaving(document: Document) {

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -22,8 +22,8 @@ import java.nio.file.Paths
 private val log = Logger.getInstance(ElmToolchain::class.java)
 
 
-data class ElmToolchain(val binDirPath: Path) {
-    constructor(binDirPath: String) : this(Paths.get(binDirPath))
+data class ElmToolchain(val binDirPath: Path, val isElmFormatOnSaveEnabled: Boolean) {
+    constructor(binDirPath: String, isElmFormatOnSaveEnabled: Boolean) : this(Paths.get(binDirPath), isElmFormatOnSaveEnabled)
 
     val presentableLocation: String
         get() = (elmCompilerPath ?: binDirPath.resolve("elm")).toString()
@@ -130,6 +130,7 @@ data class ElmToolchain(val binDirPath: Path) {
     companion object {
         const val ELM_JSON = "elm.json"
         const val ELM_LEGACY_JSON = "elm-package.json" // TODO [drop 0.18]
+        const val DEFAULT_FORMAT_ON_SAVE = false
 
         // TODO [drop 0.18] this list will no longer be necessary once the migration to 0.19 is complete
         val ELM_MANIFEST_FILE_NAMES = listOf(ElmToolchain.ELM_JSON, ElmToolchain.ELM_LEGACY_JSON)
@@ -140,7 +141,7 @@ data class ElmToolchain(val binDirPath: Path) {
         /** Suggest a toolchain that exists in in any standard location */
         fun suggest(project: Project): ElmToolchain? {
             return binDirSuggestions(project)
-                    .map { ElmToolchain(it.toAbsolutePath()) }
+                    .map { ElmToolchain(it.toAbsolutePath(), DEFAULT_FORMAT_ON_SAVE) }
                     .firstOrNull { it.looksLikeValidToolchain() }
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -223,6 +223,9 @@
         <component>
             <implementation-class>org.elm.lang.core.psi.ElmPsiManager</implementation-class>
         </component>
+        <component>
+            <implementation-class>org.elm.ide.components.ElmFormatOnFileSaveComponent</implementation-class>
+        </component>
     </project-components>
 
     <actions>
@@ -274,6 +277,5 @@
         </group>
 
     </actions>
-
 
 </idea-plugin>

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -7,6 +7,7 @@ import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.TestActionEvent
 import junit.framework.TestCase
 import org.elm.workspace.ElmWorkspaceTestBase
+import org.intellij.lang.annotations.Language
 
 class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
 
@@ -22,23 +23,7 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
 
     fun `test elm-format action with elm 19`() {
         val fileWithCaret = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.19.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", """
                     module Main exposing (f)
@@ -68,23 +53,7 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
     // TODO [drop 0.18] remove this test
     fun `test elm-format action with elm 18`() {
         val fileWithCaret = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.18.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm-package.json", manifestElm18)
             dir("src") {
                 elm("Main.elm", """
                     module Main exposing (f)
@@ -93,6 +62,9 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
                     f x = x{-caret-}
 
                 """.trimIndent())
+            }
+            dir("elm-stuff") {
+                file("exact-dependencies.json", "{}")
             }
         }.fileWithCaret
 
@@ -112,23 +84,7 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
 
     fun `test elm-format action shouldn't be active on non-elm files`() {
         val fileWithCaret = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.18.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm.json", manifestElm19.trimIndent())
             dir("src") {
                 elm("Main.scala", """
                     module Main exposing (f)
@@ -167,3 +123,39 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
         return Pair(action, event)
     }
 }
+
+
+@Language("JSON")
+private val manifestElm19 = """
+        {
+            "type": "application",
+            "source-directories": [
+                "src"
+            ],
+            "elm-version": "0.19.0",
+            "dependencies": {
+                "direct": {},
+                "indirect": {}
+            },
+            "test-dependencies": {
+                "direct": {},
+                "indirect": {}
+            }
+        }
+        """.trimIndent()
+
+
+// TODO [drop 0.18]
+@Language("JSON")
+private val manifestElm18 = """
+        {
+          "elm-version": "0.18.0 <= v < 0.19.0",
+          "version": "1.0.0",
+          "summary": "",
+          "repository": "",
+          "license": "",
+          "source-directories": [ "src" ],
+          "exposed-modules": [],
+          "dependencies": {}
+        }
+        """.trimIndent()

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import junit.framework.TestCase
 import org.elm.workspace.ElmWorkspaceTestBase
 import org.elm.workspace.elmWorkspace
+import org.intellij.lang.annotations.Language
 
 class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
@@ -39,25 +40,12 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
     fun `test ElmFormatOnFileSaveComponent should work with elm 18`() {
 
         val fileWithCaret: String = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.18.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm-package.json", manifestElm18)
             dir("src") {
                 elm("Main.elm", unformatted)
+            }
+            dir("elm-stuff") {
+                file("exact-dependencies.json", "{}")
             }
         }.fileWithCaret
 
@@ -68,23 +56,7 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
     fun `test ElmFormatOnFileSaveComponent should work with elm 19`() {
 
         val fileWithCaret: String = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.19.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", unformatted)
             }
@@ -95,23 +67,7 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
     fun `test ElmFormatOnFileSaveComponent should not touch a file with the wrong ending like 'scala'`() {
         val fileWithCaret = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.19.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.scala", """
                     module Main exposing (f)
@@ -132,23 +88,7 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
     fun `test ElmFormatOnFileSaveComponent should not touch a file if the save-hook is deactivated`() {
         val fileWithCaret = buildProject {
-            project("elm.json", """
-            {
-                "type": "application",
-                "source-directories": [
-                    "src"
-                ],
-                "elm-version": "0.19.0",
-                "dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                },
-                "test-dependencies": {
-                    "direct": {},
-                    "indirect": {}
-                }
-            }
-            """.trimIndent())
+            project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", """
                     module Main exposing (f)
@@ -187,4 +127,41 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
         TestCase.assertEquals(expected, document.text)
     }
+
 }
+
+
+@Language("JSON")
+private val manifestElm19 = """
+        {
+            "type": "application",
+            "source-directories": [
+                "src"
+            ],
+            "elm-version": "0.19.0",
+            "dependencies": {
+                "direct": {},
+                "indirect": {}
+            },
+            "test-dependencies": {
+                "direct": {},
+                "indirect": {}
+            }
+        }
+        """.trimIndent()
+
+
+// TODO [drop 0.18]
+@Language("JSON")
+private val manifestElm18 = """
+        {
+          "elm-version": "0.18.0 <= v < 0.19.0",
+          "version": "1.0.0",
+          "summary": "",
+          "repository": "",
+          "license": "",
+          "source-directories": [ "src" ],
+          "exposed-modules": [],
+          "dependencies": {}
+        }
+        """.trimIndent()

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -1,0 +1,190 @@
+package org.elm.ide.components
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import junit.framework.TestCase
+import org.elm.workspace.ElmWorkspaceTestBase
+import org.elm.workspace.elmWorkspace
+
+class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
+
+    override fun runTest() {
+        if (toolchain?.elmFormat == null) {
+            // TODO in the future maybe we should install elm-format in the CI build environment
+            System.err.println("SKIP $name: elm-format not found")
+            return
+        }
+        super.runTest()
+    }
+
+    val unformatted = """
+                    module Main exposing (f)
+
+
+                    f x = x{-caret-}
+
+                """.trimIndent()
+
+    val expectedFormatted = """
+                    module Main exposing (f)
+
+
+                    f x =
+                        x
+
+                """.trimIndent()
+
+
+    // TODO [drop 0.18] remove this test
+    fun `test ElmFormatOnFileSaveComponent should work with elm 18`() {
+
+        val fileWithCaret: String = buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.18.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", unformatted)
+            }
+        }.fileWithCaret
+
+        testCorrectFormatting(fileWithCaret, unformatted, expectedFormatted)
+
+    }
+
+    fun `test ElmFormatOnFileSaveComponent should work with elm 19`() {
+
+        val fileWithCaret: String = buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", unformatted)
+            }
+        }.fileWithCaret
+
+        testCorrectFormatting(fileWithCaret, unformatted, expectedFormatted)
+    }
+
+    fun `test ElmFormatOnFileSaveComponent should not touch a file with the wrong ending like 'scala'`() {
+        val fileWithCaret = buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.scala", """
+                    module Main exposing (f)
+
+
+                    f x = x{-caret-}
+
+                """.trimIndent())
+            }
+        }.fileWithCaret
+
+        testCorrectFormatting(
+                fileWithCaret,
+                unformatted,
+                expected = unformatted.replace("{-caret-}", "")
+        )
+    }
+
+    fun `test ElmFormatOnFileSaveComponent should not touch a file if the save-hook is deactivated`() {
+        val fileWithCaret = buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.0",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """.trimIndent())
+            dir("src") {
+                elm("Main.elm", """
+                    module Main exposing (f)
+
+
+                    f x = x{-caret-}
+
+                """.trimIndent())
+            }
+        }.fileWithCaret
+
+        testCorrectFormatting(
+                fileWithCaret,
+                unformatted,
+                expected = unformatted.replace("{-caret-}", ""),
+                activateOnSaveHook = false
+        )
+    }
+
+    private fun testCorrectFormatting(fileWithCaret: String, unformatted: String, expected: String, activateOnSaveHook: Boolean = true) {
+
+        project.elmWorkspace.useToolchain(toolchain?.copy(isElmFormatOnSaveEnabled = activateOnSaveHook))
+
+        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val fileDocumentManager = FileDocumentManager.getInstance()
+        val document = fileDocumentManager.getDocument(file)!!
+
+        // set text to mark file as unsaved
+        // (can't be the unmodified document.text since this won't trigger the beforeDocumentSaving callback)
+        val newContent = unformatted.replace("{-caret-}", "")
+        ApplicationManager.getApplication().runWriteAction {
+            document.setText(newContent)
+        }
+
+        fileDocumentManager.saveDocument(document)
+
+        TestCase.assertEquals(expected, document.text)
+    }
+}

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -531,7 +531,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
               <elmProjects>
                 <project path="$projectPathString" />
               </elmProjects>
-              <settings binDirPath="/usr/local/bin" />
+              <settings binDirPath="/usr/local/bin" isElmFormatOnSaveEnabled="false" />
             </state>
             """.trimIndent()
 
@@ -547,6 +547,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
     }
 
 
+
     fun `test persistence with empty toolchain binDirPath`() {
         val workspace = project.elmWorkspace
 
@@ -554,16 +555,24 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         val xml = """
             <state>
               <elmProjects />
-              <settings binDirPath="" />
+              <settings binDirPath=""/>
             </state>
             """.trimIndent()
+
+        val expected = """
+            <state>
+              <elmProjects />
+              <settings binDirPath="" isElmFormatOnSaveEnabled="false" />
+            </state>
+            """.trimIndent()
+
 
         // ... must be able to load from serialized state ...
         workspace.loadState(elementFromXmlString(xml))
 
         // ... and serialize the resulting state ...
         val actualXml = workspace.state.toXmlString()
-        checkEquals(xml, actualXml)
+        checkEquals(expected, actualXml)
     }
 }
 


### PR DESCRIPTION
@klazuka here's my initial draft of the ElmFormatOnFileSaveComponent. Works like a charm. Took me some time to figure out where the settings of the project are persisted.