### PR TITLE
Support mixed-rigidity in nested function annotations

### DIFF
--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -863,6 +863,29 @@ main a f =
     f <error descr="Type mismatch.Required: numberFound: comparable">a</error>
 """)
 
+    fun `test passing function with vars in annotation in let to flex vars`() = checkByText("""
+foo : (a -> b) -> a -> b
+foo f a = f a
+
+main : ()
+main =
+    let
+        b : a -> a
+        b a = a
+    in
+    <error descr="Type mismatch.Required: ()Found: String">foo b ""</error>
+""")
+
+    fun `test passing function with mixed-rigidity vars in annotation`() = checkByText("""
+main : a -> ()
+main a =
+    let
+        foo : a -> b -> a
+        foo aa bb = aa
+    in
+    <error descr="Type mismatch.Required: ()Found: a">foo a ""</error>
+""")
+
     fun `test calling rigid var in parent scope`() = checkByText("""
 main : (a -> a) -> ()
 main f =


### PR DESCRIPTION
It's possible for a nested function to contain type variables that reference variables in annotations in an outer scope. These variables are rigid at callsites (because the referenced variables are rigid within the scope), whereas all other variables in annotations are flexible at callsites. A single annotation can contain both flexible and rigid variables at callsites.

Previously, we had no way of tracking which variables were references after the annotation was inferred, and all vars in a nested annotation were inferred as rigid. Now, when we infer an annotation, we save all the vars in that annotation in the inference scope. When inferring a callsite, we can flexify only those vars that don't occur in an ancestor scope.

This solution is minimally invasive, but it definitely smells bad. Rigidity is responsible for a lot of the uglier hacks in the current code base. Given that a variable's rigidity is dependent on whether you're viewing it from inside or outside its definition, I think that there must be a better way to represent it than in the immutable `TyVar`. I'm not sure what that is, though.

Fixes #402 
FIxes #408 