### PR TITLE
Remove reserved keywords from lexer

### DIFF
--- a/src/main/grammars/ElmLexer.flex
+++ b/src/main/grammars/ElmLexer.flex
@@ -44,7 +44,6 @@ UpperCaseIdentifier = [:uppercase:]{IdentifierChar}*
 NumberLiteral = ("-")?[:digit:]+(\.[:digit:]+)?(e"-"?[:digit:]+)?
 HexLiteral = 0x{HexChar}+
 Operator = ("!"|"$"|"^"|"|"|"*"|"/"|"?"|"+"|"~"|"."|-|=|@|#|%|&|<|>|:|€|¥|¢|£|¤)+
-ReservedKeyword = ("hiding" | "export" | "foreign" | "deriving")
 
 ValidEscapeSequence = \\(u\{{HexChar}{4,6}\}|[nrt\"'\\])
 InvalidEscapeSequence = \\(u\{[^}]*\}|[^nrt\"'\\])
@@ -141,7 +140,6 @@ ThreeQuotes = \"\"\"
     "infix"                     { return INFIX; }
     "infixl"                    { return INFIXL; } // TODO [drop 0.18] remove infixl entirely
     "infixr"                    { return INFIXR; } // TODO [drop 0.18] remove infixr entirely
-    {ReservedKeyword}           { return RESERVED; }
     "("                         { return LEFT_PARENTHESIS; }
     ")"                         { return RIGHT_PARENTHESIS; }
     "["                         { return LEFT_SQUARE_BRACKET; }


### PR DESCRIPTION
As of Elm 0.19, it appears that there are no longer any reserved keywords in the compiler.

https://github.com/elm/compiler/blob/d09b95aac107291d50e8ee391d3288fc18c3891a/compiler/src/Parse/Keyword.hs#L29
https://ellie-app.com/4LRctgzwFJGa1

Fixes #297