### PR TITLE
Fix as pattern binding within tuples

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -800,7 +800,7 @@ private class InferenceScope(
             return
         }
         patternList.zip(ty.types)
-                .forEach { (pat, type) -> bindPattern(pat.child, type, isParameter) }
+                .forEach { (pat, type) -> bindPattern(pat, type, isParameter) }
     }
 
     private fun bindRecordPattern(pat: ElmRecordPattern, ty: Ty, isParameter: Boolean) {

--- a/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/TypeInferenceInspectionTest.kt
@@ -1103,6 +1103,11 @@ main r =
     <error descr="Type mismatch.Required: ()Found: String">record.field</error>
 """)
 
+    fun `test nested param as`() = checkByText("""
+main : (String, String) -> ()
+main ( (x) as foo, _ ) =
+     <error descr="Type mismatch.Required: ()Found: String">foo</error>
+""")
 
     fun `test mismatched left operand to non-associative operator`() = checkByText("""
 foo : () -> () -> ()


### PR DESCRIPTION
When iterating over the parts of a tuple pattern, we were skipping the
`as` part of the branch, resulting in an unbound pattern exception.

Fixes #295