### PR TITLE
Assorted improvements to type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The plugin can perform type inference on arbitrary expressions in your program. 
 
 The plugin also performs type checking, marking incompatible types in red.
 
-The current implementation of the type system does not infer the types of parameters of unannotated
+The current implementation of the type system does not constrain the types of parameters of unannotated
 functions, but this limitation will be removed in the future.
 
 

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -53,7 +53,9 @@ data class TyRecord(
 
     override fun withAlias(alias: AliasInfo): TyRecord = copy(alias = alias)
     override fun toString(): String {
-        return alias?.let { "{${it.name}}" } ?: baseTy?.let { "{$baseTy | $fields}" } ?: "{$fields}"
+        return alias?.let {
+            "{${it.name}${if (it.parameters.isEmpty()) "" else " ${it.parameters.joinToString(" ")}"}}"
+        } ?: baseTy?.let { "{$baseTy | $fields}" } ?: "{$fields}"
     }
 }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -909,7 +909,11 @@ private class InferenceScope(
             }
             else -> error("impossible")
         }
-        if (result && ty2.baseTy is TyVar) {
+
+        // We need to unify the base var with the record being assigned for the case where we have
+        // an alias to an extension record constructor. We only do this if the records are
+        // different, since that would incorrectly create a recursive type.
+        if (result && ty2.baseTy is TyVar && ty1.fields != ty2.fields) {
             trackReplacement(ty1, ty2.baseTy, replacements)
         }
         return result

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -267,7 +267,7 @@ private class InferenceScope(
                     val lAssignable = requireAssignable(l.start, l.ty, func.parameters[0], l.end, replacements)
                     val rAssignable = requireAssignable(r.start, r.ty, func.parameters[1], r.end, replacements)
                     val ty = when {
-                        lAssignable && rAssignable -> TypeReplacement.deepReplace(func.partiallyApply(2), replacements)
+                        lAssignable && rAssignable -> TypeReplacement.replace(func.partiallyApply(2), replacements)
                         else -> TyUnknown()
                     }
                     TyAndRange(l.start, r.end, ty)
@@ -311,7 +311,7 @@ private class InferenceScope(
 
         val resultTy = if (ok) {
             val appliedTy = targetTy.partiallyApply(arguments.size)
-            TypeReplacement.deepReplace(appliedTy, replacements)
+            TypeReplacement.replace(appliedTy, replacements)
         } else {
             TyUnknown()
         }
@@ -843,7 +843,7 @@ private class InferenceScope(
     ): Boolean {
         val assignable = assignable(ty1, ty2, replacements)
         if (!assignable) {
-            val t2 = replacements?.let { TypeReplacement.deepReplace(ty2, it) } ?: ty2
+            val t2 = replacements?.let { TypeReplacement.replace(ty2, it) } ?: ty2
             diagnostics += TypeMismatchError(element, ty1, t2, endElement)
         }
         return assignable
@@ -1003,7 +1003,7 @@ private class InferenceScope(
     }
 
     private fun trackReplacement(ty1: Ty, ty2: Ty, replacements: MutableMap<TyVar, Ty>?) {
-        if (replacements == null) return
+        if (replacements == null || ty1 == ty2) return
         // assigning anything to a variable fixes the type of that variable
         if (ty2 is TyVar && (ty2 !in replacements || ty1 !is TyVar && replacements[ty2] is TyVar)) {
             replacements[ty2] = ty1

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -26,7 +26,9 @@ fun TyUnion.renderedText(linkify: Boolean, withModule: Boolean): String {
     val type = when {
         parameters.isEmpty() -> name
         else -> parameters.joinToString(" ", prefix = "$name ") {
-            if (it is TyFunction || it is TyUnion && it.parameters.isNotEmpty()) {
+            if (it is TyFunction
+                    || it is TyUnion && it.parameters.isNotEmpty()
+                    || it.alias?.parameters?.isNotEmpty() == true) {
                 "(${it.renderedText(linkify, withModule)})"
             } else {
                 it.renderedText(linkify, withModule)

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -6,10 +6,13 @@ package org.elm.lang.core.types
  *
  * It relies on the fact that [TyVar]s can be compared by identity. Vars in different scopes must
  * compare unequal, even if they have the same name.
+ *
+ * The constructor takes a map of vars to the ty to replace them with
  */
 class TypeReplacement(
         // A map of variables that should be replaced to the ty to replace them with
-        private val replacements: Map<TyVar, Ty>
+        replacements: Map<TyVar, Ty>,
+        private val freshen: Boolean
 ) {
     companion object {
         /**
@@ -17,54 +20,30 @@ class TypeReplacement(
          */
         fun replace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
             if (replacements.isEmpty()) return ty
-            return TypeReplacement(replacements).replace(ty)
-        }
-
-        /**
-         * Replace vars in [ty] according to [replacements].
-         *
-         * If the values of [replacements] can contain [TyVar]s that occur in the keys, use this
-         * rather than [replace].
-         */
-        fun deepReplace(ty: Ty, replacements: Map<TyVar, Ty>): Ty {
-            if (replacements.isEmpty()) return ty
-            val tr = TypeReplacement(replacements)
-            var newTy = ty
-            repeat(5) {
-                val next = tr.replace(newTy)
-                if (next == newTy) {
-                    return newTy
-                }
-                newTy = next
-            }
-            // exceeded the recursion threshold, don't replace anything
-            return ty
+            return TypeReplacement(replacements, freshen = false).replace(ty)
         }
 
         /**
          * Replace all [TyVar]s in a [ty] with new copies with the same names.
          *
-         * This is important because tys are cached, and compared [TyVar]s are compared by instance
-         * to be able to scope them. Each time you call a function or reference a type, its vars are
-         * distinct, even though they share a name with vars from the previous reference. If we use
-         * the cached tys, there's no way to distinguish between vars in one call from another.
+         * This is important because tys are cached, and [TyVar]s are compared by instance to be
+         * able to differentiate them by scope. Each time you call a function or reference a type,
+         * its vars are distinct, even though they share a name with vars from the previous
+         * reference. If we use the cached tys, there's no way to distinguish between vars in one
+         * call from another.
          */
         fun freshenVars(ty: Ty): Ty {
-            return TypeReplacement(MutableMapWithDefault { TyVar(it.name) }).replace(ty)
+            return TypeReplacement(emptyMap(), freshen = true).replace(ty)
         }
     }
 
+    /** A map of var to (has been accessed, ty) */
+    private val replacements = replacements.mapValuesTo(mutableMapOf()) { (_, v) -> false to v }
+
     private fun replace(ty: Ty): Ty = when (ty) {
-        is TyVar -> replacements[ty] ?: ty
+        is TyVar -> getReplacement(ty) ?: ty
         is TyTuple -> TyTuple(ty.types.map { replace(it) }, replace(ty.alias))
-        is TyFunction -> {
-            val parameters = ty.parameters.map {
-                replace(it)
-            }
-            val ret = replace(ty.ret)
-            val alias = replace(ty.alias)
-            TyFunction(parameters, ret, alias).uncurry()
-        }
+        is TyFunction -> replaceFunction(ty)
         is TyUnknown -> TyUnknown(replace(ty.alias))
         is TyUnion -> replaceUnion(ty)
         is TyRecord -> replaceRecord(ty)
@@ -84,13 +63,18 @@ class TypeReplacement(
         info.copy(parameters = info.parameters.map { replace(it) })
     }
 
+    private fun replaceFunction(ty: TyFunction): TyFunction {
+        val parameters = ty.parameters.map { replace(it) }
+        return TyFunction(parameters, replace(ty.ret), replace(ty.alias)).uncurry()
+    }
+
     private fun replaceUnion(ty: TyUnion): TyUnion {
         val parameters = ty.parameters.map { replace(it) }
         return TyUnion(ty.module, ty.name, parameters, replace(ty.alias))
     }
 
     private fun replaceRecord(ty: TyRecord): Ty {
-        val replacedBase = if (ty.baseTy == null || ty.baseTy !is TyVar) null else replacements[ty.baseTy]
+        val replacedBase = if (ty.baseTy == null || ty.baseTy !is TyVar) null else getReplacement(ty.baseTy)
         val newBaseTy = when (replacedBase) {
             // If the base ty of the argument is a record, use it's base ty, which might be null.
             is TyRecord -> replacedBase.baseTy
@@ -105,27 +89,24 @@ class TypeReplacement(
 
         return TyRecord(baseFields + declaredFields, newBaseTy, replace(ty.alias))
     }
-}
 
+    // When we replace a var, the new ty may itself contain vars, and so we need to recursively
+    // replace the ty before we can replace the var we were given as an argument.
+    // After the recursive replacement, we avoid repeating work by storing the final ty and tracking
+    // of the fact that it's replacement is complete with the `hasBeenAccessed` flag.
+    private fun getReplacement(key: TyVar): Ty? {
+        if (key !in replacements && freshen) {
+            val ty = TyVar(key.name)
+            replacements[key] = true to ty
+            return ty
+        }
 
-private class MutableMapWithDefault<K, V>(
-        val map: MutableMap<K, V> = mutableMapOf(),
-        private val default: (key: K) -> V
-) : MutableMap<K, V> {
-    override fun equals(other: Any?): Boolean = map.equals(other)
-    override fun hashCode(): Int = map.hashCode()
-    override fun toString(): String = map.toString()
-    override val size: Int get() = map.size
-    override fun isEmpty(): Boolean = map.isEmpty()
-    override fun containsKey(key: K): Boolean = map.containsKey(key)
-    override fun containsValue(value: @UnsafeVariance V): Boolean = map.containsValue(value)
-    override fun get(key: K): V? = map.getOrPut(key) { default(key) }
-    override val keys: MutableSet<K> get() = map.keys
-    override val values: MutableCollection<V> get() = map.values
-    override val entries: MutableSet<MutableMap.MutableEntry<K, V>> get() = map.entries
+        val v = replacements[key] ?: return null
+        val (hasBeenAccessed, storedTy) = v
+        if (hasBeenAccessed) return storedTy
 
-    override fun put(key: K, value: V): V? = map.put(key, value)
-    override fun remove(key: K): V? = map.remove(key)
-    override fun putAll(from: Map<out K, V>) = map.putAll(from)
-    override fun clear() = map.clear()
+        val replacedVal = replace(storedTy)
+        replacements[key] = true to replacedVal
+        return replacedVal
+    }
 }

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -341,7 +341,8 @@ foo bar = ()
   --^
 """,
             """
-<div class='definition'><pre><i>parameter</i> bar <i>of function </i><a href="psi_element://foo">foo</a></pre></div>
+<div class='definition'><pre><i>parameter</i> bar : a
+<i>of function </i><a href="psi_element://foo">foo</a></pre></div>
 """)
 
     fun `test function parameter with primitive type annotation`() = doTest(

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -112,6 +112,11 @@ main : String
 main = <error descr="Type mismatch.Required: StringFound: ()">foo</error>
 """)
 
+    fun `test calling function without annotation with unconstrained parameters`() = checkByText("""
+foo a = a
+main : ()
+main = <error descr="Type mismatch.Required: ()Found: String">foo ""</error>
+""")
 
     fun `test correct value type from record`() = checkByText("""
 main : {x: (), y: ()}

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -247,6 +247,18 @@ main r =
     <error descr="Type mismatch.Required: ()Found: Small Large">{ rr | field2 = "" }</error>
 """)
 
+    fun `test alias to extension record`() = checkByText("""
+type alias Record a = { a | field : () }
+type alias Alias a = Record a
+
+foo : Alias a  -> Alias a
+foo it = it
+
+main : Alias a  -> ()
+main model =
+    <error descr="Type mismatch.Required: ()Found: Alias a">foo model</error>
+""")
+
     fun `test field accessor as argument`() = checkByText("""
 type alias R = {x: (), y: ()}
 foo : (R -> ()) -> ()


### PR DESCRIPTION
1. A fix when inferring aliases like `type alias A a = B a` when `B` is an extension record alias
2. Parenthesize parameterized type aliases that are arguments to rendered union types 
3. A new algorithm for type replacement: rather than performing repeated, shallow replacement until a fixed point is reached, we instead perform replacement recursively on the values of the replacement table, allowing all replacements to be completed in a single pass of the ty.
4. Infer unannotated parameters as unconstrained vars (`a`, `b`, etc.) rather than `TyUnknown`. We still don't constrain them, but they are propagated through the body. (`foo a = [a ++ ""]` is inferred as `a -> List String` rather than the correct `String -> List String`, but that's still better than the previous `unknown -> unknown`)