### PR TITLE
Update usages of deprecated APIs.

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -31,7 +31,7 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
 
         if (scope is GlobalSearchScope) {
             // to keep inspection/analysis time brief, bail out if 'Find Usages' will be slow
-            val searchCost = PsiSearchHelper.SERVICE.getInstance(project).isCheapEnoughToSearch(name, scope, null, null)
+            val searchCost = PsiSearchHelper.getInstance(project).isCheapEnoughToSearch(name, scope, null, null)
             if (searchCost == TOO_MANY_OCCURRENCES) return
         }
 

--- a/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddExposureIntention.kt
@@ -44,10 +44,8 @@ class AddExposureIntention : ElmAtCaretIntentionActionBase<AddExposureIntention.
     }
 
     override fun invoke(project: Project, editor: Editor, context: Context) {
-        object : WriteCommandAction.Simple<Unit>(project) {
-            override fun run() {
-                context.exposingList.addItem(context.nameToExpose)
-            }
-        }.execute()
+        WriteCommandAction.writeCommandAction(project).run<Throwable> {
+            context.exposingList.addItem(context.nameToExpose)
+        }
     }
 }

--- a/src/main/kotlin/org/elm/ide/intentions/MakeDeclarationIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MakeDeclarationIntention.kt
@@ -36,11 +36,9 @@ class MakeDeclarationIntention : ElmAtCaretIntentionActionBase<MakeDeclarationIn
     }
 
     override fun invoke(project: Project, editor: Editor, context: Context) {
-        object : WriteCommandAction.Simple<Unit>(project) {
-            override fun run() {
-                generateDecl(project, editor, context)
-            }
-        }.execute()
+        WriteCommandAction.writeCommandAction(project).run<Throwable> {
+            generateDecl(project, editor, context)
+        }
     }
 
     private fun generateDecl(project: Project, editor: Editor, context: Context) {

--- a/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RemoveExposureIntention.kt
@@ -48,10 +48,8 @@ class RemoveExposureIntention : ElmAtCaretIntentionActionBase<RemoveExposureInte
     }
 
     override fun invoke(project: Project, editor: Editor, context: Context) {
-        object : WriteCommandAction.Simple<Unit>(project) {
-            override fun run() {
-                context.exposingList.removeItem(context.element)
-            }
-        }.execute()
+        WriteCommandAction.writeCommandAction(project).run<Throwable> {
+            context.exposingList.removeItem(context.element)
+        }
     }
 }


### PR DESCRIPTION
There were several deprecated IntelliJ functions in use that would cause the compiler to emit warnings. All of the APIs have equivalent alternatives.