### PR TITLE
Allow elm-format to run even if there are syntax errors

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -43,18 +43,16 @@ class ElmExternalFormatAction : AnAction() {
             return
         }
 
-        val psiFile = PsiDocumentManager.getInstance(ctx.project).getPsiFile(ctx.document) ?: return
-        if (PsiTreeUtil.hasErrorElements(psiFile)) {
-            ctx.project.showBalloon(FileHasErrorsNotificationMsg, NotificationType.WARNING)
-            return
-        }
-
         try {
             elmFormat.formatDocumentAndSetText(ctx.project, ctx.document, ctx.elmVersion, addToUndoStack = true)
         } catch (ex: ExecutionException) {
             if (isUnitTestMode) throw ex
             val message = ex.message ?: "something went wrong running elm-format"
-            ctx.project.showBalloon(message, NotificationType.ERROR, fixAction)
+            if (message.contains("SYNTAX PROBLEM", ignoreCase = true)) {
+                ctx.project.showBalloon("Please fix the syntax errors before running elm-format.", NotificationType.WARNING)
+            } else {
+                ctx.project.showBalloon(message, NotificationType.ERROR, fixAction)
+            }
         }
     }
 
@@ -77,6 +75,5 @@ class ElmExternalFormatAction : AnAction() {
 
     companion object {
         const val ID = "Elm.RunExternalElmFormat" // must stay in-sync with `plugin.xml`
-        const val FileHasErrorsNotificationMsg = "Please fix the syntax errors in this file before running elm-format."
     }
 }

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -55,33 +55,6 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
         TestCase.assertEquals(expected, document.text)
     }
 
-    fun `test elm-format action should not run, when the elm-file has errors and display notification to the user`() {
-        val unformatted = """
-                    m0dule Main exposing (f)
-
-
-                    f x = x{-caret-}
-
-                """.trimIndent()
-
-        val fileWithCaret = buildProject {
-            project("elm.json", manifestElm19)
-            dir("src") {
-                elm("Main.elm", unformatted)
-            }
-        }.fileWithCaret
-
-        val notificationRef = connectToBusAndGetNotificationRef()
-
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
-        val document = FileDocumentManager.getInstance().getDocument(file)!!
-
-        reformat(file)
-
-        TestCase.assertEquals(unformatted.replace("{-caret-}", "").trimIndent(), document.text.trimIndent())
-        TestCase.assertEquals(org.elm.ide.actions.ElmExternalFormatAction.FileHasErrorsNotificationMsg, notificationRef.get().content)
-    }
-
     // TODO [drop 0.18] remove this test
     fun `test elm-format action with elm 18`() {
         val fileWithCaret = buildProject {


### PR DESCRIPTION
Fixes #341 