### PR TITLE
Inject regex language into strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ intellij {
     version intellijPlatformVersion
     pluginName 'intellij-elm'
     updateSinceUntilBuild false
+    plugins = ["IntelliLang"]
 }
 
 // ------------------------------------------------

--- a/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
@@ -1,0 +1,44 @@
+package org.elm.ide.injection
+
+import com.intellij.lang.injection.MultiHostInjector
+import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
+import org.elm.lang.core.psi.elements.ElmGlslCodeExpr
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+import org.intellij.lang.regexp.RegExpLanguage
+
+
+class ElmRegexInjector : MultiHostInjector {
+    override fun elementsToInjectIn(): List<Class<out PsiElement>> {
+        return listOf(ElmStringConstantExpr::class.java)
+    }
+
+    override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
+        if (!context.isValid || context !is ElmStringConstantExpr || !shouldInject(context)) return
+
+        val text = context.text
+        val range = when {
+            text.startsWith("\"\"\"") -> TextRange(3, text.length - 3)
+            else -> TextRange(1, text.length - 1)
+        }
+
+        registrar.startInjecting(RegExpLanguage.INSTANCE)
+                .addPlace(null, null, context, range)
+                .doneInjecting()
+    }
+
+    // This function is called on the EDT, so resolving references can freeze the UI. Instead, we
+    // just have to check the function name. This means that we won't inject unless the function is
+    // called qualified with the Regex module.
+    private fun shouldInject(context: ElmStringConstantExpr): Boolean {
+        val call = context.parent as? ElmFunctionCallExpr ?: return false
+        val targetName = call.target.text
+        // We don't need to check which argument of the call we're looking at, since both of these
+        // functions only take one string
+        return targetName == "Regex.fromString" || targetName == "Regex.fromStringWith"
+    }
+}
+

--- a/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
@@ -2,13 +2,18 @@ package org.elm.ide.injection
 
 import com.intellij.lang.injection.MultiHostInjector
 import com.intellij.lang.injection.MultiHostRegistrar
-import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
-import org.elm.lang.core.psi.elements.ElmGlslCodeExpr
 import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.psi.prevSiblings
+import org.elm.lang.core.psi.withoutWs
 import org.intellij.lang.regexp.RegExpLanguage
