### PR TITLE
 Handle execution exceptions when auto running elm-format on save

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -1,7 +1,6 @@
 package org.elm.ide.actions
 
 import com.intellij.execution.ExecutionException
-import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -36,13 +35,11 @@ class ElmExternalFormatAction : AnAction() {
             return
         }
 
+        val fixAction = "Fix" to { ctx.project.elmWorkspace.showConfigureToolchainUI() }
+
         val elmFormat = ctx.project.elmToolchain.elmFormatCLI
         if (elmFormat == null) {
-            ctx.project.showBalloon("Could not find elm-format", NotificationType.ERROR,
-                    action = NotificationAction.create("Fix") { _, notification ->
-                        notification.hideBalloon()
-                        ctx.project.elmWorkspace.showConfigureToolchainUI()
-                    })
+            ctx.project.showBalloon("Could not find elm-format", NotificationType.ERROR, fixAction)
             return
         }
 
@@ -57,7 +54,7 @@ class ElmExternalFormatAction : AnAction() {
         } catch (ex: ExecutionException) {
             if (isUnitTestMode) throw ex
             val message = ex.message ?: "something went wrong running elm-format"
-            ctx.project.showBalloon(message, NotificationType.ERROR)
+            ctx.project.showBalloon(message, NotificationType.ERROR, fixAction)
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/notifications/Utils.kt
+++ b/src/main/kotlin/org/elm/ide/notifications/Utils.kt
@@ -15,10 +15,29 @@ import com.intellij.openapi.project.Project
 
 private val pluginNotifications = NotificationGroup.balloonGroup("Elm Plugin")
 
-fun Project.showBalloon(content: String, type: NotificationType, action: NotificationAction? = null) {
+
+/**
+ * Show a balloon notification along with action(s). The notification will be automatically dismissed
+ * when an action is invoked.
+ *
+ * @param content The main content to be shown in the notification
+ * @param type The notification type
+ * @param actions Optional list of actions to be included in the notification
+ */
+fun Project.showBalloon(
+        content: String,
+        type: NotificationType,
+        vararg actions: Pair<String, (() -> Unit)>
+) {
     val notification = pluginNotifications.createNotification(content, type)
-    if (action != null) {
-        notification.addAction(action)
+    for ((actionTitle, actionCallback) in actions) {
+        notification.addAction(
+                NotificationAction.create(actionTitle)
+                { _, notif ->
+                    notif.hideBalloon()
+                    actionCallback()
+                }
+        )
     }
     Notifications.Bus.notify(notification, this)
 }


### PR DESCRIPTION
Fixes #338 

Also:
- Make it easier to show balloon notifications with actions attached
- Include a "fix" action in more cases when running elm-format