### PR TITLE
Fix assigning named constraint to plain constraint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.30"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
         classpath "com.github.JetBrains:gradle-grammar-kit-plugin:2018.3"
     }
 }
@@ -29,7 +29,7 @@ repositories {
     maven { url 'http://dl.bintray.com/jetbrains/markdown' }
 }
 
-ext.kotlinVersion = '1.3.30'
+ext.kotlinVersion = '1.3.31'
 ext.junitVersion = '4.12'
 ext.jacksonVersion = '2.9.8'
 ext.markdownVersion = '0.1.31'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1282,7 +1282,7 @@ private fun elementAllowsShadowing(element: ElmPsiElement): Boolean {
 fun isInferable(ty: Ty): Boolean = ty !is TyUnknown
 
 /** extracts the typeclass from a [TyVar] name if it is a typeclass */
-private val TYPECLASS_REGEX = Regex("(number|appendable|comparable|compappend)\\d*")
+private val TYPECLASS_REGEX = Regex("^(number|appendable|comparable|compappend).*")
 
 /** Extract the typeclass for a var name if it is one, or null if it's a normal var*/
 fun getTypeclassName(ty: TyVar): String? = TYPECLASS_REGEX.matchEntire(ty.name)?.groups?.get(1)?.value

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -527,6 +527,15 @@ main =
     <error descr="Type mismatch.Required: ()Found: List String">foo "" [""] [()]</error>
 """)
 
+    fun `test named constraint appendable`() = checkByText("""
+foo : appendableOne -> appendableTwo -> appendableThree -> appendableTwo
+foo a b c = b
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: List String">foo "" [""] [()]</error>
+""")
+
     fun `test numbered constraint appendable mismatch`() = checkByText("""
 foo : appendable1 -> appendable2 -> appendable1 -> appendable2
 foo a b c = b
@@ -536,6 +545,33 @@ main =
     foo "" [""] <error descr="Type mismatch.Required: StringFound: List String">[""]</error>
 """)
 
+    fun `test named constraint appendable mismatch`() = checkByText("""
+foo : appendableOne -> appendableTwo -> appendableOne -> appendableTwo
+foo a b c = b
+
+main : ()
+main =
+    foo "" [""] <error descr="Type mismatch.Required: StringFound: List String">[""]</error>
+""")
+
+    fun `test numbered constraint appendable invalid value`() = checkByText("""
+foo : appendable1 -> appendable1
+foo a = a
+
+main : ()
+main =
+    foo <error descr="Type mismatch.Required: appendable1Found: ()">()</error>
+""")
+
+    fun `test named constraint appendable invalid value`() = checkByText("""
+foo : appendableOne -> appendableOne
+foo a = a
+
+main : ()
+main =
+    foo <error descr="Type mismatch.Required: appendableOneFound: ()">()</error>
+""")
+
     fun `test numbered constraints in different functions`() = checkByText("""
 foo : number1 -> appendable1 -> comparable1 -> compappend1 -> appendable1
 foo a b c d = b
@@ -543,6 +579,33 @@ foo a b c d = b
 main : number2 -> appendable2 -> comparable2 -> compappend2 -> ()
 main a b c d  =
     <error descr="Type mismatch.Required: ()Found: appendable2">foo a b c d</error>
+""")
+
+    fun `test named constraints in different functions`() = checkByText("""
+foo : numberOne -> appendableOne -> comparableOne -> compappendOne -> appendableOne
+foo a b c d = b
+
+main : numberTwo -> appendableTwo -> comparableTwo -> compappendTwo -> ()
+main a b c d  =
+    <error descr="Type mismatch.Required: ()Found: appendableTwo">foo a b c d</error>
+""")
+
+    fun `test numbered constraint assigned to unnumbered constraint`() = checkByText("""
+foo : number -> number
+foo a = a
+
+main : number1 -> ()
+main a =
+    <error descr="Type mismatch.Required: ()Found: number1">foo a</error>
+""")
+
+    fun `test named constraint assigned to unnumbered constraint`() = checkByText("""
+foo : number -> number
+foo a = a
+
+main : numberOne -> ()
+main a =
+    <error descr="Type mismatch.Required: ()Found: numberOne">foo a</error>
 """)
 
     fun `test calling function with its own return value`() = checkByText("""


### PR DESCRIPTION
When I implemented this originally, I thought typeclass suffixes were restricted to numbers; since there's no documentation indicating otherwise. It turns out that suffixes are unconstrained.

Fixes #403 