### PR TITLE
Add reference support for type variables in a declaration

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -97,6 +97,11 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
             return true
         }
 
+        // Ignore soft refs
+        if (ref.isSoft) {
+            return true
+        }
+
         return false
     }
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeVariableRef.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmTypeVariableRef.kt
@@ -2,20 +2,58 @@ package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
-import org.elm.lang.core.psi.ElmPsiElementImpl
-import org.elm.lang.core.psi.ElmTypes
-import org.elm.lang.core.psi.ElmTypeRefArgumentTag
-import org.elm.lang.core.psi.ElmTypeExpressionSegmentTag
-import org.elm.lang.core.psi.ElmUnionVariantParameterTag
+import com.intellij.psi.util.parentOfType
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.resolve.ElmReferenceElement
+import org.elm.lang.core.resolve.reference.ElmReferenceCached
 
 /**
  * Holds a lower-case identifier within a type reference which
  * gives the type variable in a parametric type.
  *
  * e.g. the 'a' in `map : (a -> b) -> List a -> List b`
+ * e.g. the last `a` in `type Foo a = Bar a`
  */
-class ElmTypeVariableRef(node: ASTNode) : ElmPsiElementImpl(node), ElmUnionVariantParameterTag, ElmTypeRefArgumentTag, ElmTypeExpressionSegmentTag {
+class ElmTypeVariableRef(
+        node: ASTNode
+) : ElmPsiElementImpl(node),
+        ElmReferenceElement,
+        ElmUnionVariantParameterTag,
+        ElmTypeRefArgumentTag,
+        ElmTypeExpressionSegmentTag {
 
     val identifier: PsiElement
         get() = findNotNullChildByType(ElmTypes.LOWER_CASE_IDENTIFIER)
+
+    override val referenceNameElement: PsiElement
+        get() = identifier
+
+    override val referenceName: String
+        get() = referenceNameElement.text
+
+    override fun getReference() =
+            object : ElmReferenceCached<ElmTypeVariableRef>(this) {
+
+                override fun isSoft(): Boolean {
+                    val unionTypeDecl = parentOfType<ElmTypeDeclaration>()
+                    val typeAliasDecl = parentOfType<ElmTypeAliasDeclaration>()
+                    // The reference is considered soft if we are not in a type declaration
+                    // context. In such cases, the type variable is completely free: it does
+                    // not refer to anything else.
+                    return unionTypeDecl == null && typeAliasDecl == null
+                }
+
+                override fun resolveInner(): ElmNamedElement? =
+                        getVariants().find { it.name == referenceName }
+
+                override fun getVariants(): Array<ElmNamedElement> {
+                    if (isSoft) return emptyArray()
+
+                    val typeVars = element.parentOfType<ElmTypeDeclaration>()?.lowerTypeNameList
+                            ?: element.parentOfType<ElmTypeAliasDeclaration>()?.lowerTypeNameList
+                            ?: return emptyArray()
+
+                    return typeVars.toTypedArray()
+                }
+            }
 }

--- a/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
@@ -99,7 +99,7 @@ type Msg a b
     | MsgTwo (Maybe (Maybe Foo))
     | MsgThree b a
     | MsgFour {x: ()}
-    | MsgFive (x, y)
+    | MsgFive (a, b)
     | MsgSix (Msg () ())
 
 foo : Msg a b -> ()
@@ -114,7 +114,7 @@ type Msg a b
     | MsgTwo (Maybe (Maybe Foo))
     | MsgThree b a
     | MsgFour {x: ()}
-    | MsgFive (x, y)
+    | MsgFive (a, b)
     | MsgSix (Msg () ())
 
 foo : Msg a b -> ()
@@ -132,7 +132,7 @@ foo it =
         MsgFour record ->
             --EOL
 
-        MsgFive (x, y) ->
+        MsgFive (a, b) ->
             --EOL
 
         MsgSix msg ->

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmTypeResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmTypeResolveTest.kt
@@ -119,4 +119,17 @@ foo user =
         --^unresolved
 """)
 
+
+    fun `test variable in union type`() = checkByCode(
+            """
+type Page a = Home a
+        --X      --^
+""")
+
+
+    fun `test variable in a record type alias`() = checkByCode(
+            """
+type alias User details = { name : String, extra : details }
+                --X                                --^
+""")
 }


### PR DESCRIPTION
Fixes #9 

This also has the side effect of fixing a false positive in the 'unused symbol' inspection.