### PR TITLE
Increase the timeouts when querying the version of Elm tools

### DIFF
--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
@@ -41,7 +41,7 @@ class ElmCLI(private val elmExecutablePath: Path) {
         // Output of `elm --version` is a single line containing the version number (e.g. `0.19.0\n`)
         val firstLine = try {
             GeneralCommandLine(elmExecutablePath).withParameters("--version")
-                    .execute(timeoutInMilliseconds = 1500)
+                    .execute(timeoutInMilliseconds = 3000)
                     .stdoutLines
                     .firstOrNull()
         } catch (e: ExecutionException) {

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmFormatCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmFormatCLI.kt
@@ -72,7 +72,7 @@ class ElmFormatCLI(private val elmFormatExecutablePath: Path) {
 
         val firstLine = try {
             GeneralCommandLine(elmFormatExecutablePath)
-                    .execute(timeoutInMilliseconds = 1500)
+                    .execute(timeoutInMilliseconds = 3000)
                     .stdoutLines
                     .firstOrNull()
         } catch (e: ExecutionException) {

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmTestCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmTestCLI.kt
@@ -36,7 +36,7 @@ class ElmTestCLI(private val executablePath: Path) {
         // e.g. `0.19.0-beta9\n`, trimming off the "-betaN" suffix, if present.
         val firstLine = try {
             GeneralCommandLine(executablePath).withParameters("--version")
-                    .execute(timeoutInMilliseconds = 1500)
+                    .execute(timeoutInMilliseconds = 3000)
                     .stdoutLines
                     .firstOrNull()
         } catch (e: ExecutionException) {


### PR DESCRIPTION
It was timing-out on my Windows VM. Maybe partly due to my VM being
slow and partly due to the Rube Goldberg situation of a Java process
invoking NodeJS which in turn invokes a Haskell binary.