### PR TITLE
Freshen all vars retrieved from a cache during inference.

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -23,39 +23,49 @@ private val TY_UNION_CACHE_KEY: Key<CachedValue<ParameterizedInferenceResult<TyU
 private val TY_CACHE_KEY: Key<CachedValue<ParameterizedInferenceResult<Ty>>> = Key.create("TY_INFERENCE")
 private val TY_VARIANT_CACHE_KEY: Key<CachedValue<ParameterizedInferenceResult<VariantParameters>>> = Key.create("TY_VARIANT_INFERENCE")
 
-fun ElmTypeDeclaration.typeExpressionInference(): ParameterizedInferenceResult<TyUnion> =
-        CachedValuesManager.getCachedValue(this, TY_UNION_CACHE_KEY) {
-            val inferenceResult = TypeExpression().beginTypeDeclarationInference(this)
-            CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
-        }
+fun ElmTypeDeclaration.typeExpressionInference(): ParameterizedInferenceResult<TyUnion> {
+    val cachedValue = CachedValuesManager.getCachedValue(this, TY_UNION_CACHE_KEY) {
+        val inferenceResult = TypeExpression().beginTypeDeclarationInference(this)
+        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+    }
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value) as TyUnion)
+}
 
-fun ElmTypeAliasDeclaration.typeExpressionInference(): ParameterizedInferenceResult<Ty> =
-        CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
-            val inferenceResult = TypeExpression().beginTypeAliasDeclarationInference(this)
-            CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
-        }
+fun ElmTypeAliasDeclaration.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
+    val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
+        val inferenceResult = TypeExpression().beginTypeAliasDeclarationInference(this)
+        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+    }
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
+}
 
 
-fun ElmPortAnnotation.typeExpressionInference(): ParameterizedInferenceResult<Ty> =
-        CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
-            val inferenceResult = TypeExpression().beginPortAnnotationInference(this)
-            CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
-        }
+fun ElmPortAnnotation.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
+    val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
+        val inferenceResult = TypeExpression().beginPortAnnotationInference(this)
+        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+    }
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
 
-fun ElmUnionVariant.typeExpressionInference(): ParameterizedInferenceResult<Ty> =
-        CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
-            val inferenceResult = TypeExpression().beginUnionConstructorInference(this)
-            CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
-        }
+}
+
+fun ElmUnionVariant.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
+    val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
+        val inferenceResult = TypeExpression().beginUnionConstructorInference(this)
+        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+    }
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
+}
 
 
 /** Get the type of the expression in this annotation, or null if the program is incomplete and no expression exists */
 fun ElmTypeAnnotation.typeExpressionInference(): ParameterizedInferenceResult<Ty>? {
     val typeRef = typeExpression ?: return null
-    return CachedValuesManager.getCachedValue(typeRef, TY_CACHE_KEY) {
+    val cachedValue = CachedValuesManager.getCachedValue(typeRef, TY_CACHE_KEY) {
         val inferenceResult = TypeExpression().beginTypeRefInference(typeRef)
         CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
     }
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
 }
 
 /** Get the names and parameter tys for all variants of this union */

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -578,7 +578,7 @@ private class InferenceScope(
     private fun inferReferencedValueDeclaration(decl: ElmValueDeclaration?): Ty {
         if (decl == null || checkRecursion(decl)) return TyUnknown()
         val existing = resolvedDeclarations[decl]
-        if (existing != null) return existing
+        if (existing != null) return TypeReplacement.freshenVars(existing)
         // Use the type annotation if there is one
         var ty = decl.typeAnnotation?.typeExpressionInference()?.value
         // If there's no annotation, do full inference on the function.
@@ -1001,9 +1001,8 @@ private class InferenceScope(
 
     private fun trackReplacement(ty1: Ty, ty2: Ty, replacements: MutableMap<TyVar, Ty>?) {
         if (replacements == null) return
-        // assigning anything to a variable fixes the type of that variable (we later do replacements
-        // for vars that are assigned to other vars)
-        if (ty2 is TyVar && (ty2 !in replacements || ty1 !is TyVar)) {
+        // assigning anything to a variable fixes the type of that variable
+        if (ty2 is TyVar && (ty2 !in replacements || ty1 !is TyVar && replacements[ty2] is TyVar)) {
             replacements[ty2] = ty1
         }
         // unification: assigning a var to a type also restricts the vars type, but only if not

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1601,4 +1601,15 @@ main : ()
 main =
     <error descr="Type mismatch.Required: ()Found: Foo (String → Float → f) f">(foo (foo bar baz) qux)</error>
 """)
+
+    // https://github.com/klazuka/intellij-elm/issues/296
+    fun `test tuple with repeated unfixed vars`() = checkByText("""
+type alias Example = ( Maybe String, Maybe Int )
+
+foo : Example -> Example
+foo model = model
+
+main : Example
+main = ( Nothing, Nothing ) |> foo
+""")
 }


### PR DESCRIPTION
Fixes #296 

`Nothing` is of type `Maybe a`. In that issue, `a` was being unified to `String` correctly, but since both `a` variables were the same (because we were only freshening function return values), the second `Nothing` was already fixed to `String`, rather than being a unique variable that could be unified with `Int`.