+
+private val commentRegex = Regex("(?i)^(?:\\{-|--)\\s*language\\s*[:=]\\s*regexp?\\s*(?:-})?$")
 
 
 class ElmRegexInjector : MultiHostInjector {
@@ -30,15 +35,35 @@ class ElmRegexInjector : MultiHostInjector {
                 .doneInjecting()
     }
 
+    private fun shouldInject(context: ElmStringConstantExpr): Boolean {
+        return isRegexFromStringArg(context) || hasRegexLangComment(context)
+    }
+
     // This function is called on the EDT, so resolving references can freeze the UI. Instead, we
     // just have to check the function name. This means that we won't inject unless the function is
     // called qualified with the Regex module.
-    private fun shouldInject(context: ElmStringConstantExpr): Boolean {
+    private fun isRegexFromStringArg(context: ElmStringConstantExpr): Boolean {
         val call = context.parent as? ElmFunctionCallExpr ?: return false
         val targetName = call.target.text
         // We don't need to check which argument of the call we're looking at, since both of these
         // functions only take one string
         return targetName == "Regex.fromString" || targetName == "Regex.fromStringWith"
+    }
+
+    private fun hasRegexLangComment(context: ElmStringConstantExpr): Boolean {
+        val comment = getPrevComment(context) ?: getValueDeclComment(context) ?: return false
+        return comment.text.matches(commentRegex)
+    }
+
+    private fun getPrevComment(element: PsiElement): PsiComment? {
+        return element.prevSiblings.withoutWs.firstOrNull() as? PsiComment
+    }
+
+    /** If [element] is a direct child of a value declaration, return the declaration's comment */
+    private fun getValueDeclComment(element: PsiElement): PsiComment? {
+        val decl = element.parent as? ElmValueDeclaration ?: return null
+        return decl.prevSiblings.withoutWs.filter { it !is ElmTypeAnnotation }
+                .firstOrNull() as? PsiComment
     }
 }
 

--- a/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
@@ -2,7 +2,6 @@ package org.elm.ide.injection
 
 import com.intellij.lang.injection.MultiHostInjector
 import com.intellij.lang.injection.MultiHostRegistrar
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
@@ -25,10 +24,7 @@ class ElmRegexInjector : MultiHostInjector {
         if (!context.isValid || context !is ElmStringConstantExpr || !shouldInject(context)) return
 
         val text = context.text
-        val range = when {
-            text.startsWith("\"\"\"") -> TextRange(3, text.length - 3)
-            else -> TextRange(1, text.length - 1)
-        }
+        val range = context.contentOffsets
 
         registrar.startInjecting(RegExpLanguage.INSTANCE)
                 .addPlace(null, null, context, range)

--- a/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmRegexInjector.kt
@@ -21,9 +21,13 @@ class ElmRegexInjector : MultiHostInjector {
     }
 
     override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
-        if (!context.isValid || context !is ElmStringConstantExpr || !shouldInject(context)) return
+        if (context !is ElmStringConstantExpr ||
+                !context.isValid ||
+                !context.isValidHost ||
+                !shouldInject(context)) {
+            return
+        }
 
-        val text = context.text
         val range = context.contentOffsets
 
         registrar.startInjecting(RegExpLanguage.INSTANCE)

--- a/src/main/kotlin/org/elm/ide/injection/ElmStringEscaper.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmStringEscaper.kt
@@ -1,0 +1,90 @@
+package org.elm.ide.injection
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.LiteralTextEscaper
+import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+
+class ElmStringEscaper(
+        host: ElmStringConstantExpr,
+        private val isOneLine: Boolean
+) : LiteralTextEscaper<ElmStringConstantExpr>(host) {
+    /** A map of indexes in the decoded string to their index in the original string */
+    private var outSourceOffsets: IntArray = intArrayOf()
+
+    override fun isOneLine(): Boolean = isOneLine
+
+    override fun getOffsetInHost(offsetInDecoded: Int, rangeInsideHost: TextRange): Int {
+        val result = outSourceOffsets.getOrNull(offsetInDecoded) ?: return -1
+        val offset = if (result <= rangeInsideHost.length) result else rangeInsideHost.length
+        return offset + rangeInsideHost.startOffset
+    }
+
+    override fun decode(rangeInsideHost: TextRange, outChars: StringBuilder): Boolean {
+        val (offsets, result) = decodeEscapes(rangeInsideHost, myHost, outChars)
+        outSourceOffsets = offsets
+        return result
+    }
+}
+
+/**
+ * Based on [com.intellij.codeInsight.CodeInsightUtilCore.parseStringCharacters], but using the
+ * pre-lexed elements instead of lexing the string again manually.
+ */
+private fun decodeEscapes(
+        rangeInsideHost: TextRange,
+        constantExpr: ElmStringConstantExpr,
+        outChars: StringBuilder
+): Pair<IntArray, Boolean> {
+    val chunks = constantExpr.content
+    val sourceOffsets = IntArray(rangeInsideHost.length + 1)
+    val outOffset = outChars.length
+    var index = 0
+    for (chunk in chunks) {
+        if (chunk.elementType == ElmTypes.REGULAR_STRING_PART) {
+            val first = outChars.length - outOffset
+            outChars.append(chunk.text)
+            val last = outChars.length - outOffset - 1
+            for (i in first..last) {
+                sourceOffsets[i] = index
+                index += 1
+            }
+            continue
+        }
+
+        // Set offset for the decoded character to the beginning of the escape sequence.
+        sourceOffsets[outChars.length - outOffset] = index
+        sourceOffsets[outChars.length - outOffset + 1] = index + 1
+
+        when (chunk.elementType) {
+            ElmTypes.STRING_ESCAPE -> {
+                val text = chunk.text
+                val decodeEscape = decodeEscape(text)
+                outChars.append(decodeEscape)
+                index += text.length
+            }
+            ElmTypes.INVALID_STRING_ESCAPE -> return sourceOffsets to false
+            else -> error("Invalid string part $chunk")
+        }
+    }
+
+    sourceOffsets[outChars.length - outOffset] = index
+
+    return sourceOffsets to true
+}
+
+private fun decodeEscape(esc: String): String = when (esc) {
+    "\\n" -> "\n"
+    "\\r" -> "\r"
+    "\\t" -> "\t"
+    "\\\"" -> "\""
+    "\\'" -> "\'"
+    "\\\\" -> "\\"
+
+    else -> {
+        assert(esc.length >= 2)
+        assert(esc.startsWith("\\u"))
+        Integer.parseInt(esc.substring(3, esc.length - 1), 16).toChar().toString()
+    }
+}

--- a/src/main/kotlin/org/elm/ide/injection/ElmStringLiteralManipulator.kt
+++ b/src/main/kotlin/org/elm/ide/injection/ElmStringLiteralManipulator.kt
@@ -1,0 +1,19 @@
+package org.elm.ide.injection
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+
+class ElmStringLiteralManipulator : AbstractElementManipulator<ElmStringConstantExpr>() {
+    override fun handleContentChange(element: ElmStringConstantExpr, range: TextRange, newContent: String): ElmStringConstantExpr {
+        if (range != getRangeInElement(element)) {
+            // not supported
+            return element
+        }
+
+        element.updateText(newContent)
+        return element
+    }
+
+    override fun getRangeInElement(element: ElmStringConstantExpr): TextRange = element.contentOffsets
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -123,7 +123,7 @@ class ElmPsiFactory(private val project: Project) {
                     ?: error("Invalid glsl expression: `$text`")
 
     fun createStringConstant(text: String): ElmStringConstantExpr =
-            createFromText("foo = x $text y")
+            createFromText("foo = x \"$text\" y")
                     ?: error("Invalid string constant: `$text`")
 
     fun createImport(moduleName: String, alias: String?): ElmImportClause {

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -122,6 +122,10 @@ class ElmPsiFactory(private val project: Project) {
             createFromText("foo = x $text y")
                     ?: error("Invalid glsl expression: `$text`")
 
+    fun createStringConstant(text: String): ElmStringConstantExpr =
+            createFromText("foo = x $text y")
+                    ?: error("Invalid string constant: `$text`")
+
     fun createImport(moduleName: String, alias: String?): ElmImportClause {
         val asClause = if (alias != null) " as $alias" else ""
         return createFromText("import $moduleName$asClause")

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLanguageInjectionHost
 import org.elm.ide.injection.ElmStringEscaper
 import org.elm.lang.core.psi.*
+import org.intellij.lang.annotations.Language
 
 
 /** A literal string. e.g. `""` or `"""a"b"""` */

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
@@ -1,16 +1,21 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.LiteralTextEscaper
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLanguageInjectionHost
 import org.elm.ide.injection.ElmStringEscaper
 import org.elm.lang.core.psi.*
-import org.intellij.lang.annotations.Language
+import org.intellij.lang.regexp.DefaultRegExpPropertiesProvider
+import org.intellij.lang.regexp.RegExpLanguageHost
+import org.intellij.lang.regexp.psi.RegExpChar
+import org.intellij.lang.regexp.psi.RegExpGroup
+import org.intellij.lang.regexp.psi.RegExpNamedGroupRef
 
 
 /** A literal string. e.g. `""` or `"""a"b"""` */
-class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), PsiLanguageInjectionHost, ElmConstantTag {
+class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), PsiLanguageInjectionHost, RegExpLanguageHost, ElmConstantTag {
     /** The elements that make up the string, excluding the opening or closing quotes */
     val content: Sequence<PsiElement>
         get() =
@@ -21,6 +26,12 @@ class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), PsiLanguag
                             it == ElmTypes.INVALID_STRING_ESCAPE
                 }
             }
+
+    /** The offset, relative to this element, of the content of the string (everything except the quotation marks)*/
+    val contentOffsets: TextRange get() = when {
+        text.startsWith("\"\"\"") -> TextRange(3, text.length - 3)
+        else -> TextRange(1, text.length - 1)
+    }
 
     override fun isValidHost(): Boolean = true
 
@@ -33,4 +44,27 @@ class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), PsiLanguag
     override fun createLiteralTextEscaper(): LiteralTextEscaper<ElmStringConstantExpr> {
         return ElmStringEscaper(this, !text.startsWith("\"\"\""))
     }
+
+    override fun characterNeedsEscaping(c: Char): Boolean = false
+    override fun supportsPerl5EmbeddedComments(): Boolean = false
+    override fun supportsPossessiveQuantifiers(): Boolean = true
+    override fun supportsPythonConditionalRefs(): Boolean = false
+    override fun supportsNamedGroupSyntax(group: RegExpGroup): Boolean = true
+
+    override fun supportsNamedGroupRefSyntax(ref: RegExpNamedGroupRef): Boolean =
+            ref.isNamedGroupRef
+
+    override fun supportsExtendedHexCharacter(regExpChar: RegExpChar): Boolean = true
+
+    override fun isValidCategory(category: String): Boolean =
+            DefaultRegExpPropertiesProvider.getInstance().isValidCategory(category)
+
+    override fun getAllKnownProperties(): Array<Array<String>> =
+            DefaultRegExpPropertiesProvider.getInstance().allKnownProperties
+
+    override fun getPropertyDescription(name: String?): String? =
+            DefaultRegExpPropertiesProvider.getInstance().getPropertyDescription(name)
+
+    override fun getKnownCharacterClasses(): Array<Array<String>> =
+            DefaultRegExpPropertiesProvider.getInstance().knownCharacterClasses
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
@@ -33,7 +33,9 @@ class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), PsiLanguag
         else -> TextRange(1, text.length - 1)
     }
 
-    override fun isValidHost(): Boolean = true
+    override fun isValidHost(): Boolean {
+        return findChildByType<PsiElement>(ElmTypes.CLOSE_QUOTE) != null
+    }
 
     override fun updateText(text: String): PsiLanguageInjectionHost {
         val expr = ElmPsiFactory(project).createStringConstant(text)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
@@ -1,9 +1,35 @@
 package org.elm.lang.core.psi.elements
 
 import com.intellij.lang.ASTNode
-import org.elm.lang.core.psi.ElmConstantTag
-import org.elm.lang.core.psi.ElmPsiElementImpl
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
+import org.elm.ide.injection.ElmStringEscaper
+import org.elm.lang.core.psi.*
 
 
 /** A literal string. e.g. `""` or `"""a"b"""` */
-class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmConstantTag
+class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), PsiLanguageInjectionHost, ElmConstantTag {
+    /** The elements that make up the string, excluding the opening or closing quotes */
+    val content: Sequence<PsiElement>
+        get() =
+            directChildren.filter { child ->
+                child.elementType.let {
+                    it == ElmTypes.REGULAR_STRING_PART ||
+                            it == ElmTypes.STRING_ESCAPE ||
+                            it == ElmTypes.INVALID_STRING_ESCAPE
+                }
+            }
+
+    override fun isValidHost(): Boolean = true
+
+    override fun updateText(text: String): PsiLanguageInjectionHost {
+        val expr = ElmPsiFactory(project).createStringConstant(text)
+        node.replaceAllChildrenToChildrenOf(expr.node)
+        return this
+    }
+
+    override fun createLiteralTextEscaper(): LiteralTextEscaper<ElmStringConstantExpr> {
+        return ElmStringEscaper(this, !text.startsWith("\"\"\""))
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -225,6 +225,8 @@
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmModulesIndex"/>
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmNamedElementIndex"/>
 
+        <lang.elementManipulator forClass="org.elm.lang.core.psi.elements.ElmStringConstantExpr"
+                                 implementationClass="org.elm.ide.injection.ElmStringLiteralManipulator"/>
         <multiHostInjector implementation="org.elm.ide.injection.ElmGlslInjector"/>
         <multiHostInjector implementation="org.elm.ide.injection.ElmRegexInjector"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -226,6 +226,7 @@
         <stubIndex implementation="org.elm.lang.core.stubs.index.ElmNamedElementIndex"/>
 
         <multiHostInjector implementation="org.elm.ide.injection.ElmGlslInjector"/>
+        <multiHostInjector implementation="org.elm.ide.injection.ElmRegexInjector"/>
 
         <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext"/>
         <defaultLiveTemplatesProvider implementation="org.elm.ide.livetemplates.ElmLiveTemplateProvider"/>

--- a/src/test/kotlin/org/elm/ide/intentions/InjectLanguageIntentTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/InjectLanguageIntentTest.kt
@@ -1,0 +1,66 @@
+package org.elm.ide.intentions
+
+import com.intellij.injected.editor.EditorWindow
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.injection.Injectable
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import org.elm.lang.core.psi.parentOfType
+import org.intellij.lang.annotations.Language
+import org.intellij.plugins.intelliLang.inject.InjectLanguageAction
+import org.intellij.plugins.intelliLang.inject.InjectedLanguage
+
+class InjectLanguageIntentionTest : ElmIntentionTestBase(InjectLanguageAction()) {
+    fun `test available inside string`() = checkAvailable("""
+foo = "{-caret-}"
+""")
+
+    fun `test available before string`() = checkAvailable("""
+foo = {-caret-}"123"
+""")
+
+    fun `test unavailable inside number`() = doUnavailableTest("""
+foo = {-caret-}123
+""")
+
+    fun `test inject RegExp`() = doTest("RegExp", """
+foo = {-caret-}"abc(def)"
+""")
+
+    private fun checkAvailable(@Language("Elm") code: String) {
+        InlineFile(code).withCaret()
+        check(intention.isAvailable(project, myFixture.editor, myFixture.file)) {
+            "Intention is not available"
+        }
+    }
+
+    private fun doTest(lang: String, @Language("Elm") code: String) {
+        InlineFile(code.trimIndent()).withCaret()
+        val language = InjectedLanguage.findLanguageById(lang)
+        val injectable = Injectable.fromLanguage(language)
+        InjectLanguageAction.invokeImpl(project, myFixture.editor, myFixture.file, injectable)
+        val host = findInjectionHost(myFixture.editor, myFixture.file)
+                ?: error("InjectionHost not found")
+        val injectedList = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(host)
+                ?: error("Language injection failed")
+        LightPlatformCodeInsightFixtureTestCase.assertEquals(injectedList.size, 1)
+        val injectedPsi = injectedList.first().first
+        LightPlatformCodeInsightFixtureTestCase.assertEquals(injectedPsi.language, language)
+    }
+}
+
+private fun findInjectionHost(editor: Editor, file: PsiFile): PsiLanguageInjectionHost? {
+    if (editor is EditorWindow) return null
+    val offset = editor.caretModel.offset
+    val vp = file.viewProvider
+    for (language in vp.languages) {
+        val host = vp.findElementAt(offset, language)
+                ?.parentOfType<PsiLanguageInjectionHost>(strict = false)
+        if (host != null && host.isValidHost) {
+            return host
+        }
+    }
+    return null
+}


### PR DESCRIPTION
This PR injects the regular expression language into string that are passed to `Regex.fromString`, or are preceded by a comment like `--language: regex` (or `Language=RegExp` etc.). If the string is the body of a value declaration, you can also put the comment before the declaration.

Unfortunately, the callback that determines whether an element can be injected is called on the EDT, so we can't resolve the method call do more advanced heuristics.