### PR TITLE
Fix quick docs for nested functions

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -55,7 +55,7 @@ class ElmDocumentationProvider : AbstractDocumentationProvider() {
 
 private fun documentationFor(decl: ElmFunctionDeclarationLeft): String? = buildString {
     val parent = decl.parent as? ElmValueDeclaration ?: return null
-    val ty = decl.findInference()?.ty
+    val ty = decl.functionTy()
     val id = decl.lowerCaseIdentifier.text
     definition {
         if (ty != null && ty !is TyUnknown) {

--- a/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
@@ -21,6 +21,7 @@ import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
 import org.elm.lang.core.types.TyUnion
 import org.elm.lang.core.types.TyUnknown
 import org.elm.lang.core.types.findInference
+import org.elm.lang.core.types.functionTy
 import org.elm.openapiext.isUnitTestMode
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.saveAllDocuments
@@ -85,7 +86,7 @@ class ElmBuildAction : AnAction() {
     private fun findMainEntryPoint(project: Project, elmProject: ElmProject): ElmFunctionDeclarationLeft? =
             ElmLookup.findByName<ElmFunctionDeclarationLeft>("main", LookupClientLocation(project, elmProject))
                     .find { decl ->
-                        val ty = decl.findInference()?.ty
+                        val ty = decl.functionTy()
                         val key = when (ty) {
                             is TyUnion -> ty.module to ty.name
                             is TyUnknown -> ty.alias?.let { it.module to it.name }

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -130,9 +130,24 @@ main a =
         --^
 """,
             """
-<div class='definition'><pre><b>foo</b> : <a href="psi_element://Int">Int</a> → <a href="psi_element://Int">Int</a> → <a href="psi_element://Int">Int</a> → <a href="psi_element://Int">Int</a>
+<div class='definition'><pre><b>foo</b> : <a href="psi_element://Int">Int</a> → <a href="psi_element://Int">Int</a> → <a href="psi_element://Int">Int</a>
 <b>foo</b> bar baz</pre></div>
 """)
+
+    fun `test function in let`() = doTest(
+            """
+foo a =
+    let
+      bar b = b + 1
+      --^
+    in
+        a
+""",
+            """
+<div class='definition'><pre><b>bar</b> : number → number
+<b>bar</b> b</pre></div>
+""")
+
 
     fun `test function with qualified type annotation`() = doTest(
             """


### PR DESCRIPTION
Since nested function inference is done in the scope of its top-level
ancestor, we were showing function types for the top level function in
the docs for nested functions.