### PR TITLE
Add GLSL language injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The plugin also performs type checking, marking incompatible types in red.
 The current implementation of the type system does not infer the types of parameters of unannotated
 functions, but this limitation will be removed in the future.
 
+# GLSL integration
+
+If you install the [GLSL language plugin](https://plugins.jetbrains.com/plugin/6993-glsl-support),
+all of its features will be available in GLSL code blocks in your elm files.
 
 # Creating a new Elm project
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ functions, but this limitation will be removed in the future.
 # GLSL integration
 
 If you install the [GLSL language plugin](https://plugins.jetbrains.com/plugin/6993-glsl-support),
-all of its features will be available in GLSL code blocks in your elm files.
+all of its features will be available in GLSL code blocks in your Elm files.
 
 # Creating a new Elm project
 

--- a/src/main/kotlin/org/elm/ide/injection/ElmGlslInjector.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmGlslInjector.kt
@@ -1,0 +1,27 @@
+package org.elm.ide.injection
+
+import com.intellij.lang.Language
+import com.intellij.lang.injection.MultiHostInjector
+import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.elements.ElmGlslCodeExpr
+
+
+class ElmGlslInjector : MultiHostInjector {
+    override fun elementsToInjectIn(): List<Class<out PsiElement>> {
+        return listOf(ElmGlslCodeExpr::class.java)
+    }
+
+    override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
+        if (!context.isValid || context !is ElmGlslCodeExpr) return
+
+        val language = Language.findInstancesByMimeType("x-shader/x-fragment").firstOrNull() ?: return
+        val range = TextRange(7, context.textLength - 2)
+
+        registrar.startInjecting(language)
+                .addPlace(null, null, context, range)
+                .doneInjecting()
+    }
+}
+

--- a/src/main/kotlin/org/elm/ide/injection/GlslEscaper.kt
+++ b/src/main/kotlin/org/elm/ide/injection/GlslEscaper.kt
@@ -1,0 +1,19 @@
+package org.elm.ide.injection
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.LiteralTextEscaper
+import org.elm.lang.core.psi.elements.ElmGlslCodeExpr
+
+// GLSL blocks don't require any escaping, so this is a passthrough
+class GlslEscaper(host: ElmGlslCodeExpr) : LiteralTextEscaper<ElmGlslCodeExpr>(host) {
+    override fun isOneLine(): Boolean = false
+
+    override fun getOffsetInHost(offsetInDecoded: Int, rangeInsideHost: TextRange): Int {
+        return rangeInsideHost.startOffset + offsetInDecoded
+    }
+
+    override fun decode(rangeInsideHost: TextRange, outChars: StringBuilder): Boolean {
+        outChars.append(rangeInsideHost.substring(myHost.text))
+        return true
+    }
+}

--- a/src/main/kotlin/org/elm/lang/core/ElmLanguage.kt
+++ b/src/main/kotlin/org/elm/lang/core/ElmLanguage.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.fileTypes.LanguageFileType
 import org.elm.ide.icons.ElmIcons
 
 
-object ElmLanguage : Language("Elm")
+object ElmLanguage : Language("Elm", "text/elm", "text/x-elm", "application/x-elm")
 
 
 object ElmFileType : LanguageFileType(ElmLanguage) {

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -118,6 +118,10 @@ class ElmPsiFactory(private val project: Project) {
             createFromText("foo = x $text y", OPERATOR_IDENTIFIER)
                     ?: error("Invalid operator identifier: `$text`")
 
+    fun createGlslExpr(text: String): ElmGlslCodeExpr =
+            createFromText("foo = x $text y")
+                    ?: error("Invalid glsl expression: `$text`")
+
     fun createImport(moduleName: String, alias: String?): ElmImportClause {
         val asClause = if (alias != null) " as $alias" else ""
         return createFromText("import $moduleName$asClause")

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmGlslCodeExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmGlslCodeExpr.kt
@@ -1,8 +1,27 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
+import org.elm.ide.injection.GlslEscaper
 import org.elm.lang.core.psi.ElmAtomTag
 import org.elm.lang.core.psi.ElmPsiElementImpl
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.ElmTypes
 
 
-class ElmGlslCodeExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmAtomTag
+class ElmGlslCodeExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmAtomTag, PsiLanguageInjectionHost {
+    val content: List<PsiElement> get() = findChildrenByType(ElmTypes.GLSL_CODE_CONTENT)
+
+    override fun updateText(text: String): PsiLanguageInjectionHost {
+        val expr = ElmPsiFactory(project).createGlslExpr(text)
+        node.replaceAllChildrenToChildrenOf(expr.node)
+        return this
+    }
+
+    override fun createLiteralTextEscaper() = GlslEscaper(this)
+
+    override fun isValidHost(): Boolean = true
+}
+
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -214,6 +214,7 @@
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmModulesIndex"/>
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmNamedElementIndex"/>
 
+        <multiHostInjector implementation="org.elm.ide.injection.ElmGlslInjector"/>
 
         <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext"/>
         <defaultLiveTemplatesProvider implementation="org.elm.ide.livetemplates.ElmLiveTemplateProvider"/>


### PR DESCRIPTION
IntelliJ allows you to inject languages from other plugins if they register a mimetype. This PR adds language injection to GLSL code blocks if the user has a plugin that supports it. If no plugin is found, GLSL blocks will behave the same way they currently do.

I also added mimetypes to the elm language registration so that other plugins can inject elm code if they want to.