### PR TITLE
elm-format only adds to the undo-stack if invoked directly via Action

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -39,7 +39,7 @@ class ElmExternalFormatAction : AnAction() {
         }
 
         try {
-            elmFormat.formatDocumentAndSetText(ctx.project, ctx.document, ctx.elmVersion)
+            elmFormat.formatDocumentAndSetText(ctx.project, ctx.document, ctx.elmVersion, addToUndoStack = true)
         } catch (ex: ExecutionException) {
             if (isUnitTestMode) throw ex
             val message = ex.message ?: "something went wrong running elm-format"

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -31,7 +31,7 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                         val elmVersion = ElmFormatCLI.getElmVersion(project, vFile) ?: return
                         val elmFormat = project.elmToolchain?.elmFormat ?: return
 
-                        elmFormat.formatDocumentAndSetText(project, document, elmVersion)
+                        elmFormat.formatDocumentAndSetText(project, document, elmVersion, addToUndoStack = false)
                     }
                 }
         )

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -1,7 +1,9 @@
 package org.elm.ide.components
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.undo.UndoManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
 import junit.framework.TestCase
 import org.elm.workspace.ElmWorkspaceTestBase
 import org.elm.workspace.elmWorkspace
@@ -63,6 +65,24 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
         }.fileWithCaret
 
         testCorrectFormatting(fileWithCaret, unformatted, expectedFormatted)
+    }
+
+    fun `test ElmFormatOnFileSaveComponent should not add to the undo stack`() {
+
+        val fileWithCaret: String = buildProject {
+            project("elm.json", manifestElm19)
+            dir("src") {
+                elm("Main.elm", unformatted)
+            }
+        }.fileWithCaret
+
+        testCorrectFormatting(fileWithCaret, unformatted, expectedFormatted)
+
+        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val fileEditor = FileEditorManager.getInstance(project).getSelectedEditor(file)
+
+        val undoManager = UndoManager.getInstance(project)
+        TestCase.assertFalse(undoManager.isUndoAvailable(fileEditor))
     }
 
     fun `test ElmFormatOnFileSaveComponent should not touch a file with the wrong ending like 'scala'`() {
@@ -127,7 +147,6 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
         TestCase.assertEquals(expected, document.text)
     }
-
 }
 
 


### PR DESCRIPTION
when invoked indirectly via ElmFormatOnFileSaveComponent nothing is added to the undo-stack