### PR TITLE
Fix plugin crash when renaming element to invalid name

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmNamedElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmNamedElement.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.*
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
+import com.intellij.util.IncorrectOperationException
 import org.elm.ide.presentation.getPresentation
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
 import org.elm.lang.core.psi.ElmTypes.OPERATOR_IDENTIFIER


### PR DESCRIPTION
Throwing a `IllegalArgumentException`, as we we previously doing, crashes the plugin. Throwing an `IncorrectOperationException` causes IntelliJ to show the user an error message.

Fixes #243