### PR TITLE
Force UTF8 on stdin when communicating with elm-format process

### DIFF
--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -101,15 +101,12 @@ fun GeneralCommandLine.execute(
         CapturingProcessHandler(this)
     } else {
         val process = createProcess()
-
         val stdInStream = process.outputStream
-        val writer = BufferedWriter(OutputStreamWriter(stdInStream))
-
-        writer.append(stdIn)
+        val writer = OutputStreamWriter(stdInStream, Charsets.UTF_8)
+        writer.write(stdIn)
         writer.flush()
         writer.close()
-
-        CapturingProcessHandler(process, Charset.forName("UTF-8"), commandLineString)
+        CapturingProcessHandler(process, Charsets.UTF_8, commandLineString)
     }
 
     val output = if(timeoutInMilliseconds == null) {


### PR DESCRIPTION
I ran into a bug on Windows when trying to invoke elm-format on an Elm
file which contained a Unicode ellipsis. We were passing non-UTF8 data
to elm-format, and it doesn't like that. So now we explicitly convert
to UTF8.