### PR TITLE
Prompt user when adding an aliased import, even if only one candidate

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
@@ -15,9 +15,29 @@ import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReference
 import org.elm.lang.core.resolve.reference.QualifiedReference
 import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.openapiext.isUnitTestMode
 import org.elm.openapiext.runWriteCommandAction
 import org.elm.openapiext.toPsiFile
+import org.jetbrains.annotations.TestOnly
 import javax.swing.JList
+
+
+interface ImportPickerUI {
+    fun choose(candidates: List<Candidate>, callback: (Candidate) -> Unit)
+}
+
+private var MOCK: ImportPickerUI? = null
+
+@TestOnly
+fun withMockUI(mockUi: ImportPickerUI, action: () -> Unit) {
+    MOCK = mockUi
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}
+
 
 class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Context>() {
 
@@ -53,7 +73,16 @@ class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Cont
         val file = editor.toPsiFile(project) as? ElmFile ?: error("no file: should not happen")
         when (context.candidates.size) {
             0 -> error("should not happen: must be at least one candidate")
-            1 -> addImportForCandidate(context.candidates.first(), file, context)
+            1 -> {
+                val candidate = context.candidates.first()
+                // Normally we would just directly perform the import here without prompting,
+                // but if it's an alias-based import, we should show the user some UI so that
+                // they know what they're getting into. See https://github.com/klazuka/intellij-elm/issues/309
+                when {
+                    candidate.moduleAlias != null -> promptToSelectCandidate(context, file)
+                    else -> addImportForCandidate(candidate, file, context)
+                }
+            }
             else -> promptToSelectCandidate(context, file)
         }
     }
@@ -122,18 +151,31 @@ class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Cont
         require(context.candidates.isNotEmpty())
         val candidates = context.candidates.sortedBy { it.moduleName }
         val project = file.project
+
+        val picker = if (isUnitTestMode) {
+            MOCK ?: error("You must set mock UI via `withMockUI`")
+        } else {
+            PickerUI(project, context)
+        }
+        picker.choose(candidates) { candidate ->
+            project.runWriteCommandAction {
+                addImportForCandidate(candidate, file, context)
+            }
+        }
+    }
+}
+
+class PickerUI(val project: Project, val context: AddImportIntention.Context) : ImportPickerUI {
+    override fun choose(candidates: List<Candidate>, callback: (Candidate) -> Unit) {
         val editor = FileEditorManager.getInstance(project).selectedTextEditor!!
         JBPopupFactory.getInstance().createPopupChooserBuilder(candidates)
                 .setTitle("Import '${context.refName}' from module:")
-                .setItemChosenCallback {
-                    project.runWriteCommandAction { addImportForCandidate(it, file, context) }
-                }
+                .setItemChosenCallback { callback(it) }
                 .setNamerForFiltering { it.moduleName }
                 .setRenderer(CandidateRenderer())
                 .createPopup().showInBestPositionFor(editor)
     }
 }
-
 
 private class CandidateRenderer : ColoredListCellRenderer<Candidate>() {
     override fun customizeCellRenderer(list: JList<out Candidate>, value: Candidate, index: Int, selected: Boolean, hasFocus: Boolean) {


### PR DESCRIPTION
Fixes #309.

This was actually a pretty small change, but I had to add a bunch of junk to mock out the picker UI for the tests. Luckily intellij-rust had already come up with a decent solution.