### PR TITLE
 Show a banner notification when Elm project not found

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
+++ b/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
@@ -87,7 +87,7 @@ class ElmWorkspaceConfigurable(
                         is Result.Ok ->
                             when {
                                 versionResult.value < ElmToolchain.MIN_SUPPORTED_COMPILER_VERSION -> {
-                                    elmVersionLabel.text = "$versionResult.value (not supported)"
+                                    elmVersionLabel.text = "${versionResult.value} (not supported)"
                                     elmVersionLabel.foreground = JBColor.RED
                                 }
                                 else -> {


### PR DESCRIPTION
Fixes #267

And a few other things:
- Increase timeout when running `elm --version` (previous 1s, now 1.5s)
- Consolidate `GeneralCommandLine` code for running a process with a timeout
- Fix a bug when rendering the version number result in the `ElmWorkspaceConfigurable`