### PR TITLE
Allow user to configure location of `elm-format` and `elm-test` executables

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -34,7 +34,7 @@ class ElmExternalFormatAction : AnAction() {
             return
         }
 
-        val elmFormat = ctx.project.elmToolchain?.elmFormat
+        val elmFormat = ctx.project.elmToolchain.elmFormatCLI
         if (elmFormat == null) {
             ctx.project.showBalloon("could not find elm-format", NotificationType.ERROR)
             return

--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -14,8 +14,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.notifications.showBalloon
 import org.elm.lang.core.psi.isElmFile
 import org.elm.openapiext.isUnitTestMode
-import org.elm.workspace.ElmFormatCLI
 import org.elm.workspace.Version
+import org.elm.workspace.commandLineTools.ElmFormatCLI
 import org.elm.workspace.elmToolchain
 
 

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -25,7 +25,7 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                 object : FileDocumentManagerListener {
                     override fun beforeDocumentSaving(document: Document) {
 
-                        if (project.elmSettings.toolchain?.isElmFormatOnSaveEnabled != true) return
+                        if (!project.elmSettings.toolchain.isElmFormatOnSaveEnabled) return
 
                         val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document) ?: return
                         if (PsiTreeUtil.hasErrorElements(psiFile)) return
@@ -34,7 +34,7 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                         if (!vFile.isElmFile) return
 
                         val elmVersion = ElmFormatCLI.getElmVersion(project, vFile) ?: return
-                        val elmFormat = project.elmToolchain?.elmFormat ?: return
+                        val elmFormat = project.elmToolchain.elmFormatCLI ?: return
 
                         elmFormat.formatDocumentAndSetText(project, document, elmVersion, addToUndoStack = false)
                     }

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.isElmFile
-import org.elm.workspace.ElmFormatCLI
+import org.elm.workspace.commandLineTools.ElmFormatCLI
 import org.elm.workspace.elmSettings
 import org.elm.workspace.elmToolchain
 

--- a/src/main/kotlin/org/elm/ide/notifications/ElmNeedsConfigNotificationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/notifications/ElmNeedsConfigNotificationProvider.kt
@@ -48,13 +48,16 @@ class ElmNeedsConfigNotificationProvider(
             return null
 
         val toolchain = project.elmToolchain
-        if (toolchain == null || !toolchain.looksLikeValidToolchain()) {
-            return createBadToolchainPanel("No Elm toolchain configured")
+        if (!toolchain.looksLikeValidToolchain()) {
+            return createBadToolchainPanel("Elm toolchain needs configuration")
         }
+
+        val elmCLI = toolchain.elmCLI
+                ?: return createBadToolchainPanel("Need path to Elm compiler")
 
         val elmVersionResult = CachedValuesManager.getManager(project)
                 .getCachedValue(project, versionCacheKey, {
-                    val v = toolchain.queryCompilerVersion()
+                    val v = elmCLI.queryVersion()
                     CachedValueProvider.Result.create(v, workspaceChangedTracker)
                 }, false)
 

--- a/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
+++ b/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
@@ -125,7 +125,7 @@ private class ElmProjectWizardStep(val context: WizardContext) : ModuleWizardSte
             // prompted later to complete configuration.
 
             val project = module.project
-            if (project.elmToolchain == null) {
+            if (!project.elmToolchain.looksLikeValidToolchain()) {
                 log.debug("Begin auto-discover the toolchain")
                 try {
                     asyncAutoDiscoverWorkspace(project, explicitRequest = true).get()
@@ -135,19 +135,17 @@ private class ElmProjectWizardStep(val context: WizardContext) : ModuleWizardSte
                 log.debug("Finished auto-discover: toolchain=${project.elmToolchain}")
             }
 
-            if (project.elmToolchain != null) {
-                log.debug("Attempting to attach the Elm project")
-                // `asyncAutoDiscoverWorkspace` *should* find and attach any `elm.json` files,
-                // but at this point in the "new project" lifecycle, the IntelliJ Module has not
-                // yet been added to the IntelliJ project. And since the auto-discover workspace
-                // feature uses the content roots of each module in the project to recursively
-                // search for `elm.json` files, it will not have found anything.
-                //
-                // TODO check if there's a better lifecycle hook so that we don't need to do this here.
-                //
-                // IMPORTANT: do *not* block on completion of the future (deadlock risk).
-                project.elmWorkspace.asyncAttachElmProject(root.pathAsPath.resolve("elm.json"))
-            }
+            log.debug("Attempting to attach the Elm project")
+            // `asyncAutoDiscoverWorkspace` *should* find and attach any `elm.json` files,
+            // but at this point in the "new project" lifecycle, the IntelliJ Module has not
+            // yet been added to the IntelliJ project. And since the auto-discover workspace
+            // feature uses the content roots of each module in the project to recursively
+            // search for `elm.json` files, it will not have found anything.
+            //
+            // TODO check if there's a better lifecycle hook so that we don't need to do this here.
+            //
+            // IMPORTANT: do *not* block on completion of the future (deadlock risk).
+            project.elmWorkspace.asyncAttachElmProject(root.pathAsPath.resolve("elm.json"))
         }
     }
 

--- a/src/main/kotlin/org/elm/openapiext/ui.kt
+++ b/src/main/kotlin/org/elm/openapiext/ui.kt
@@ -10,7 +10,7 @@ package org.elm.openapiext
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.ui.TextComponentAccessor
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.Disposer
@@ -44,17 +44,16 @@ class UiDebouncer(
     }
 }
 
-fun pathToDirectoryTextField(
+
+fun fileSystemPathTextField(
         disposable: Disposable,
         title: String,
+        fileDescriptor: FileChooserDescriptor,
         onTextChanged: () -> Unit = {}
 ): TextFieldWithBrowseButton {
 
     val component = TextFieldWithBrowseButton(null, disposable)
-    component.addBrowseFolderListener(title, null, null,
-            FileChooserDescriptorFactory.createSingleFolderDescriptor(),
-            TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT
-    )
+    component.addBrowseFolderListener(title, null, null, fileDescriptor, TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT)
     component.childComponent.document.addDocumentListener(object : DocumentAdapter() {
         override fun textChanged(e: DocumentEvent) {
             onTextChanged()

--- a/src/main/kotlin/org/elm/workspace/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmBuildAction.kt
@@ -17,8 +17,8 @@ class ElmBuildAction : AnAction() {
                 ?: return
         saveAllDocuments()
 
-        val compilerPath = project.elmToolchain?.elmCompilerPath
-        if (compilerPath == null) {
+        val elmCLI = project.elmToolchain.elmCLI
+        if (elmCLI == null) {
             Messages.showErrorDialog("No path to the Elm compiler", "Build Error")
             return
         }
@@ -37,7 +37,7 @@ class ElmBuildAction : AnAction() {
         toolWindow.contentManager.addContent(content)
 
         val elmProject = project.elmWorkspace.allProjects.first()
-        val processOutput = ElmCLI(compilerPath).make(project, elmProject)
+        val processOutput = elmCLI.make(project, elmProject)
 
         consoleView.clear()
         consoleView.print(processOutput.stdout, ConsoleViewContentType.NORMAL_OUTPUT)

--- a/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
@@ -14,7 +14,7 @@ class ElmRefreshProjectsAction : AnAction() {
                 ?: return
         saveAllDocuments()
 
-        if (project.elmToolchain == null || !project.elmWorkspace.hasAtLeastOneValidProject()) {
+        if (!(project.elmToolchain.looksLikeValidToolchain() && project.elmWorkspace.hasAtLeastOneValidProject())) {
             asyncAutoDiscoverWorkspace(project, explicitRequest = true)
         } else {
             project.elmWorkspace.asyncRefreshAllProjects()

--- a/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
@@ -1,0 +1,111 @@
+package org.elm.workspace
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.util.io.isDirectory
+import org.elm.openapiext.modules
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+
+/**
+ * Provides suggestions about where Elm tools may be installed
+ */
+object ElmSuggest {
+
+    /**
+     * Suggest paths to common Elm tools. This performs file I/O
+     * in order to determine that the file exists and that it is executable.
+     */
+    fun suggestTools(project: Project) =
+            listOf("elm", "elm-format").associateWith { programPath(it, project) }
+
+    /**
+     * Attempt to find the path to [programName].
+     */
+    private fun programPath(programName: String, project: Project): Path? {
+        val programNameVariants = executableNamesFor(programName)
+        return binDirSuggestions(project)
+                .flatMap { binDir ->
+                    programNameVariants.map { filename ->
+                        binDir.resolve(filename)
+                    }
+                }.firstOrNull { Files.isExecutable(it) }
+    }
+
+    /**
+     * Return one or more variants on program [name] based on OS-specific file extensions.
+     */
+    fun executableNamesFor(name: String) =
+            if (SystemInfo.isWindows) sequenceOf("$name.exe", "$name.cmd", name)
+            else sequenceOf(name)
+
+    /**
+     * Return a list of directories which may contain Elm binaries.
+     */
+    private fun binDirSuggestions(project: Project) =
+            sequenceOf(
+                    suggestionsFromNPM(project),
+                    suggestionsFromPath(),
+                    suggestionsForMac(),
+                    suggestionsForWindows(),
+                    suggestionsForUnix(),
+                    suggestionsFromNVM()
+            ).flatten()
+
+
+    private fun suggestionsFromNPM(project: Project): Sequence<Path> {
+        return project.modules
+                .asSequence()
+                .flatMap { ModuleRootManager.getInstance(it).contentRoots.asSequence() }
+                .flatMap {
+                    FileUtil.fileTraverser(File(it.path))
+                            .filter { it.name == "node_modules" && it.isDirectory }
+                            .bfsTraversal()
+                            .asSequence()
+                }.map { Paths.get(it.absolutePath, ".bin") }
+    }
+
+    private fun suggestionsFromNVM(): Sequence<Path> {
+        // nvm (Node Version Manager): see https://github.com/klazuka/intellij-elm/issues/252
+        // nvm is not available on Windows
+        if (SystemInfo.isWindows) return emptySequence()
+        return sequenceOf(Paths.get(FileUtil.expandUserHome("~/.config/yarn/global/node_modules/elm/unpacked_bin")))
+    }
+
+    private fun suggestionsFromPath(): Sequence<Path> {
+        return System.getenv("PATH").orEmpty()
+                .splitToSequence(File.pathSeparator)
+                .filter { !it.isEmpty() }
+                .map { Paths.get(it) }
+                .filter { it.isDirectory() }
+    }
+
+    private fun suggestionsForMac(): Sequence<Path> {
+        if (!SystemInfo.isMac) return emptySequence()
+        return sequenceOf(Paths.get("/usr/local/bin"))
+    }
+
+    private fun suggestionsForUnix(): Sequence<Path> {
+        if (!SystemInfo.isUnix) return emptySequence()
+        return sequenceOf(Paths.get("/usr/local/bin"))
+    }
+
+    private fun suggestionsForWindows(): Sequence<Path> {
+        if (!SystemInfo.isWindows) return emptySequence()
+        return sequenceOf(
+                Paths.get("C:/Program Files (x86)/Elm Platform/0.19/bin"), // npm install -g elm
+                Paths.get("C:/Program Files/Elm Platform/0.19/bin"),
+                Paths.get("C:/Program Files (x86)/Elm/0.19/bin"), // choco install elm-platform
+                Paths.get("C:/Program Files/Elm/0.19/bin"),
+                Paths.get("C:/Program Files (x86)/Elm Platform/0.18/bin"), // TODO [drop 0.18]
+                Paths.get("C:/Program Files/Elm Platform/0.18/bin"),
+                Paths.get("C:/Program Files (x86)/Elm/0.18/bin"), // TODO [drop 0.18]
+                Paths.get("C:/Program Files/Elm/0.18/bin")
+        )
+    }
+}

--- a/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
@@ -22,7 +22,7 @@ object ElmSuggest {
      * in order to determine that the file exists and that it is executable.
      */
     fun suggestTools(project: Project) =
-            listOf("elm", "elm-format").associateWith { programPath(it, project) }
+            listOf("elm", "elm-format", "elm-test").associateWith { programPath(it, project) }
 
     /**
      * Attempt to find the path to [programName].

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -5,6 +5,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.io.exists
+import org.elm.workspace.commandLineTools.ElmCLI
+import org.elm.workspace.commandLineTools.ElmFormatCLI
+import org.elm.workspace.commandLineTools.ElmTestCLI
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -16,20 +19,22 @@ private val log = Logger.getInstance(ElmToolchain::class.java)
 data class ElmToolchain(
         val elmCompilerPath: Path?,
         val elmFormatPath: Path?,
+        val elmTestPath: Path?,
         val isElmFormatOnSaveEnabled: Boolean
 ) {
-    constructor(elmCompilerPath: String, elmFormatPath: String, isElmFormatOnSaveEnabled: Boolean) :
+    constructor(elmCompilerPath: String, elmFormatPath: String, elmTestPath: String, isElmFormatOnSaveEnabled: Boolean) :
             this(
                     if (elmCompilerPath.isNotBlank()) Paths.get(elmCompilerPath) else null,
                     if (elmFormatPath.isNotBlank()) Paths.get(elmFormatPath) else null,
+                    if (elmTestPath.isNotBlank()) Paths.get(elmTestPath) else null,
                     isElmFormatOnSaveEnabled
             )
 
-    val elmCLI: ElmCLI? =
-            elmCompilerPath?.let { ElmCLI(it) }
+    val elmCLI: ElmCLI? = elmCompilerPath?.let { ElmCLI(it) }
 
-    val elmFormatCLI: ElmFormatCLI? =
-            elmFormatPath?.let { ElmFormatCLI(it) }
+    val elmFormatCLI: ElmFormatCLI? = elmFormatPath?.let { ElmFormatCLI(it) }
+
+    val elmTestCLI: ElmTestCLI? = elmTestPath?.let { ElmTestCLI(it) }
 
     val presentableLocation: String =
             elmCompilerPath?.toString() ?: "unknown location"
@@ -107,7 +112,8 @@ data class ElmToolchain(
         val suggestions = ElmSuggest.suggestTools(project)
         return copy(
                 elmCompilerPath = elmCompilerPath ?: suggestions["elm"],
-                elmFormatPath = elmFormatPath ?: suggestions["elm-format"]
+                elmFormatPath = elmFormatPath ?: suggestions["elm-format"],
+                elmTestPath = elmTestPath ?: suggestions["elm-test"]
         )
     }
 
@@ -122,6 +128,7 @@ data class ElmToolchain(
         val BLANK = ElmToolchain(
                 elmCompilerPath = null,
                 elmFormatPath = null,
+                elmTestPath = null,
                 isElmFormatOnSaveEnabled = ElmToolchain.DEFAULT_FORMAT_ON_SAVE
         )
 

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -1,19 +1,11 @@
 package org.elm.workspace
 
-import com.intellij.execution.ExecutionException
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.io.exists
-import com.intellij.util.io.isDirectory
-import org.elm.openapiext.GeneralCommandLine
-import org.elm.openapiext.Result
-import org.elm.openapiext.execute
-import org.elm.openapiext.modules
 import java.io.File
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -21,11 +13,26 @@ import java.nio.file.Paths
 private val log = Logger.getInstance(ElmToolchain::class.java)
 
 
-data class ElmToolchain(val binDirPath: Path, val isElmFormatOnSaveEnabled: Boolean) {
-    constructor(binDirPath: String, isElmFormatOnSaveEnabled: Boolean) : this(Paths.get(binDirPath), isElmFormatOnSaveEnabled)
+data class ElmToolchain(
+        val elmCompilerPath: Path?,
+        val elmFormatPath: Path?,
+        val isElmFormatOnSaveEnabled: Boolean
+) {
+    constructor(elmCompilerPath: String, elmFormatPath: String, isElmFormatOnSaveEnabled: Boolean) :
+            this(
+                    if (elmCompilerPath.isNotBlank()) Paths.get(elmCompilerPath) else null,
+                    if (elmFormatPath.isNotBlank()) Paths.get(elmFormatPath) else null,
+                    isElmFormatOnSaveEnabled
+            )
 
-    val presentableLocation: String
-        get() = (elmCompilerPath ?: binDirPath.resolve("elm")).toString()
+    val elmCLI: ElmCLI? =
+            elmCompilerPath?.let { ElmCLI(it) }
+
+    val elmFormatCLI: ElmFormatCLI? =
+            elmFormatPath?.let { ElmFormatCLI(it) }
+
+    val presentableLocation: String =
+            elmCompilerPath?.toString() ?: "unknown location"
 
     val elmHomePath: String
         get() {
@@ -57,24 +64,8 @@ data class ElmToolchain(val binDirPath: Path, val isElmFormatOnSaveEnabled: Bool
             }
         }
 
-    val elmCompilerPath: Path? get() {
-        return executableNameSuggestionsFor("elm")
-                .map { binDirPath.resolve(it) }
-                .firstOrNull { Files.isExecutable(it) }
-    }
-
-    val elmTestPath: Path? get() {
-        return executableNameSuggestionsFor("elm-test")
-                .map { binDirPath.resolve(it) }
-                .firstOrNull { Files.isExecutable(it) }
-    }
-    val elmFormat: ElmFormatCLI?
-        get() = executableNameSuggestionsFor("elm-format")
-                .map { binDirPath.resolve(it) }
-                .firstOrNull { Files.isExecutable(it) }
-                ?.let { ElmFormatCLI(it) }
-
-    fun looksLikeValidToolchain(): Boolean = elmCompilerPath != null
+    fun looksLikeValidToolchain(): Boolean =
+            elmCompilerPath != null && Files.isExecutable(elmCompilerPath)
 
     /**
      * Path to directory for a package at a specific version, containing `elm.json`
@@ -108,74 +99,16 @@ data class ElmToolchain(val binDirPath: Path, val isElmFormatOnSaveEnabled: Bool
         return files.mapNotNull { Version.parseOrNull(it.name) }
     }
 
-    fun queryCompilerVersion(): Result<Version> {
-        val elm = elmCompilerPath ?: return Result.Err("Elm compiler not found")
-
-        // Output of `elm --version` is a single line containing the version number (e.g. `0.19.0\n`)
-        val versionString = try {
-            GeneralCommandLine(elm).withParameters("--version")
-                    .execute(timeoutInMilliseconds = 1500)
-                    .stdoutLines
-                    .firstOrNull()
-        } catch (e: ExecutionException) {
-            log.debug("Failed to run `elm --version`", e)
-            null
-        }
-        if (versionString == null) {
-            // NodeJS tools like npm and nvm like to play games with wrapper scripts around native binaries
-            // such as the Elm compiler. So we will try to detect if the wrapper may have been the problem
-            // and notify the user. See https://github.com/klazuka/intellij-elm/issues/252
-            return if (elm.toFile().isWrapperScript()) {
-                Result.Err("the 'elm' file here is a wrapper script; please use the path to the actual Elm compiler")
-            } else {
-                Result.Err("failed to run the Elm compiler")
-            }
-        }
-
-        return try {
-            Result.Ok(Version.parse(versionString))
-        } catch (e: ParseException) {
-            Result.Err("invalid Elm version: ${e.message}")
-        }
-    }
-
-    fun queryElmFormatVersion(): Result<Version> {
-        val elmFormat = elmFormat ?: return Result.Err("elm-format not found")
-
-        // Output of `elm-format` is multiple lines where the first line is 'elm-format 0.8.1'
-
-        val elmFormatRegex = Regex("elm-format (\\d+(?:\\.\\d+){2})")
-
-        val versionString = try {
-            GeneralCommandLine(elmFormat.elmFormatExecutablePath)
-                    .execute(timeoutInMilliseconds = 1500)
-                    .stdoutLines
-                    .firstOrNull()
-        } catch (e: ExecutionException) {
-            log.debug("Failed to run `elm-format`", e)
-            null
-        }
-        if (versionString == null) {
-            // NodeJS tools like npm and nvm like to play games with wrapper scripts around native binaries
-            // such as the Elm compiler. So we will try to detect if the wrapper may have been the problem
-            // and notify the user. See https://github.com/klazuka/intellij-elm/issues/252
-            return if (elmFormat.elmFormatExecutablePath.toFile().isWrapperScript()) {
-                Result.Err("the 'elm-format' file here is a wrapper script; please use the path to the actual executable")
-            } else {
-                Result.Err("failed to run the elm-format")
-            }
-        }
-
-        return try {
-            val matchResult = elmFormatRegex.matchEntire(versionString)
-
-            if(matchResult == null) return Result.Err("invalid elm-format version string: ${versionString}")
-
-            val (elmVersionString) = matchResult.destructured
-            Result.Ok(Version.parse(elmVersionString))
-        } catch (e: ParseException) {
-            Result.Err("invalid elm-format version: ${e.message}")
-        }
+    /**
+     * Attempts to locate Elm tool paths for all tools which are un-configured.
+     * Returns a copy of the receiver. Performs file I/O.
+     */
+    fun autoDiscoverAll(project: Project): ElmToolchain {
+        val suggestions = ElmSuggest.suggestTools(project)
+        return copy(
+                elmCompilerPath = elmCompilerPath ?: suggestions["elm"],
+                elmFormatPath = elmFormatPath ?: suggestions["elm-format"]
+        )
     }
 
     companion object {
@@ -183,102 +116,27 @@ data class ElmToolchain(val binDirPath: Path, val isElmFormatOnSaveEnabled: Bool
         const val ELM_LEGACY_JSON = "elm-package.json" // TODO [drop 0.18]
         const val DEFAULT_FORMAT_ON_SAVE = false
 
+        /**
+         * A blank, default [ElmToolchain].
+         */
+        val BLANK = ElmToolchain(
+                elmCompilerPath = null,
+                elmFormatPath = null,
+                isElmFormatOnSaveEnabled = ElmToolchain.DEFAULT_FORMAT_ON_SAVE
+        )
+
+
         // TODO [drop 0.18] this list will no longer be necessary once the migration to 0.19 is complete
         val ELM_MANIFEST_FILE_NAMES = listOf(ElmToolchain.ELM_JSON, ElmToolchain.ELM_LEGACY_JSON)
 
         // TODO [drop 0.18] set the min compiler version to 0.19
         val MIN_SUPPORTED_COMPILER_VERSION = Version(0, 18, 0)
 
-        /** Suggest a toolchain that exists in in any standard location */
-        fun suggest(project: Project): ElmToolchain? {
-            return binDirSuggestions(project)
-                    .map { ElmToolchain(it.toAbsolutePath(), DEFAULT_FORMAT_ON_SAVE) }
-                    .firstOrNull { it.looksLikeValidToolchain() }
-        }
-    }
-}
-
-// Look for both installed and npm versions of the binary
-private fun executableNameSuggestionsFor(name: String) =
-        if (SystemInfo.isWindows) sequenceOf("$name.exe", "$name.cmd", name)
-        else sequenceOf(name)
-
-private fun binDirSuggestions(project: Project) =
-        sequenceOf(
-                suggestionsFromNPM(project),
-                suggestionsFromPath(),
-                suggestionsForMac(),
-                suggestionsForWindows(),
-                suggestionsForUnix(),
-                suggestionsFromNVM()
-        ).flatten()
-
-
-private fun suggestionsFromNPM(project: Project): Sequence<Path> {
-    return project.modules
-            .asSequence()
-            .flatMap { ModuleRootManager.getInstance(it).contentRoots.asSequence() }
-            .flatMap {
-                FileUtil.fileTraverser(File(it.path))
-                        .filter { it.name == "node_modules" && it.isDirectory }
-                        .bfsTraversal()
-                        .asSequence()
-            }.map { Paths.get(it.absolutePath, ".bin") }
-}
-
-private fun suggestionsFromNVM(): Sequence<Path> {
-    // nvm (Node Version Manager): see https://github.com/klazuka/intellij-elm/issues/252
-    // nvm is not available on Windows
-    if (SystemInfo.isWindows) return emptySequence()
-    return sequenceOf(Paths.get(FileUtil.expandUserHome("~/.config/yarn/global/node_modules/elm/unpacked_bin")))
-}
-
-private fun suggestionsFromPath(): Sequence<Path> {
-    return System.getenv("PATH").orEmpty()
-            .splitToSequence(File.pathSeparator)
-            .filter { !it.isEmpty() }
-            .map { Paths.get(it) }
-            .filter { it.isDirectory() }
-}
-
-private fun suggestionsForMac(): Sequence<Path> {
-    if (!SystemInfo.isMac) return emptySequence()
-    return sequenceOf(Paths.get("/usr/local/bin"))
-}
-
-private fun suggestionsForUnix(): Sequence<Path> {
-    if (!SystemInfo.isUnix) return emptySequence()
-    return sequenceOf(Paths.get("/usr/local/bin"))
-}
-
-private fun suggestionsForWindows(): Sequence<Path> {
-    if (!SystemInfo.isWindows) return emptySequence()
-    return sequenceOf(
-            Paths.get("C:/Program Files (x86)/Elm Platform/0.19/bin"), // npm install -g elm
-            Paths.get("C:/Program Files/Elm Platform/0.19/bin"),
-            Paths.get("C:/Program Files (x86)/Elm/0.19/bin"), // choco install elm-platform
-            Paths.get("C:/Program Files/Elm/0.19/bin"),
-            Paths.get("C:/Program Files (x86)/Elm Platform/0.18/bin"), // TODO [drop 0.18]
-            Paths.get("C:/Program Files/Elm Platform/0.18/bin"),
-            Paths.get("C:/Program Files (x86)/Elm/0.18/bin"), // TODO [drop 0.18]
-            Paths.get("C:/Program Files/Elm/0.18/bin")
-    )
-}
-
-
-/** Returns true if the file looks like a wrapper script created by NodeJS tools like npm */
-private fun File.isWrapperScript(): Boolean {
-    val firstChars = try {
-        val bytes = ByteArray(3)
-        inputStream().use { it.read(bytes, 0, 3) }
-        bytes.toString(Charsets.US_ASCII)
-    } catch (e: IOException) {
-        return false
-    }
-
-    return when (firstChars) {
-        "#!/" -> true // hash-bang used by Unix scripts
-        "@IF" -> true // npm Windows batch script starts with `@IF EXIST "%~dp0\node.exe"`
-        else -> false
+        /**
+         * Suggest a default toolchain based on common locations where Elm tools are frequently installed.
+         * This performs file I/O.
+         */
+        fun suggest(project: Project): ElmToolchain =
+                BLANK.autoDiscoverAll(project)
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -92,6 +92,7 @@ class ElmWorkspaceService(
     data class RawSettings(
             val elmCompilerPath: String = "",
             val elmFormatPath: String = "",
+            val elmTestPath: String = "",
             val isElmFormatOnSaveEnabled: Boolean = DEFAULT_FORMAT_ON_SAVE
     )
 
@@ -102,6 +103,7 @@ class ElmWorkspaceService(
             val toolchain = ElmToolchain(
                     elmCompilerPath = raw.elmCompilerPath,
                     elmFormatPath = raw.elmFormatPath,
+                    elmTestPath = raw.elmTestPath,
                     isElmFormatOnSaveEnabled = raw.isElmFormatOnSaveEnabled)
             return Settings(toolchain = toolchain)
         }
@@ -127,6 +129,7 @@ class ElmWorkspaceService(
         modifySettings {
             it.copy(elmCompilerPath = toolchain.elmCompilerPath.toString(),
                     elmFormatPath = toolchain.elmFormatPath.toString(),
+                    elmTestPath = toolchain.elmTestPath.toString(),
                     isElmFormatOnSaveEnabled = toolchain.isElmFormatOnSaveEnabled)
         }
     }
@@ -345,6 +348,7 @@ class ElmWorkspaceService(
         val raw = rawSettingsRef.get()
         settingsElement.setAttribute("elmCompilerPath", raw.elmCompilerPath)
         settingsElement.setAttribute("elmFormatPath", raw.elmFormatPath)
+        settingsElement.setAttribute("elmTestPath", raw.elmTestPath)
         settingsElement.setAttribute("isElmFormatOnSaveEnabled", raw.isElmFormatOnSaveEnabled.toString())
 
         return state
@@ -364,6 +368,7 @@ class ElmWorkspaceService(
         val settingsElement = state.getChild("settings")
         val elmCompilerPath = settingsElement.getAttributeValue("elmCompilerPath") ?: ""
         val elmFormatPath = settingsElement.getAttributeValue("elmFormatPath") ?: ""
+        val elmTestPath = settingsElement.getAttributeValue("elmTestPath") ?: ""
         val isElmFormatOnSaveEnabled = settingsElement
                 .getAttributeValue("isElmFormatOnSaveEnabled")
                 .takeIf { it != null && it.isNotBlank() }?.toBoolean()
@@ -373,6 +378,7 @@ class ElmWorkspaceService(
             RawSettings(
                     elmCompilerPath = elmCompilerPath,
                     elmFormatPath = elmFormatPath,
+                    elmTestPath = elmTestPath,
                     isElmFormatOnSaveEnabled = isElmFormatOnSaveEnabled
             )
         }

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
@@ -1,4 +1,4 @@
-package org.elm.workspace
+package org.elm.workspace.commandLineTools
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessOutput
@@ -7,8 +7,14 @@ import org.elm.openapiext.GeneralCommandLine
 import org.elm.openapiext.Result
 import org.elm.openapiext.execute
 import org.elm.openapiext.withWorkDirectory
+import org.elm.workspace.ElmProject
+import org.elm.workspace.ParseException
+import org.elm.workspace.Version
 import java.nio.file.Path
 
+/**
+ * Interact with external `elm` process (the compiler, package manager, etc.)
+ */
 class ElmCLI(private val elmExecutablePath: Path) {
 
     // TODO [kl] allow the caller to specify the main entry point Elm file

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmFormatCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmFormatCLI.kt
@@ -1,4 +1,4 @@
-package org.elm.workspace
+package org.elm.workspace.commandLineTools
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessOutput
@@ -11,11 +11,18 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import org.elm.lang.core.psi.ElmFile
 import org.elm.openapiext.*
+import org.elm.workspace.ElmApplicationProject
+import org.elm.workspace.ElmPackageProject
+import org.elm.workspace.ParseException
+import org.elm.workspace.Version
 import java.nio.file.Path
 
 private val log = logger<ElmFormatCLI>()
 
 
+/**
+ * Interact with external `elm-format` process.
+ */
 class ElmFormatCLI(private val elmFormatExecutablePath: Path) {
 
     private fun getFormattedContentOfDocument(elmVersion: Version, document: Document): ProcessOutput {

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmTestCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmTestCLI.kt
@@ -1,0 +1,58 @@
+package org.elm.workspace.commandLineTools
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ColoredProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import org.elm.openapiext.GeneralCommandLine
+import org.elm.openapiext.Result
+import org.elm.openapiext.execute
+import org.elm.workspace.ParseException
+import org.elm.workspace.Version
+import java.nio.file.Path
+
+/**
+ * Interact with external `elm-test` process.
+ */
+class ElmTestCLI(private val executablePath: Path) {
+
+    /**
+     * Construct a [ProcessHandler] that will run `elm-test` (the caller is responsible for
+     * actually invoking the process). The test results will be reported using elm-test's
+     * JSON format on stdout.
+     */
+    fun runTestsProcessHandler(elmCompilerPath: Path, elmProjectDirPath: String): ProcessHandler {
+        val commandLine = GeneralCommandLine(executablePath.toString(), "--report=json")
+                .withWorkDirectory(elmProjectDirPath)
+                .withParameters("--compiler", elmCompilerPath.toString())
+                .withRedirectErrorStream(true)
+                .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+        return ColoredProcessHandler(commandLine)
+    }
+
+
+    fun queryVersion(): Result<Version> {
+        // Output of `elm-test --version` is a single line containing the version number,
+        // e.g. `0.19.0-beta9\n`, trimming off the "-betaN" suffix, if present.
+        val firstLine = try {
+            GeneralCommandLine(executablePath).withParameters("--version")
+                    .execute(timeoutInMilliseconds = 1500)
+                    .stdoutLines
+                    .firstOrNull()
+        } catch (e: ExecutionException) {
+            return Result.Err("failed to run elm-test: ${e.message}")
+        }
+
+        if (firstLine == null) {
+            return Result.Err("no output from elm-test")
+        }
+
+        val trimmedFirstLine = firstLine.takeWhile { it != '-' }
+
+        return try {
+            Result.Ok(Version.parse(trimmedFirstLine))
+        } catch (e: ParseException) {
+            Result.Err("could not parse elm-test version: ${e.message}")
+        }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -18,7 +18,7 @@ import org.intellij.lang.annotations.Language
 class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
 
     override fun runTest() {
-        if (toolchain?.elmFormatCLI == null) {
+        if (toolchain.elmFormatCLI == null) {
             // TODO in the future maybe we should install elm-format in the CI build environment
             System.err.println("SKIP $name: elm-format not found")
             return

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -18,7 +18,7 @@ import org.intellij.lang.annotations.Language
 class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
 
     override fun runTest() {
-        if (toolchain?.elmFormat == null) {
+        if (toolchain?.elmFormatCLI == null) {
             // TODO in the future maybe we should install elm-format in the CI build environment
             System.err.println("SKIP $name: elm-format not found")
             return

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -12,7 +12,7 @@ import org.intellij.lang.annotations.Language
 class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
     override fun runTest() {
-        if (toolchain?.elmFormat == null) {
+        if (toolchain?.elmFormatCLI == null) {
             // TODO in the future maybe we should install elm-format in the CI build environment
             System.err.println("SKIP $name: elm-format not found")
             return
@@ -152,7 +152,7 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
     private fun testCorrectFormatting(fileWithCaret: String, unformatted: String, expected: String, activateOnSaveHook: Boolean = true) {
 
-        project.elmWorkspace.useToolchain(toolchain?.copy(isElmFormatOnSaveEnabled = activateOnSaveHook))
+        project.elmWorkspace.useToolchain(toolchain.copy(isElmFormatOnSaveEnabled = activateOnSaveHook))
 
         val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
         val fileDocumentManager = FileDocumentManager.getInstance()

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -12,7 +12,7 @@ import org.intellij.lang.annotations.Language
 class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
 
     override fun runTest() {
-        if (toolchain?.elmFormatCLI == null) {
+        if (toolchain.elmFormatCLI == null) {
             // TODO in the future maybe we should install elm-format in the CI build environment
             System.err.println("SKIP $name: elm-format not found")
             return

--- a/src/test/kotlin/org/elm/lang/ElmTestBase.kt
+++ b/src/test/kotlin/org/elm/lang/ElmTestBase.kt
@@ -229,7 +229,7 @@ abstract class ElmTestBase : LightPlatformCodeInsightFixtureTestCase(), ElmTestC
                 return
 
             val toolchain = ElmToolchain.suggest(module.project)
-            require(toolchain != null) { "failed to find Elm toolchain: cannot setup workspace for tests" }
+            require(toolchain.looksLikeValidToolchain()) { "failed to find Elm toolchain: cannot setup workspace for tests" }
 
             val elmProject = if (enableStdlib) {
                 log.debug("Configuring Elm Stdlib")

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -531,7 +531,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
               <elmProjects>
                 <project path="$projectPathString" />
               </elmProjects>
-              <settings elmCompilerPath="/usr/local/bin/elm" elmFormatPath="/usr/local/bin/elm-format" isElmFormatOnSaveEnabled="true" />
+              <settings elmCompilerPath="/usr/local/bin/elm" elmFormatPath="/usr/local/bin/elm-format" elmTestPath="/usr/local/bin/elm-test" isElmFormatOnSaveEnabled="true" />
             </state>
             """.trimIndent()
 

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -495,7 +495,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         check(elmProjects.isEmpty()) { "Should have found zero Elm projects but found ${elmProjects.size}" }
     }
 
-    fun `test persistence`() {
+    fun `test persistence roundtrip`() {
         // setup real files on disk
         val testProject = fileTree {
             dir("a") {
@@ -531,7 +531,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
               <elmProjects>
                 <project path="$projectPathString" />
               </elmProjects>
-              <settings binDirPath="/usr/local/bin" isElmFormatOnSaveEnabled="false" />
+              <settings elmCompilerPath="/usr/local/bin/elm" elmFormatPath="/usr/local/bin/elm-format" isElmFormatOnSaveEnabled="true" />
             </state>
             """.trimIndent()
 
@@ -544,35 +544,6 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         // ... and serialize the resulting state ...
         val actualXml = workspace.state.toXmlString()
         checkEquals(xml, actualXml)
-    }
-
-
-
-    fun `test persistence with empty toolchain binDirPath`() {
-        val workspace = project.elmWorkspace
-
-        // The missing binDirPath is treated as the empty string
-        val xml = """
-            <state>
-              <elmProjects />
-              <settings binDirPath=""/>
-            </state>
-            """.trimIndent()
-
-        val expected = """
-            <state>
-              <elmProjects />
-              <settings binDirPath="" isElmFormatOnSaveEnabled="false" />
-            </state>
-            """.trimIndent()
-
-
-        // ... must be able to load from serialized state ...
-        workspace.loadState(elementFromXmlString(xml))
-
-        // ... and serialize the resulting state ...
-        val actualXml = workspace.state.toXmlString()
-        checkEquals(expected, actualXml)
     }
 }
 

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -25,8 +25,8 @@ import java.util.concurrent.CompletableFuture
 abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBuilder<*>>() {
 
 
-    protected var toolchain: ElmToolchain? = null
-    private var originalToolchain: ElmToolchain? = null
+    protected var toolchain = ElmToolchain.BLANK
+    private var originalToolchain = ElmToolchain.BLANK
 
 
     protected val elmWorkspaceDirectory: VirtualFile
@@ -40,21 +40,19 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
     protected fun ensureElmStdlibInstalled(variant: ElmStdlibVariant) {
         // IMPORTANT: do not use the returned `ElmProject` from [ensureElmStdlibInstalled] as it
         // uses paths designed for IntelliJ's "light" tests (in-memory VFS).
-        variant.ensureElmStdlibInstalled(project, toolchain!!)
+        variant.ensureElmStdlibInstalled(project, toolchain)
     }
 
     override fun setUp() {
         super.setUp()
         originalToolchain = project.elmToolchain
         toolchain = ElmToolchain.suggest(project)
-        if (toolchain != null) {
-            project.elmWorkspace.useToolchain(toolchain)
-        }
+        project.elmWorkspace.useToolchain(toolchain)
     }
 
 
     override fun runTest() {
-        if (toolchain == null) {
+        if (!toolchain.looksLikeValidToolchain()) {
             System.err.println("SKIP $name: no Elm toolchain found")
             return
         }

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -28,12 +28,12 @@ interface ElmStdlibVariant {
      * @return An application Elm project which depends on the specified Stdlib packages
      */
     fun ensureElmStdlibInstalled(project: Project, toolchain: ElmToolchain): ElmProject {
-        val compilerVersion = toolchain.queryCompilerVersion().orNull()
+        val elmCLI = toolchain.elmCLI
+                ?: error("Must have a path to the Elm compiler to install Elm stdlib")
+
+        val compilerVersion = elmCLI.queryVersion().orNull()
                 ?: error("Could not query the Elm compiler version")
         require(compilerVersion != Version(0, 18, 0))
-
-        val elm = toolchain.elmCompilerPath?.let { ElmCLI(it) }
-                ?: error("Must have a path to the Elm compiler to install Elm stdlib")
 
         // Create the dummy Elm project on-disk (real file system) and invoke the Elm compiler on it.
         val onDiskTmpDir = LocalFileSystem.getInstance()
@@ -47,7 +47,7 @@ interface ElmStdlibVariant {
 
 //        println("-----------------------------")
 //        println("Installing Deps for $this")
-        val output = elm.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
+        val output = elmCLI.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
 //        println("STDOUT: ${output.stdout}")
 //        println("\n")
 //        println("STDERR: ${output.stderr}")

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -45,13 +45,7 @@ interface ElmStdlibVariant {
             file("Main.elm", elmHeadlessWorkerCode)
         }.create(project, onDiskTmpDir)
 
-//        println("-----------------------------")
-//        println("Installing Deps for $this")
-        val output = elmCLI.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
-//        println("STDOUT: ${output.stdout}")
-//        println("\n")
-//        println("STDERR: ${output.stderr}")
-//        println("-----------------------------")
+        elmCLI.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
 
         // Now return an `ElmProject` with a manifest path suitable for IntelliJ's "light"
         // integration tests which put everything at `/src` using the in-memory VFS.


### PR DESCRIPTION
I also refactored `ElmToolchain` and related classes.

Notable Changes:
- the user can now set the path to `elm-format` and `elm-test`
- added an "Auto Discover" button to the settings UI to find each tool based on common locations
- the path to `elm-format` and `elm-test` are now persisted in workspace settings
- code related to suggesting program locations has been moved into its own class, `ElmSuggest`
- created an `ElmTestCLI` class to match the existing `ElmCLI` and `ElmFormatCLI` classes
- the toolchain on the ElmWorkspace is no longer nullable

I'm still not 100% happy with how the `Settings`, `RawSettings` and `ElmToolchain` all fit together, but  at least now the user will have more control.

Tomorrow I plan on making it easier for the user to fix problems like trying to run `elm-test` via Run Configuration when the path to `elm-test` is unknown. I will also standardize the notification UI for these sorts of things.