### PR TITLE
Fix CachedValueStability warnings in IntelliJ 2019

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -113,7 +113,7 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
         if (element !is ElmValueExpr && element !is ElmTypeRef) return false
         val elmFile = element.containingFile as? ElmFile ?: return false
 
-        val importDecl = ModuleScope(elmFile).getImportDecls().find { it.moduleQID.text == ref.qualifierPrefix }
+        val importDecl = ModuleScope.getImportDecls(elmFile).find { it.moduleQID.text == ref.qualifierPrefix }
                 ?: return false
         val aliasName = importDecl.asClause?.upperCaseIdentifier?.text ?: return false
 

--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -39,8 +39,9 @@ class ElmDocumentationProvider : AbstractDocumentationProvider() {
         if (context !is ElmPsiElement) return null
         val lastDot = link.indexOfLast { it == '.' }
         return if (lastDot <= 0) {
-            with(ModuleScope(context.elmFile)) {
-                getVisibleTypes().all.find { it.name == link } ?: getDeclaredValues().find { it.name == link }
+            with(ModuleScope) {
+                getVisibleTypes(context.elmFile).all.find { it.name == link }
+                        ?: getDeclaredValues(context.elmFile).find { it.name == link }
             }
         } else {
             val qualifierPrefix = link.substring(0, lastDot)
@@ -184,7 +185,7 @@ private fun documentationFor(decl: ElmModuleDeclaration): String? = buildString 
     }
 
     renderDocContent(decl) { html ->
-        val declarations = ModuleScope(decl.elmFile).run { getDeclaredValues() + getDeclaredTypes() }
+        val declarations = ModuleScope.run { getDeclaredValues(decl.elmFile) + getDeclaredTypes(decl.elmFile) }
 
         // Render @docs commands
         html.replace(Regex("<p>@docs (.+?)</p>", RegexOption.DOT_MATCHES_ALL)) { match ->

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -28,7 +28,7 @@ class ElmUnusedImportInspection : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor {
         val file = session.file as? ElmFile
                 ?: return super.buildVisitor(holder, isOnTheFly, session)
-        val visitor = ImportVisitor(ModuleScope(file).getImportDecls())
+        val visitor = ImportVisitor(ModuleScope.getImportDecls(file))
         session.putUserData(visitorKey, visitor)
         return visitor
     }

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -104,7 +104,7 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
             return Result.NoMissing
         }
 
-        val qualifierPrefix = ModuleScope(element.elmFile).getQualifierForTypeName(exprTy.module, exprTy.name)
+        val qualifierPrefix = ModuleScope.getQualifierForTypeName(element.elmFile, exprTy.module, exprTy.name)
                 ?: ""
 
         return Result.MissingVariants(missingBranches.mapKeys { (k, _) -> qualifierPrefix + k })

--- a/src/main/kotlin/org/elm/ide/inspections/fixes/OptimizeImportsFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/fixes/OptimizeImportsFix.kt
@@ -20,7 +20,7 @@ class OptimizeImportsFix : LocalQuickFix {
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val file = descriptor.psiElement?.containingFile as? ElmFile ?: return
-        val visitor = ImportVisitor(ModuleScope(file).getImportDecls())
+        val visitor = ImportVisitor(ModuleScope.getImportDecls(file))
 
         file.accept(object : PsiRecursiveElementWalkingVisitor() {
             override fun visitElement(element: PsiElement) {

--- a/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddImportIntention.kt
@@ -94,7 +94,7 @@ class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Cont
         else
             factory.createImportExposing(candidate.moduleName, listOf(candidate.nameToBeExposed))
 
-        val existingImport = ModuleScope(file).getImportDecls()
+        val existingImport = ModuleScope.getImportDecls(file)
                 .find { it.moduleQID.text == candidate.moduleName }
         if (existingImport != null) {
             // merge with existing import
@@ -120,7 +120,7 @@ class AddImportIntention : ElmAtCaretIntentionActionBase<AddImportIntention.Cont
      * Returns the node which will *follow* the new import clause
      */
     private fun getInsertPosition(file: ElmFile, moduleName: String): ASTNode {
-        val existingImports = ModuleScope(file).getImportDecls()
+        val existingImports = ModuleScope.getImportDecls(file)
         return when {
             existingImports.isEmpty() -> prepareInsertInNewSection(file)
             else -> getSortedInsertPosition(moduleName, existingImports)

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -40,7 +40,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 is ElmValueExpr -> {
                     if (qualifierPrefix.isEmpty()) {
                         ExpressionScope(parent).getVisibleValues().forEach { result.add(it) }
-                        ModuleScope(file).getVisibleConstructors().all.forEach { result.add(it) }
+                        ModuleScope.getVisibleConstructors(file).all.forEach { result.add(it) }
                         GlobalScope.builtInValues.forEach { result.add(it) }
                     } else {
                         /* TODO Make a distinction between completion results that are already imported
@@ -54,7 +54,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 }
                 is ElmUnionPattern -> {
                     if (qualifierPrefix.isEmpty()) {
-                        ModuleScope(file).getVisibleConstructors().all
+                        ModuleScope.getVisibleConstructors(file).all
                                 .filter { it is ElmUnionVariant }
                                 .forEach { result.add(it) }
                     } else {
@@ -66,7 +66,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 }
                 is ElmTypeRef -> {
                     if (qualifierPrefix.isEmpty()) {
-                        ModuleScope(file).getVisibleTypes().all.forEach { result.add(it) }
+                        ModuleScope.getVisibleTypes(file).all.forEach { result.add(it) }
                         GlobalScope.builtInTypes.forEach { result.add(it) }
                     } else {
                         ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
@@ -94,7 +94,7 @@ object ElmQualifiableRefSuggestor : Suggestor {
         // Aliases are forbidden from having dots in the name. So if the qualifier prefix is empty, then
         // we are in a state where aliases can (and should) be suggested.
         if (qualifierPrefix.isEmpty()) {
-            ModuleScope(file).getAliasDecls().forEach { result.add(it) }
+            ModuleScope.getAliasDecls(file).forEach { result.add(it) }
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
@@ -59,7 +59,7 @@ class ExposedOperatorModuleReference(exposedValue: ElmExposedOperator
 
     override fun getVariants(): Array<ElmNamedElement> {
         // TODO [kl] verify: this was copied from ElmExposedValue's ref
-        return ModuleScope(element.elmFile).getDeclaredValues().toTypedArray()
+        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
     }
 }
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
@@ -55,7 +55,6 @@ class LocalOperatorReference(element: ElmReferenceElement)
 
     override fun getVariants(): Array<ElmNamedElement> {
         // TODO [kl] filter the variants to just include binary operators
-        return ModuleScope(element.elmFile).getDeclaredValues()
-                .toTypedArray()
+        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
@@ -16,7 +16,7 @@ class ExposedTypeReferenceFromModuleDecl(exposedType: ElmExposedType)
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
-        return ModuleScope(element.elmFile).getDeclaredTypes().toTypedArray()
+        return ModuleScope.getDeclaredTypes(element.elmFile).toTypedArray()
     }
 
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
@@ -15,7 +15,7 @@ class ExposedValueModuleReference(exposedValue: ElmExposedValue)
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
-        return ModuleScope(element.elmFile).getDeclaredValues().toTypedArray()
+        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
     }
 
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
@@ -16,5 +16,5 @@ class LocalTopLevelValueReference(element: ElmReferenceElement)
     }
 
     override fun getVariants() =
-            ModuleScope(element.elmFile).getDeclaredValues().toTypedArray()
+            ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ModuleNameQualifierReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ModuleNameQualifierReference.kt
@@ -36,7 +36,7 @@ class ModuleNameQualifierReference<T : ElmReferenceElement>(
 
     override fun resolveInner(): ElmNamedElement? {
         val clientFile = element.elmFile
-        val importDecls = ModuleScope(clientFile).getImportDecls()
+        val importDecls = ModuleScope.getImportDecls(clientFile)
 
         // First, check to see if it resolves to an aliased import
         importDecls.mapNotNull { it.asClause }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
@@ -16,6 +16,6 @@ class SimpleOperatorReference(element: ElmReferenceElement)
 
     override fun getVariants(): Array<ElmNamedElement> {
         // TODO [kl] filter the variants to just include binary operators
-        return ModuleScope(element.elmFile).getVisibleValues().all.toTypedArray()
+        return ModuleScope.getVisibleValues(element.elmFile).all.toTypedArray()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
@@ -17,6 +17,6 @@ class SimpleTypeReference(element: ElmReferenceElement)
             getCandidates().find { it.name == element.referenceName }
 
     private fun getCandidates(): Array<ElmNamedElement> {
-        return ModuleScope(element.elmFile).getVisibleTypes().all.toTypedArray()
+        return ModuleScope.getVisibleTypes(element.elmFile).all.toTypedArray()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
@@ -18,7 +18,7 @@ class SimpleUnionConstructorReference(element: ElmReferenceElement)
             getCandidates().find { it.name == element.referenceName }
 
     private fun getCandidates(): Array<ElmNamedElement> =
-            ModuleScope(element.elmFile).getVisibleConstructors().all
+            ModuleScope.getVisibleConstructors(element.elmFile).all
                     .filter { it is ElmUnionVariant }
                     .toTypedArray()
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
@@ -15,7 +15,7 @@ class SimpleUnionOrRecordConstructorReference(element: ElmReferenceElement)
             getCandidates().find { it.name == element.referenceName }
 
     private fun getCandidates(): Array<ElmNamedElement> {
-        return ModuleScope(element.elmFile).getVisibleConstructors().all.toTypedArray()
+        return ModuleScope.getVisibleConstructors(element.elmFile).all.toTypedArray()
     }
 
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
@@ -18,7 +18,7 @@ class ExpressionScope(val element: PsiElement) {
 
         treeWalkUp(element) {
             if (it is ElmFile) {
-                results.addAll(ModuleScope(it).getVisibleValues().all)
+                results.addAll(ModuleScope.getVisibleValues(it).all)
                 return@treeWalkUp false // stop
             }
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -75,7 +75,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
         // function.
         fun helper(moduleName: String) =
                 ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope(it.elmFile).getDeclaredValues() }
+                        ?.let { ModuleScope.getDeclaredValues(it.elmFile) }
                         ?: emptyList()
 
         val rest = mutableListOf<ElmNamedElement>()
@@ -92,7 +92,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
     fun getVisibleTypes(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
                 ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope(it.elmFile).getDeclaredTypes() }
+                        ?.let { ModuleScope.getDeclaredTypes(it.elmFile) }
                         ?: emptyList()
 
         val rest = mutableListOf<ElmNamedElement>()
@@ -111,7 +111,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
     fun getVisibleConstructors(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
                 ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope(it.elmFile).getDeclaredConstructors() }
+                        ?.let { ModuleScope.getDeclaredConstructors(it.elmFile) }
                         ?: emptyList()
 
         val rest = mutableListOf<ElmNamedElement>()

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -42,7 +42,7 @@ class ImportScope(val elmFile: ElmFile) {
             val implicitScopes = GlobalScope.implicitModulesMatching(qualifierPrefix, clientFile)
                     .map { ImportScope(it.elmFile) }
 
-            val explicitScopes = ModuleScope(clientFile).importDeclsForQualifierPrefix(qualifierPrefix)
+            val explicitScopes = ModuleScope.importDeclsForQualifierPrefix(clientFile, qualifierPrefix)
                     .mapNotNull { ImportScope.fromImportDecl(it) }
 
             return if (importsOnly) {
@@ -65,7 +65,7 @@ class ImportScope(val elmFile: ElmFile) {
                 ?: return emptyList()
 
         if (moduleDecl.exposesAll)
-            return ModuleScope(elmFile).getDeclaredValues()
+            return ModuleScope.getDeclaredValues(elmFile)
 
         val exposingList = moduleDecl.exposingList
                 ?: return emptyList()
@@ -86,7 +86,7 @@ class ImportScope(val elmFile: ElmFile) {
                 ?: return emptyList()
 
         if (moduleDecl.exposesAll)
-            return ModuleScope(elmFile).getDeclaredTypes()
+            return ModuleScope.getDeclaredTypes(elmFile)
 
         return moduleDecl.exposingList?.exposedTypeList
                 ?.mapNotNull { it.reference.resolve() }
@@ -101,7 +101,7 @@ class ImportScope(val elmFile: ElmFile) {
                 ?: return emptyList()
 
         if (moduleDecl.exposesAll)
-            return ModuleScope(elmFile).getDeclaredConstructors()
+            return ModuleScope.getDeclaredConstructors(elmFile)
 
         return moduleDecl.exposingList
                 ?.exposedTypeList

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -29,7 +29,7 @@ private fun ElmValueDeclaration.inference(activeScopes: Set<ElmValueDeclaration>
     return CachedValuesManager.getCachedValue(this, TYPE_INFERENCE_KEY) {
         // Elm lets you shadow imported names, including auto-imported names, so only count names
         // declared in this file as shadowable.
-        val shadowableNames = ModuleScope(elmFile).getVisibleValues().topLevel.mapNotNullTo(mutableSetOf()) { it.name }
+        val shadowableNames = ModuleScope.getVisibleValues(elmFile).topLevel.mapNotNullTo(mutableSetOf()) { it.name }
         val result = InferenceScope(shadowableNames, activeScopes.toMutableSet(), false, null).beginDeclarationInference(this)
         CachedValueProvider.Result.create(result, project.modificationTracker, modificationTracker)
     }


### PR DESCRIPTION
Fixes #365 

I think the warning for `ModuleScope` was a false positive. But the cached type inference was capturing a parameter, which is explicitly forbidden in the `CachedValue` javadoc in the 2019 code.