### PR TITLE
Move Code that optimizes Imports into its own class and register it with Intellij

### DIFF
--- a/src/main/kotlin/org/elm/ide/code/format/ElmImportOptimizer.kt
+++ b/src/main/kotlin/org/elm/ide/code/format/ElmImportOptimizer.kt
@@ -1,0 +1,45 @@
+package org.elm.ide.code.format
+
+import com.intellij.lang.ImportOptimizer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import org.elm.ide.inspections.ImportVisitor
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.psi.elements.removeItem
+import org.elm.lang.core.psi.parentOfType
+import org.elm.lang.core.psi.prevSiblings
+import org.elm.lang.core.resolve.scope.ModuleScope
+
+class ElmImportOptimizer : ImportOptimizer {
+    override fun supports(file: PsiFile?) = file is ElmFile
+
+    override fun processFile(file: PsiFile?): Runnable {
+        return Runnable {
+            if(file !is ElmFile)
+                return@Runnable
+
+            val visitor = ImportVisitor(ModuleScope.getImportDecls(file))
+
+            file.accept(object : PsiRecursiveElementWalkingVisitor() {
+                override fun visitElement(element: PsiElement) {
+                    element.accept(visitor)
+                    super.visitElement(element)
+                }
+            })
+
+            for (unusedImport in visitor.unusedImports) {
+                val prevNewline = unusedImport.prevSiblings.firstOrNull { it.textContains('\n') }
+                if (prevNewline == null) unusedImport.delete()
+                else unusedImport.parent.deleteChildRange(prevNewline, unusedImport)
+            }
+
+            for (item in visitor.unusedExposedItems) {
+                val exposingList = item.parentOfType<ElmImportClause>()?.exposingList ?: continue
+                if (exposingList.allExposedItems.size <= 1) exposingList.delete()
+                else exposingList.removeItem(item)
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -194,6 +194,8 @@
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
 
+        <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.code.format.ElmImportOptimizer" />
+
         <!-- Inspections -->
 
         <localInspection language="Elm" groupName="Elm"


### PR DESCRIPTION
This allows the user to press "Code" -> "Optimize Imports" or the corresponding Keyboard Shortcut to optimize the Imports of the current file without having to use the Quickfix for every single unused Import

Right now the Checkbox **Optimize Imports** inside the _Git Commit_-Window is enabled,
but doesn't have any effect, because Intellij won't optimize Imports, when there is no **FormattingModelBuilder** for Elm-Files