### PR TITLE
Build action should work in all cases..

### DIFF
--- a/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
@@ -4,7 +4,6 @@ import com.intellij.execution.ExecutionException
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
@@ -48,7 +47,7 @@ class ElmBuildAction : AnAction() {
 
         val elmProject = findElmProject(e)
         if (elmProject == null) {
-            project.showBalloon("Could not Elm project", NotificationType.ERROR)
+            project.showBalloon("Could not find Elm project", NotificationType.ERROR)
             return
         }
 
@@ -98,10 +97,10 @@ class ElmBuildAction : AnAction() {
     }
 
     private fun findElmProject(e: AnActionEvent): ElmProject? {
-        val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null
+        // val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null
         e.project?.let {
             val elmWorkspaceService = ServiceManager.getService(it, ElmWorkspaceService::class.java)
-            return elmWorkspaceService.findProjectForFile(file)
+            return elmWorkspaceService.allProjects[0]
         }
         return null
     }

--- a/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
@@ -100,7 +100,8 @@ class ElmBuildAction : AnAction() {
         // val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null
         e.project?.let {
             val elmWorkspaceService = ServiceManager.getService(it, ElmWorkspaceService::class.java)
-            return elmWorkspaceService.allProjects[0]
+            if (elmWorkspaceService.allProjects.isNotEmpty())
+                return elmWorkspaceService.allProjects[0]
         }
         return null
     }


### PR DESCRIPTION
Fixed the wording of the error message 
Just use first project from ElmWorkspaceService:
That mechanism "e.getData(...VIRTUAL_FILE)" did not work, if the Build-Button in the compiler-toolwindow is clicked by mouse, even if there is an Elm-file open in the editor.

Right now, there is no "multi-workspace" compiler-mode anyway, so I figure we should just use the first project from ElmWorkspaceService.
(that is,  no multi 'Main.elm'... using 2 or more parameters for 'elm make ...')