### PR TITLE
Add 'introduce variable' refactoring

### DIFF
--- a/src/main/grammars/ElmParser.bnf
+++ b/src/main/grammars/ElmParser.bnf
@@ -286,9 +286,7 @@ private CallOrAtom ::=
 
 FunctionCallExpr ::=
     FunctionCallTarget Atom+
-    { pin = 2
-      hooks = [ rightBinder="GREEDY_RIGHT_BINDER" ]
-    }
+    { pin = 2 }
 
 private FunctionCallTarget ::=
     FieldAccessExpr

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
@@ -75,10 +75,12 @@ class ElmIntroduceVariableHandler : RefactoringActionHandler {
         // find the nearest location where a let/in would be
         var current: PsiElement? = chosenExpr
         while (current != null) {
-            when (current) {
-                is ElmValueDeclaration -> return current.expression
-                is ElmCaseOfBranch -> return current.expression
-                is ElmAnonymousFunctionExpr -> return current.expression
+            when {
+                current is ElmValueDeclaration -> return current.expression
+                current is ElmCaseOfBranch -> return current.expression
+                current is ElmAnonymousFunctionExpr -> {
+                    if (current.expression in chosenExpr.ancestors) return current.expression
+                }
             }
             current = current.parent
         }

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
@@ -146,7 +146,8 @@ private class ExpressionReplacer(
         val file = letExpr.elmFile
         val anchor = letExpr.valueDeclarationList.last()
         val indent = DocumentUtil.getIndent(editor.document, anchor.startOffset)
-        val indentedDeclExpr = chosenExpr.text.lines().joinToString("\n") { "${indent}    ${it.trimStart()}" }
+        val indentedDeclExpr = chosenExpr.textWithNormalizedIndents.lines()
+                .joinToString("\n") { "$indent    $it" }
         val textToInsert = "\n\n$indent${identifier.text} =\n$indentedDeclExpr"
         val offsetOfNewDecl = anchor.endOffset + textToInsert.indexOf(identifier.text)
 

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
@@ -66,7 +66,7 @@ class ElmIntroduceVariableHandler : RefactoringActionHandler {
         val replacer = ExpressionReplacer(project, editor, chosenExpr)
         val anchor = findAnchor(chosenExpr) ?: error("could not find a place to introduce variable")
         when {
-            anchor is ElmLetInExpr -> replacer.extendExistingLet(anchor)
+            anchor is ElmLetInExpr && anchor !== chosenExpr -> replacer.extendExistingLet(anchor)
             else -> replacer.introduceLet(anchor)
         }
     }
@@ -111,7 +111,7 @@ private class ExpressionReplacer(
     fun introduceLet(elementToReplace: PsiElement) {
         val indent = DocumentUtil.getIndent(editor.document, elementToReplace.startOffset).toString()
         val exprText = chosenExpr.text
-        val declText = "${identifier.text} = $exprText"
+        val declText = "${identifier.text} =\n    $exprText"
 
         val newIdentifierElement = project.runWriteCommandAction {
             val newLetExpr = if (elementToReplace !== chosenExpr) {
@@ -137,7 +137,7 @@ private class ExpressionReplacer(
         val file = letExpr.elmFile
         val anchor = letExpr.valueDeclarationList.last()
         val indent = DocumentUtil.getIndent(editor.document, anchor.startOffset)
-        val textToInsert = "\n\n$indent${identifier.text} = ${chosenExpr.text}"
+        val textToInsert = "\n\n$indent${identifier.text} =\n$indent    ${chosenExpr.text}"
         val offsetOfNewDecl = anchor.endOffset + textToInsert.indexOf(identifier.text)
 
         /*

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
@@ -1,0 +1,177 @@
+package org.elm.ide.refactoring
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiNamedElement
+import com.intellij.refactoring.RefactoringActionHandler
+import com.intellij.refactoring.RefactoringBundle
+import com.intellij.refactoring.introduce.inplace.InplaceVariableIntroducer
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import com.intellij.util.DocumentUtil
+import org.elm.ide.utils.findExpressionAtCaret
+import org.elm.ide.utils.findExpressionInRange
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.elements.ElmAnonymousFunctionExpr
+import org.elm.lang.core.psi.elements.ElmCaseOfBranch
+import org.elm.lang.core.psi.elements.ElmLetInExpr
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.openapiext.runWriteCommandAction
+
+class ElmIntroduceVariableHandler : RefactoringActionHandler {
+
+    override fun invoke(project: Project, editor: Editor, file: PsiFile, dataContext: DataContext?) {
+        if (file !is ElmFile) return
+        val exprs = findCandidateExpressions(editor, file)
+        when (exprs.size) {
+            0 -> {
+                val message = RefactoringBundle.message(if (editor.selectionModel.hasSelection())
+                    "selected.block.should.represent.an.expression"
+                else
+                    "refactoring.introduce.selection.error"
+                )
+                val title = RefactoringBundle.message("introduce.variable.title")
+                val helpId = "refactoring.extractVariable"
+                CommonRefactoringUtil.showErrorHint(project, editor, message, title, helpId)
+            }
+            1 -> introduceVariable(editor, exprs.single())
+            else -> showExpressionChooser(editor, exprs) { chosenExpr ->
+                introduceVariable(editor, chosenExpr)
+            }
+        }
+    }
+
+    private fun findCandidateExpressions(editor: Editor, file: ElmFile): List<ElmExpressionTag> {
+        val selection = editor.selectionModel
+        return if (selection.hasSelection()) {
+            // If the user has some text selected, make a single suggestion based on the selection
+            listOfNotNull(findExpressionInRange(file, selection.selectionStart, selection.selectionEnd))
+        } else {
+            // Suggest nested expressions at caret position
+            val expr = findExpressionAtCaret(file, editor.caretModel.offset) ?: return emptyList()
+            expr.ancestors
+                    .takeWhile { it !is ElmValueDeclaration && it !is ElmLetInExpr }
+                    .filterIsInstance<ElmExpressionTag>()
+                    .toList()
+        }
+    }
+
+    private fun introduceVariable(editor: Editor, chosenExpr: ElmExpressionTag) {
+        if (!chosenExpr.isValid) return
+        val project = editor.project ?: return
+
+        val replacer = ExpressionReplacer(project, editor, chosenExpr)
+        val anchor = findAnchor(chosenExpr) ?: error("could not find a place to introduce variable")
+        when {
+            anchor is ElmLetInExpr -> replacer.extendExistingLet(anchor)
+            else -> replacer.introduceLet(anchor)
+        }
+    }
+
+    private fun findAnchor(chosenExpr: ElmExpressionTag): ElmPsiElement? {
+        // find the nearest location where a let/in would be
+        var current: PsiElement? = chosenExpr
+        while (current != null) {
+            when (current) {
+                is ElmValueDeclaration -> return current.expression
+                is ElmCaseOfBranch -> return current.expression
+                is ElmAnonymousFunctionExpr -> return current.expression
+            }
+            current = current.parent
+        }
+        return null
+    }
+
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
+        // IntelliJ will never call this when introducing a variable
+    }
+}
+
+/**
+ * Manages the replacement of an expression with the appropriate let/in expr
+ *
+ * This class exists solely to make the calling code nicer by consolidating shared parameters.
+ * (poor-man's partially applied functions)
+ */
+private class ExpressionReplacer(
+        private val project: Project,
+        private val editor: Editor,
+        private val chosenExpr: ElmExpressionTag
+) {
+    private val psiFactory = ElmPsiFactory(project)
+    private val suggestedNames = chosenExpr.suggestedNames()
+    private val identifier = psiFactory.createLowerCaseIdentifier(suggestedNames.default)
+
+    /**
+     * Wrap the existing function body in a `let` expression
+     */
+    fun introduceLet(elementToReplace: PsiElement) {
+        val indent = DocumentUtil.getIndent(editor.document, elementToReplace.startOffset).toString()
+        val exprText = chosenExpr.text
+        val declText = "${identifier.text} = $exprText"
+
+        val newIdentifierElement = project.runWriteCommandAction {
+            val newLetExpr = if (elementToReplace !== chosenExpr) {
+                chosenExpr.replace(identifier)
+                psiFactory.createLetInWrapper(indent, declText, elementToReplace.text)
+            } else {
+                psiFactory.createLetInWrapper(indent, declText, identifier.text)
+            }
+            val newLetElement = elementToReplace.replace(newLetExpr) as ElmLetInExpr
+            moveEditorToNameElement(editor, newLetElement.valueDeclarationList.first())
+        }
+
+        if (newIdentifierElement != null) {
+            val occurrences = emptyArray<PsiElement>() // TODO implement me
+            ElmInplaceVariableIntroducer(newIdentifierElement, editor, project, "choose a name", occurrences)
+                    .performInplaceRefactoring(suggestedNames.all)
+        }
+    }
+
+    /**
+     * Insert a new value decl into the exiting `let` expression's inner declarations.
+     */
+    fun extendExistingLet(letExpr: ElmLetInExpr) {
+        val anchor = letExpr.valueDeclarationList.last()
+        val indent = DocumentUtil.getIndent(editor.document, anchor.startOffset)
+        val declText = "\n\n$indent${identifier.text} = ${chosenExpr.text}"
+
+        project.runWriteCommandAction {
+            /*
+                I'm not sure what the best way to handle this would be. Normally you construct
+                Psi elements from text and then splice them into the tree. But "let/in" expressions
+                are parsed in a whitespace-sensitive manner, and we haven't yet done the IntelliJ
+                integration for whitespace formatting. The best I could come up with was a hodge-podge
+                of Psi manipulation and textual manipulation.
+                 */
+            chosenExpr.replace(identifier)
+            PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+            editor.document.replaceString(anchor.endOffset, anchor.endOffset, declText)
+            // HACK to move the cursor to the newly introduced identifier
+            // FIXME find a better way to do this
+            val relativeOffsetOfNewDeclIdentifier = 2 + indent.length // 2 newlines + leading indent
+            editor.caretModel.moveToOffset(anchor.endOffset + relativeOffsetOfNewDeclIdentifier)
+        }
+    }
+}
+
+
+class ElmInplaceVariableIntroducer(
+        elementToRename: PsiNamedElement,
+        editor: Editor,
+        project: Project,
+        title: String,
+        occurrences: Array<PsiElement>
+) : InplaceVariableIntroducer<PsiElement>(elementToRename, editor, project, title, occurrences, null)
+
+
+fun moveEditorToNameElement(editor: Editor, element: PsiElement?): PsiNamedElement? {
+    val newName = element?.descendants
+            ?.filterIsInstance<ElmNameIdentifierOwner>()
+            ?.firstOrNull { it.nameIdentifier.elementType == ElmTypes.LOWER_CASE_IDENTIFIER }
+    editor.caretModel.moveToOffset(newName?.nameIdentifier?.startOffset ?: 0)
+    return newName
+}

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
@@ -77,6 +77,7 @@ class ElmIntroduceVariableHandler : RefactoringActionHandler {
         var current: PsiElement? = chosenExpr
         while (current != null) {
             when {
+                current is ElmLetInExpr -> return current
                 current is ElmValueDeclaration -> return current.expression
                 current is ElmCaseOfBranch -> return current.expression
                 current is ElmAnonymousFunctionExpr -> {

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmNamesValidator.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmNamesValidator.kt
@@ -1,4 +1,4 @@
-package org.elm.lang.refactoring
+package org.elm.ide.refactoring
 
 import com.intellij.lang.refactoring.NamesValidator
 import com.intellij.openapi.project.Project

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmRefactoringSupportProvider.kt
@@ -1,4 +1,4 @@
-package org.elm.lang.refactoring
+package org.elm.ide.refactoring
 
 import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.psi.PsiElement

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmRefactoringSupportProvider.kt
@@ -2,6 +2,7 @@ package org.elm.ide.refactoring
 
 import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.psi.PsiElement
+import com.intellij.refactoring.RefactoringActionHandler
 
 
 class ElmRefactoringSupportProvider : RefactoringSupportProvider() {
@@ -9,5 +10,9 @@ class ElmRefactoringSupportProvider : RefactoringSupportProvider() {
     override fun isMemberInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
         // TODO [kl] eventually we will want to be more selective
         return true
+    }
+
+    override fun getIntroduceVariableHandler(): RefactoringActionHandler? {
+        return ElmIntroduceVariableHandler()
     }
 }

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmRenamePsiElementProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmRenamePsiElementProcessor.kt
@@ -1,7 +1,6 @@
-package org.elm.lang.refactoring
+package org.elm.ide.refactoring
 
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.util.Pass
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.rename.RenamePsiFileProcessor
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmRenamePsiFileProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmRenamePsiFileProcessor.kt
@@ -1,4 +1,4 @@
-package org.elm.lang.refactoring
+package org.elm.ide.refactoring
 
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement

--- a/src/main/kotlin/org/elm/ide/refactoring/extractExpressionUI.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/extractExpressionUI.kt
@@ -28,7 +28,7 @@ interface ExtractExpressionUi {
     fun chooseTarget(exprs: List<ElmExpressionTag>): ElmExpressionTag
 }
 
-var MOCK: ExtractExpressionUi? = null
+private var MOCK: ExtractExpressionUi? = null
 @TestOnly
 fun withMockTargetExpressionChooser(mock: ExtractExpressionUi, f: () -> Unit) {
     MOCK = mock

--- a/src/main/kotlin/org/elm/ide/refactoring/extractExpressionUI.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/extractExpressionUI.kt
@@ -1,0 +1,40 @@
+package org.elm.ide.refactoring
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.Pass
+import com.intellij.refactoring.IntroduceTargetChooser
+import org.elm.lang.core.psi.ElmExpressionTag
+import org.elm.openapiext.isUnitTestMode
+import org.jetbrains.annotations.TestOnly
+
+fun showExpressionChooser(
+        editor: Editor,
+        exprs: List<ElmExpressionTag>,
+        callback: (ElmExpressionTag) -> Unit
+) {
+    if (isUnitTestMode) {
+        callback(MOCK!!.chooseTarget(exprs))
+    } else {
+        IntroduceTargetChooser.showChooser(editor, exprs, callback.asPass) { it.text }
+    }
+}
+
+private val <T> ((T) -> Unit).asPass: Pass<T>
+    get() = object : Pass<T>() {
+        override fun pass(t: T) = this@asPass(t)
+    }
+
+interface ExtractExpressionUi {
+    fun chooseTarget(exprs: List<ElmExpressionTag>): ElmExpressionTag
+}
+
+var MOCK: ExtractExpressionUi? = null
+@TestOnly
+fun withMockTargetExpressionChooser(mock: ExtractExpressionUi, f: () -> Unit) {
+    MOCK = mock
+    try {
+        f()
+    } finally {
+        MOCK = null
+    }
+}

--- a/src/main/kotlin/org/elm/ide/refactoring/nameSuggestions.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/nameSuggestions.kt
@@ -5,7 +5,10 @@ import org.elm.lang.core.psi.ElmExpressionTag
 import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
 import org.elm.lang.core.psi.elements.ElmValueExpr
 import org.elm.lang.core.toElmLowerId
-import org.elm.lang.core.types.*
+import org.elm.lang.core.types.TyFloat
+import org.elm.lang.core.types.TyFunction
+import org.elm.lang.core.types.TyInt
+import org.elm.lang.core.types.findTy
 
 data class SuggestedNames(val default: String, val all: LinkedHashSet<String>)
 
@@ -33,7 +36,6 @@ fun ElmExpressionTag.suggestedNames(): SuggestedNames {
     when (ty) {
         TyInt -> names.addName("i")
         TyFloat -> names.addName("x")
-        is TyVar -> if (ty.name == "number") names.addName("foo") // TODO fix the tests so that they don't depend on "foo"
         is TyFunction -> names.addName("f")
     }
 

--- a/src/main/kotlin/org/elm/ide/refactoring/nameSuggestions.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/nameSuggestions.kt
@@ -56,7 +56,7 @@ private fun Ty.suggestedTyName(): String? =
             is TyUnion -> name.toElmLowerId()
             is TyRecord -> "record"
             is TyTuple -> "tuple"
-            is TyVar -> if (name == "number") "x" else name
+            is TyVar -> name
             else -> null
         }
 

--- a/src/main/kotlin/org/elm/ide/refactoring/nameSuggestions.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/nameSuggestions.kt
@@ -1,0 +1,50 @@
+package org.elm.ide.refactoring
+
+import com.intellij.psi.codeStyle.NameUtil
+import org.elm.lang.core.psi.ElmExpressionTag
+import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
+import org.elm.lang.core.psi.elements.ElmValueExpr
+import org.elm.lang.core.toElmLowerId
+import org.elm.lang.core.types.*
+
+data class SuggestedNames(val default: String, val all: LinkedHashSet<String>)
+
+/**
+ * Return at least one suggestion for a name that describes the receiver expression.
+ */
+fun ElmExpressionTag.suggestedNames(): SuggestedNames {
+    val names = LinkedHashSet<String>()
+    val ty = findTy()
+
+    // suggest based on function call (e.g. suggest "books" for expr: `getBooks "shakespeare" library`)
+    if (this is ElmFunctionCallExpr) {
+        val target = target
+        if (target is ElmValueExpr) {
+            names.addName(target.referenceName)
+        }
+    }
+
+    // TODO suggest names on based on ElmFieldAccessExpr (e.g. suggest "title" for `model.currentPage.title`)
+
+    // if present, suggest type alias (useful for records which often have a descriptive alias name)
+    ty?.alias?.name?.let { names.addName(it) }
+
+    // suggest based on common types
+    when (ty) {
+        TyInt -> names.addName("i")
+        TyFloat -> names.addName("x")
+        is TyVar -> if (ty.name == "number") names.addName("foo") // TODO fix the tests so that they don't depend on "foo"
+        is TyFunction -> names.addName("f")
+    }
+
+    // TODO do not suggest names which are already bound in the current lexical scope
+
+    val defaultName = names.firstOrNull() ?: "x"
+    return SuggestedNames(defaultName, names)
+}
+
+private fun LinkedHashSet<String>.addName(name: String) {
+    // Generate variants on compound words (e.g. "selectedItem" -> ["item", "selectedItem"])
+    NameUtil.getSuggestionsByName(name, "", "", false, false, false)
+            .mapTo(this) { it.toElmLowerId() }
+}

--- a/src/main/kotlin/org/elm/ide/utils/SearchByOffset.kt
+++ b/src/main/kotlin/org/elm/ide/utils/SearchByOffset.kt
@@ -1,0 +1,107 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elm.ide.utils
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.PsiTreeUtil
+import org.elm.lang.core.psi.*
+
+/**
+ * Find an [ElmExpressionTag] element at [offset], being smart about whether
+ * we look to the left or the right of the caret offset.
+ */
+fun findExpressionAtCaret(file: ElmFile, offset: Int): ElmExpressionTag? {
+    val expr = file.expressionAtOffset(offset)
+    val exprBefore = file.expressionAtOffset(offset - 1)
+    return when {
+        expr == null -> exprBefore
+        exprBefore == null -> expr
+        PsiTreeUtil.isAncestor(expr, exprBefore, false) -> exprBefore
+        else -> expr
+    }
+}
+
+private fun ElmFile.expressionAtOffset(offset: Int): ElmExpressionTag? =
+        findElementAt(offset)?.parentOfType(strict = false)
+
+/**
+ * Finds top-most [ElmExpressionTag] within selected range.
+ */
+fun findExpressionInRange(file: PsiFile, startOffset: Int, endOffset: Int): ElmExpressionTag? {
+    val (element1, element2) = file.getElementRange(startOffset, endOffset) ?: return null
+
+    // Get common expression parent.
+    var parent = PsiTreeUtil.findCommonParent(element1, element2) ?: return null
+    parent = parent.parentOfType<ElmExpressionTag>(strict = false) ?: return null
+
+    // If our parent's deepest first child is element1 and deepest last - element 2,
+    // then it is completely within selection, so this is our sought expression.
+    if (element1 == PsiTreeUtil.getDeepestFirst(parent) && element2 == PsiTreeUtil.getDeepestLast(element2)) {
+        return parent
+    }
+
+    return null
+}
+
+/**
+ * Finds two edge leaf PSI elements within given range.
+ */
+fun PsiFile.getElementRange(startOffset: Int, endOffset: Int): Pair<PsiElement, PsiElement>? {
+    val element1 = findElementAtIgnoreWhitespaceBefore(startOffset) ?: return null
+    val element2 = findElementAtIgnoreWhitespaceAfter(endOffset - 1) ?: return null
+
+    // Elements have crossed (for instance when selection was inside single whitespace block)
+    if (element1.startOffset >= element2.endOffset) return null
+
+    return element1 to element2
+}
+
+/**
+ * Finds a leaf PSI element at the specified offset from the start of the text range of this node.
+ * If found element is whitespace, returns its next non-whitespace sibling.
+ */
+fun PsiFile.findElementAtIgnoreWhitespaceBefore(offset: Int): PsiElement? {
+    val element = findElementAt(offset)
+    if (element is PsiWhiteSpace) {
+        return findElementAt(element.getTextRange().endOffset)
+    }
+    return element
+}
+
+/**
+ * Finds a leaf PSI element at the specified offset from the start of the text range of this node.
+ * If found element is whitespace, returns its previous non-whitespace sibling.
+ */
+fun PsiFile.findElementAtIgnoreWhitespaceAfter(offset: Int): PsiElement? {
+    val element = findElementAt(offset)
+    if (element is PsiWhiteSpace) {
+        return findElementAt(element.getTextRange().startOffset - 1)
+    }
+    return element
+}

--- a/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
+++ b/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
@@ -1,5 +1,9 @@
 package org.elm.lang.core
 
+import com.intellij.openapi.util.text.StringUtil
+import org.elm.lang.core.psi.ElmPsiElement
+import org.elm.lang.core.psi.startOffset
+
 /**
  * Convert a string so that its first character is guaranteed to be lowercase.
  * This is necessary in some parts of Elm's syntax (e.g. a function parameter).
@@ -13,3 +17,20 @@ fun String.toElmLowerId(): String =
             all { it.isUpperCase() } -> toLowerCase()
             else -> first().toLowerCase() + substring(1)
         }
+
+/**
+ * Returns the element's text content where each line has been normalized such that:
+ *
+ *   1) it starts with a non-whitespace character
+ *   2) relative indentation is preserved
+ *
+ * This is useful when manually building strings involving multi-line Elm expressions and declarations.
+ */
+val ElmPsiElement.textWithNormalizedIndents: String
+    get() {
+        val platformNewline = if (this.text.contains("\n\r")) "\n\r" else "\n"
+        val firstColumn = StringUtil.offsetToLineColumn(this.containingFile.text, this.startOffset).column
+        return this.text.lines().mapIndexed { index: Int, s: String ->
+            if (index == 0) s else s.drop(firstColumn)
+        }.joinToString(platformNewline)
+    }

--- a/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
+++ b/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
@@ -28,9 +28,8 @@ fun String.toElmLowerId(): String =
  */
 val ElmPsiElement.textWithNormalizedIndents: String
     get() {
-        val platformNewline = if (this.text.contains("\r\n")) "\r\n" else "\n"
         val firstColumn = StringUtil.offsetToLineColumn(this.containingFile.text, this.startOffset).column
         return this.text.lines().mapIndexed { index: Int, s: String ->
             if (index == 0) s else s.drop(firstColumn)
-        }.joinToString(platformNewline)
+        }.joinToString("\n")
     }

--- a/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
+++ b/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
@@ -1,0 +1,15 @@
+package org.elm.lang.core
+
+/**
+ * Convert a string so that its first character is guaranteed to be lowercase.
+ * This is necessary in some parts of Elm's syntax (e.g. a function parameter).
+ *
+ * If the receiver consists of all uppercase letters, the entire thing will be made
+ * lowercase (because "uuid" is a far more sensible transformation of "UUID" than "uUID").
+ */
+fun String.toElmLowerId(): String =
+        when {
+            isEmpty() -> ""
+            all { it.isUpperCase() } -> toLowerCase()
+            else -> first().toLowerCase() + substring(1)
+        }

--- a/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
+++ b/src/main/kotlin/org/elm/lang/core/ElmTextUtils.kt
@@ -28,7 +28,7 @@ fun String.toElmLowerId(): String =
  */
 val ElmPsiElement.textWithNormalizedIndents: String
     get() {
-        val platformNewline = if (this.text.contains("\n\r")) "\n\r" else "\n"
+        val platformNewline = if (this.text.contains("\r\n")) "\r\n" else "\n"
         val firstColumn = StringUtil.offsetToLineColumn(this.containingFile.text, this.startOffset).column
         return this.text.lines().mapIndexed { index: Int, s: String ->
             if (index == 0) s else s.drop(firstColumn)

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -140,12 +140,15 @@ class ElmPsiFactory(private val project: Project) {
                     ?.childOfType<ElmCaseOfExpr>()?.branches
                     ?: error("Failed to create case of branches from $patterns")
 
-    fun createLetInWrapper(indent: String, newDeclText: String, bodyText: String): ElmLetInExpr {
-        val newDeclIndented = newDeclText.lines().joinToString("\n") { "${indent}    $it" }
+    fun createLetInWrapper(indent: String, newDeclName: String, newDeclBody: String, bodyText: String): ElmLetInExpr {
+        // NOTE: Assumes that each line in newDeclBody has had its indent normalized to match the indent of the first line.
+        //       Each line of newDeclBody must start with a non-whitespace character.
+        val newDeclBodyIndented = newDeclBody.lines().joinToString("\n") { "$indent        $it" }
         val code = """
 foo =
 ${indent}let
-$newDeclIndented
+${indent}    $newDeclName =
+$newDeclBodyIndented
 ${indent}in
 ${indent}$bodyText
 """

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -140,6 +140,18 @@ class ElmPsiFactory(private val project: Project) {
                     ?.childOfType<ElmCaseOfExpr>()?.branches
                     ?: error("Failed to create case of branches from $patterns")
 
+    fun createLetInWrapper(indent: String, newDeclText: String, bodyText: String): ElmLetInExpr =
+            """
+foo =
+${indent}let
+${indent}    $newDeclText
+${indent}in
+${indent}$bodyText
+            """
+                    .let { createFromText<ElmValueDeclaration>(it) }
+                    ?.childOfType<ElmLetInExpr>()
+                    ?: error("Failed to create let/in wrapper")
+
     fun createNewline(): PsiElement = createWhitespace("\n")
 
     fun createWhitespace(ws: String): PsiElement =

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -140,17 +140,19 @@ class ElmPsiFactory(private val project: Project) {
                     ?.childOfType<ElmCaseOfExpr>()?.branches
                     ?: error("Failed to create case of branches from $patterns")
 
-    fun createLetInWrapper(indent: String, newDeclText: String, bodyText: String): ElmLetInExpr =
-            """
+    fun createLetInWrapper(indent: String, newDeclText: String, bodyText: String): ElmLetInExpr {
+        val newDeclIndented = newDeclText.lines().joinToString("\n") { "${indent}    $it" }
+        val code = """
 foo =
 ${indent}let
-${indent}    $newDeclText
+$newDeclIndented
 ${indent}in
 ${indent}$bodyText
-            """
-                    .let { createFromText<ElmValueDeclaration>(it) }
-                    ?.childOfType<ElmLetInExpr>()
-                    ?: error("Failed to create let/in wrapper")
+"""
+        return createFromText<ElmValueDeclaration>(code)
+                ?.childOfType<ElmLetInExpr>()
+                ?: error("Failed to create let/in wrapper")
+    }
 
     fun createNewline(): PsiElement = createWhitespace("\n")
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -1,6 +1,7 @@
 package org.elm.lang.core.types
 
 import com.intellij.codeInsight.documentation.DocumentationManagerUtil
+import org.elm.lang.core.toElmLowerId
 
 /**
  * Render a [Ty] to a string that can be shown to the user.
@@ -94,10 +95,10 @@ private class TypeRenderer(private val linkify: Boolean, private val withModule:
 
 /** Render a name or destructuring pattern to use as a parameter for a function or case branch */
 fun Ty.renderParam(): String {
-    return alias?.name?.toFirstCharLowerCased() ?: when (this) {
+    return alias?.name?.toElmLowerId() ?: when (this) {
         is TyFunction -> "function"
         TyShader -> "shader"
-        is TyUnion -> name.toFirstCharLowerCased()
+        is TyUnion -> name.toElmLowerId()
         is TyRecord, is MutableTyRecord -> "record"
         is TyTuple -> renderParam()
         is TyVar -> name
@@ -109,10 +110,6 @@ fun Ty.renderParam(): String {
 fun TyTuple.renderParam(): String {
     return types.joinToString(", ", prefix = "(", postfix = ")") { it.renderParam() }
 }
-
-private fun String.toFirstCharLowerCased(): String =
-        if (isEmpty()) ""
-        else first().toLowerCase() + substring(1)
 
 /** An infinite sequence of possible type variable names: (a, b, ... z, a1, b1, ...) */
 fun varNames(): Sequence<String> = (0..Int.MAX_VALUE).asSequence().map { nthVarName(it) }

--- a/src/main/kotlin/org/elm/utils/EditorUtils.kt
+++ b/src/main/kotlin/org/elm/utils/EditorUtils.kt
@@ -4,5 +4,14 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.util.DocumentUtil
 
+/**
+ * Calculates indent of the line containing [offset]
+ * @return Whitespaces at the beginning of the line
+ */
 fun Document.getIndent(offset: Int): String = DocumentUtil.getIndent(this, offset).toString()
+
+/**
+ * Calculates indent of the line containing [offset]
+ * @return Whitespaces at the beginning of the line
+ */
 fun Editor.getIndent(offset: Int): String = document.getIndent(offset)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -195,14 +195,14 @@
         <completion.contributor language="Elm"
                                 implementationClass="org.elm.lang.core.completion.ElmCompletionContributor"/>
         <lang.findUsagesProvider language="Elm" implementationClass="org.elm.ide.search.ElmFindUsagesProvider"/>
-        <lang.namesValidator language="Elm" implementationClass="org.elm.lang.refactoring.ElmNamesValidator"/>
+        <lang.namesValidator language="Elm" implementationClass="org.elm.ide.refactoring.ElmNamesValidator"/>
         <lang.parserDefinition language="Elm" implementationClass="org.elm.lang.core.parser.ElmParserDefinition"/>
         <lang.psiStructureViewFactory language="Elm"
                                       implementationClass="org.elm.ide.structure.ElmStructureViewFactory"/>
         <lang.refactoringSupport language="Elm"
-                                 implementationClass="org.elm.lang.refactoring.ElmRefactoringSupportProvider"/>
-        <renamePsiElementProcessor implementation="org.elm.lang.refactoring.ElmRenamePsiFileProcessor"/>
-        <renamePsiElementProcessor implementation="org.elm.lang.refactoring.ElmRenamePsiElementProcessor"/>
+                                 implementationClass="org.elm.ide.refactoring.ElmRefactoringSupportProvider"/>
+        <renamePsiElementProcessor implementation="org.elm.ide.refactoring.ElmRenamePsiFileProcessor"/>
+        <renamePsiElementProcessor implementation="org.elm.ide.refactoring.ElmRenamePsiElementProcessor"/>
         <lang.syntaxHighlighterFactory language="Elm"
                                        implementationClass="org.elm.ide.highlight.ElmSyntaxHighlighterFactory"/>
         <spellchecker.support language="Elm" implementationClass="org.elm.ide.spelling.ElmSpellCheckingStrategy"/>

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -323,19 +323,14 @@ f model =
 
 
     fun `test suggest an alternate name if the default is already taken`() = doTest("""
-f p =
+f x =
+    {-caret-}"foo"
+""", listOf("\"foo\""), 0, """
+f x =
     let
-        x = 0
+        x1 = "foo"
     in
-    x + {-caret-}p.x
-""", listOf("p", "p.x", "x + p.x"), 1, """
-f p =
-    let
-        x = 0
-
-        x1 = p.x
-    in
-    x + x1
+    x1
 """)
 
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -365,6 +365,30 @@ f g =
 """)
 
 
+    fun `test preserve indentation when extracting multi-line expr into an existing let-in`() = doTest("""
+f =
+    let
+        k =
+            4
+    in
+    2{-caret-}
+        *
+        k
+""", listOf("2", "2\n        *\n        k"), 1, """
+f =
+    let
+        k =
+            4
+
+        x =
+            2
+                *
+                k
+    in
+    x
+""")
+
+
     // NAME SUGGESTIONS
 
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -187,6 +187,23 @@ f model =
 """)
 
 
+    fun `test suggest an alternate name if the default is already taken`() = doTest("""
+f p =
+    let
+        x = 0
+    in
+    x + {-caret-}p.x
+""", listOf("p", "p.x", "x + p.x"), 1, """
+f p =
+    let
+        x = 0
+
+        x1 = p.x
+    in
+    x + x1
+""")
+
+
     private fun doTest(
             @Language("Elm") before: String,
             expressions: List<String>,

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -226,15 +226,15 @@ f x =
 
     // AJ example2: throws an exception about an invalid offset when trying to do inplace rename
     fun `test extract lambda inside parens`() = doTest("""
-f =
-     (\extractMe{-caret-} -> ())
+g =
+    (\extractMe{-caret-} -> ())
 """, listOf("""\extractMe -> ()""", """(\extractMe -> ())"""), 0, """
-f =
+g =
     let
-        x =
+        f =
             \extractMe -> ()
     in
-    (x)
+    (f)
 """)
 
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -159,6 +159,18 @@ f =
 """)
 
 
+    fun `test extracts if predicate expr cleanly`() = doTest("""
+f k =
+    if {-caret-}0 == identity k then 1 else 0
+""", listOf("0", "0 == identity k", "if 0 == identity k then 1 else 0"), 1, """
+f k =
+    let
+        x = 0 == identity k
+    in
+    if x then 1 else 0
+""")
+
+
     fun `test suggests based on function call name`() = doTest("""
 f =
     selectWidget {-caret-}3

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -292,6 +292,31 @@ f =
 """)
 
 
+    // AJ example7: this is strange Elm code, but maybe people do it to control the visibility of the inner decls?
+    fun `test extract in the context of a let nested within the body of another let`() = doTest("""
+example7 =
+    let
+        x = 1
+    in
+    let
+        y = 2
+    in
+    y{-caret-}
+""", listOf("y"), 0, """
+example7 =
+    let
+        x = 1
+    in
+    let
+        y = 2
+
+        number =
+            y
+    in
+    number
+""")
+
+
     // AJ example8 alt: extracting entire let-in generated code mangles previous top-level decl
     fun `test extract entire let-in`() = doTest("""
 module Foo exposing (f)

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -343,6 +343,19 @@ f =
 """)
 
 
+    // AJ example 9: the indentation gets screwed up because the following lines need more indent
+    // TODO re-enable this test once we have a better way of formatting generated Elm code
+//    fun `test extract expr on same line as the function decl`() = doTest("""
+//example9 = (){-caret-}
+//""", listOf("()"), 0, """
+//example9 = let
+//               x =
+//                   ()
+//           in
+//           x
+//""")
+
+
     fun `test extend a let with a multi-line expression`() = doTest("""
 f =
     let

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -19,10 +19,10 @@ f =
 """, listOf("3", "4 + 3"), 0, """
 f =
     let
-        x =
+        number =
             3
     in
-    4 + x
+    4 + number
 """)
 
 
@@ -32,10 +32,10 @@ f =
 """, listOf("3", "4 + 3"), 1, """
 f =
     let
-        x =
+        number =
             4 + 3
     in
-    x
+    number
 """)
 
 
@@ -45,10 +45,10 @@ f =
 """, emptyList(), 0, """
 f =
     let
-        x =
+        number =
             4 + 3
     in
-    x
+    number
 """)
 
 
@@ -65,10 +65,10 @@ f =
         k =
             4
 
-        x =
+        number =
             3
     in
-    k + x
+    k + number
 """)
 
 
@@ -91,10 +91,10 @@ f =
         r =
             0
 
-        x =
+        number =
             3
     in
-    k + x
+    k + number
 """)
 
 
@@ -113,10 +113,10 @@ f =
     let
         k =
             let
-                x =
+                number =
                     3
             in
-            4 + x
+            4 + number
     in
     k
 """)
@@ -141,10 +141,10 @@ f =
                 y =
                     4
 
-                x =
+                number =
                     3
             in
-            y + x
+            y + number
     in
     k
 """)
@@ -156,10 +156,10 @@ f =
 """, listOf("3"), 0, """
 f =
     let
-        x =
+        number =
             3
     in
-    x
+    number
 """)
 
 
@@ -173,10 +173,10 @@ f =
     case () of
         _ ->
             let
-                x =
+                number =
                     3
             in
-            x
+            number
 """)
 
 
@@ -188,10 +188,10 @@ f =
 f =
     \_ ->
         let
-            x =
+            number =
                 3
         in
-        x
+        number
 """)
 
 
@@ -265,12 +265,12 @@ f =
 """, listOf("1\n    +\n    2"), 0, """
 f =
     let
-        x =
+        number =
             1
             +
             2
     in
-    x
+    number
 """)
 
 
@@ -283,12 +283,12 @@ f =
 """, listOf("1\n        +\n        2"), 0, """
 f =
     let
-        x =
+        number =
             1
                 +
                 2
     in
-    x
+    number
 """)
 
 
@@ -307,14 +307,14 @@ module Foo exposing (f)
 
 f =
     let
-        x1 =
+        number =
             let
                 x =
                     1
             in
             2
     in
-    x1
+    number
 """)
 
 
@@ -380,12 +380,12 @@ f =
         k =
             4
 
-        x =
+        number =
             2
                 *
                 k
     in
-    x
+    number
 """)
 
 
@@ -423,15 +423,15 @@ f model =
 
 
     fun `test suggest an alternate name if the default is already taken`() = doTest("""
-f x =
+f number =
     {-caret-}42
 """, listOf("42"), 0, """
-f x =
+f number =
     let
-        x1 =
+        number1 =
             42
     in
-    x1
+    number1
 """)
 
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -467,15 +467,14 @@ f number =
             @Language("Elm") before: String,
             expressions: List<String>,
             target: Int,
-            @Language("Elm") after: String,
-            replaceAll: Boolean = false
+            @Language("Elm") after: String
     ) {
         checkByText(before, after) {
-            doIntroduceVariable(expressions, target, replaceAll)
+            doIntroduceVariable(expressions, target)
         }
     }
 
-    private fun doIntroduceVariable(expressions: List<String>, target: Int, replaceAll: Boolean) {
+    private fun doIntroduceVariable(expressions: List<String>, target: Int) {
         var shownTargetChooser = false
         withMockTargetExpressionChooser(object : ExtractExpressionUi {
             override fun chooseTarget(exprs: List<ElmExpressionTag>): ElmExpressionTag {

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -16,9 +16,9 @@ f =
 """, listOf("3", "4 + 3"), 0, """
 f =
     let
-        foo = 3
+        x = 3
     in
-    4 + foo
+    4 + x
 """)
 
 
@@ -28,92 +28,92 @@ f =
 """, listOf("3", "4 + 3"), 1, """
 f =
     let
-        foo = 4 + 3
+        x = 4 + 3
     in
-    foo
+    x
 """)
 
 
     fun `test reuses existing let-in`() = doTest("""
 f =
     let
-        x = 4
+        k = 4
     in
-    x + {-caret-}3
-""", listOf("3", "x + 3"), 0, """
+    k + {-caret-}3
+""", listOf("3", "k + 3"), 0, """
 f =
     let
-        x = 4
+        k = 4
 
-        foo = 3
+        x = 3
     in
-    x + foo
+    k + x
 """)
 
 
     fun `test creates after the last decl in a let-in`() = doTest("""
 f =
     let
-        x = 4
+        k = 4
 
-        y = 3
+        r = 0
     in
-    x + {-caret-}3
-""", listOf("3", "x + 3"), 0, """
+    k + {-caret-}3
+""", listOf("3", "k + 3"), 0, """
 f =
     let
-        x = 4
+        k = 4
 
-        y = 3
+        r = 0
 
-        foo = 3
+        x = 3
     in
-    x + foo
+    k + x
 """)
 
 
     fun `test creates a let within a let`() = doTest("""
 f =
     let
-        x =
+        k =
             4 + {-caret-}3
     in
-    x
+    k
 """, listOf("3", "4 + 3"), 0, """
 f =
     let
-        x =
+        k =
             let
-                foo = 3
+                x = 3
             in
-            4 + foo
+            4 + x
     in
-    x
+    k
 """)
 
 
     fun `test creates in a let expression body nested in a let expr inner decl`() = doTest("""
 f =
     let
-        x =
+        k =
             let
                 y = 4
             in
             y + {-caret-}3
     in
-    x
+    k
 """, listOf("3", "y + 3"), 0, """
 f =
     let
-        x =
+        k =
             let
                 y = 4
 
-                foo = 3
+                x = 3
             in
-            y + foo
+            y + x
     in
-    x
+    k
 """)
 
 
@@ -123,9 +123,9 @@ f =
 """, listOf("3"), 0, """
 f =
     let
-        foo = 3
+        x = 3
     in
-    foo
+    x
 """)
 
 
@@ -139,9 +139,9 @@ f =
     case () of
         _ ->
             let
-                foo = 3
+                x = 3
             in
-            foo
+            x
 """)
 
 
@@ -153,9 +153,9 @@ f =
 f =
     \_ ->
         let
-            foo = 3
+            x = 3
         in
-        foo
+        x
 """)
 
 
@@ -163,7 +163,7 @@ f =
 f =
     selectWidget {-caret-}3
 
-selectWidget x = x
+selectWidget w = w
 """, listOf("3", "selectWidget 3"), 1, """
 f =
     let
@@ -171,7 +171,7 @@ f =
     in
     widget
 
-selectWidget x = x
+selectWidget w = w
 """)
 
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -1,0 +1,205 @@
+package org.elm.ide.refactoring
+
+import junit.framework.TestCase
+import org.elm.lang.ElmTestBase
+import org.elm.lang.core.psi.ElmExpressionTag
+import org.intellij.lang.annotations.Language
+
+class ElmIntroduceVariableHandlerTest : ElmTestBase() {
+
+    override fun getProjectDescriptor() = ElmWithStdlibDescriptor
+
+
+    fun `test creates let-in when necessary`() = doTest("""
+f =
+    4 + {-caret-}3
+""", listOf("3", "4 + 3"), 0, """
+f =
+    let
+        foo = 3
+    in
+    4 + foo
+""")
+
+
+    fun `test can select alternate expression`() = doTest("""
+f =
+    4 + {-caret-}3
+""", listOf("3", "4 + 3"), 1, """
+f =
+    let
+        foo = 4 + 3
+    in
+    foo
+""")
+
+
+    fun `test reuses existing let-in`() = doTest("""
+f =
+    let
+        x = 4
+    in
+    x + {-caret-}3
+""", listOf("3", "x + 3"), 0, """
+f =
+    let
+        x = 4
+
+        foo = 3
+    in
+    x + foo
+""")
+
+
+    fun `test creates after the last decl in a let-in`() = doTest("""
+f =
+    let
+        x = 4
+
+        y = 3
+    in
+    x + {-caret-}3
+""", listOf("3", "x + 3"), 0, """
+f =
+    let
+        x = 4
+
+        y = 3
+
+        foo = 3
+    in
+    x + foo
+""")
+
+
+    fun `test creates a let within a let`() = doTest("""
+f =
+    let
+        x =
+            4 + {-caret-}3
+    in
+    x
+""", listOf("3", "4 + 3"), 0, """
+f =
+    let
+        x =
+            let
+                foo = 3
+            in
+            4 + foo
+    in
+    x
+""")
+
+
+    fun `test creates in a let expression body nested in a let expr inner decl`() = doTest("""
+f =
+    let
+        x =
+            let
+                y = 4
+            in
+            y + {-caret-}3
+    in
+    x
+""", listOf("3", "y + 3"), 0, """
+f =
+    let
+        x =
+            let
+                y = 4
+
+                foo = 3
+            in
+            y + foo
+    in
+    x
+""")
+
+
+    fun `test works for very simple functions`() = doTest("""
+f =
+    {-caret-}3
+""", listOf("3"), 0, """
+f =
+    let
+        foo = 3
+    in
+    foo
+""")
+
+
+    fun `test introduces a let-in within a case branch`() = doTest("""
+f =
+    case () of
+        _ ->
+            {-caret-}3
+""", listOf("3", "case () of\n        _ ->\n            3"), 0, """
+f =
+    case () of
+        _ ->
+            let
+                foo = 3
+            in
+            foo
+""")
+
+
+    fun `test introduces a let-in within a lambda`() = doTest("""
+f =
+    \_ ->
+        {-caret-}3
+""", listOf("3", "\\_ ->\n        3"), 0, """
+f =
+    \_ ->
+        let
+            foo = 3
+        in
+        foo
+""")
+
+
+    fun `test suggests based on function call name`() = doTest("""
+f =
+    selectWidget {-caret-}3
+
+selectWidget x = x
+""", listOf("3", "selectWidget 3"), 1, """
+f =
+    let
+        widget = selectWidget 3
+    in
+    widget
+
+selectWidget x = x
+""")
+
+
+    private fun doTest(
+            @Language("Elm") before: String,
+            expressions: List<String>,
+            target: Int,
+            @Language("Elm") after: String,
+            replaceAll: Boolean = false
+    ) {
+        checkByText(before, after) {
+            doIntroduceVariable(expressions, target, replaceAll)
+        }
+    }
+
+    private fun doIntroduceVariable(expressions: List<String>, target: Int, replaceAll: Boolean) {
+        var shownTargetChooser = false
+        withMockTargetExpressionChooser(object : ExtractExpressionUi {
+            override fun chooseTarget(exprs: List<ElmExpressionTag>): ElmExpressionTag {
+                shownTargetChooser = true
+                TestCase.assertEquals(exprs.map { it.text }, expressions)
+                return exprs[target]
+            }
+        }) {
+            myFixture.performEditorAction("IntroduceVariable")
+            if (expressions.size > 1 && !shownTargetChooser) {
+                error("Didn't show chooser")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -201,10 +201,10 @@ f k =
 """, listOf("0", "0 == identity k", "if 0 == identity k then 1 else 0"), 1, """
 f k =
     let
-        x =
+        bool =
             0 == identity k
     in
-    if x then 1 else 0
+    if bool then 1 else 0
 """)
 
 
@@ -216,11 +216,11 @@ f x =
 """, listOf("case x of\n        blah -> x"), 0, """
 f x =
     let
-        x1 =
+        a =
             case x of
                 blah -> x
     in
-    x1
+    a
 """)
 
 
@@ -247,12 +247,12 @@ f =
 """, listOf("1", "{ field = 1\n    , field2 = 2\n    }"), 1, """
 f =
     let
-        x =
+        record =
             { field = 1
             , field2 = 2
             }
     in
-    x
+    record
 """)
 
 
@@ -334,13 +334,13 @@ f =
         _ =
             ()
 
-        x =
+        list =
             [ 0
             , 1
             , 2
             ]
     in
-    x
+    list
 """)
 
 
@@ -354,14 +354,14 @@ f g =
 """, listOf("0", "[ 0\n        , 1\n        , 2\n        ]", "g\n        [ 0\n        , 1\n        , 2\n        ]"), 1, """
 f g =
     let
-        x =
+        list =
             [ 0
             , 1
             , 2
             ]
     in
     g
-        x
+        list
 """)
 
 
@@ -424,12 +424,12 @@ f model =
 
     fun `test suggest an alternate name if the default is already taken`() = doTest("""
 f x =
-    {-caret-}"foo"
-""", listOf("\"foo\""), 0, """
+    {-caret-}42
+""", listOf("42"), 0, """
 f x =
     let
         x1 =
-            "foo"
+            42
     in
     x1
 """)

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -175,6 +175,18 @@ selectWidget w = w
 """)
 
 
+    fun `test suggests based on end of field access chain`() = doTest("""
+f model =
+    {-caret-}model.currentPage.title
+""", listOf("model", "model.currentPage", "model.currentPage.title"), 2, """
+f model =
+    let
+        title = model.currentPage.title
+    in
+    title
+""")
+
+
     private fun doTest(
             @Language("Elm") before: String,
             expressions: List<String>,

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -19,7 +19,8 @@ f =
 """, listOf("3", "4 + 3"), 0, """
 f =
     let
-        x = 3
+        x =
+            3
     in
     4 + x
 """)
@@ -31,7 +32,8 @@ f =
 """, listOf("3", "4 + 3"), 1, """
 f =
     let
-        x = 4 + 3
+        x =
+            4 + 3
     in
     x
 """)
@@ -43,7 +45,8 @@ f =
 """, emptyList(), 0, """
 f =
     let
-        x = 4 + 3
+        x =
+            4 + 3
     in
     x
 """)
@@ -52,15 +55,18 @@ f =
     fun `test reuses existing let-in`() = doTest("""
 f =
     let
-        k = 4
+        k =
+            4
     in
     k + {-caret-}3
 """, listOf("3", "k + 3"), 0, """
 f =
     let
-        k = 4
+        k =
+            4
 
-        x = 3
+        x =
+            3
     in
     k + x
 """)
@@ -69,19 +75,24 @@ f =
     fun `test creates after the last decl in a let-in`() = doTest("""
 f =
     let
-        k = 4
+        k =
+            4
 
-        r = 0
+        r =
+            0
     in
     k + {-caret-}3
 """, listOf("3", "k + 3"), 0, """
 f =
     let
-        k = 4
+        k =
+            4
 
-        r = 0
+        r =
+            0
 
-        x = 3
+        x =
+            3
     in
     k + x
 """)
@@ -102,7 +113,8 @@ f =
     let
         k =
             let
-                x = 3
+                x =
+                    3
             in
             4 + x
     in
@@ -115,7 +127,8 @@ f =
     let
         k =
             let
-                y = 4
+                y =
+                    4
             in
             y + {-caret-}3
     in
@@ -125,9 +138,11 @@ f =
     let
         k =
             let
-                y = 4
+                y =
+                    4
 
-                x = 3
+                x =
+                    3
             in
             y + x
     in
@@ -141,7 +156,8 @@ f =
 """, listOf("3"), 0, """
 f =
     let
-        x = 3
+        x =
+            3
     in
     x
 """)
@@ -157,7 +173,8 @@ f =
     case () of
         _ ->
             let
-                x = 3
+                x =
+                    3
             in
             x
 """)
@@ -171,7 +188,8 @@ f =
 f =
     \_ ->
         let
-            x = 3
+            x =
+                3
         in
         x
 """)
@@ -183,7 +201,8 @@ f k =
 """, listOf("0", "0 == identity k", "if 0 == identity k then 1 else 0"), 1, """
 f k =
     let
-        x = 0 == identity k
+        x =
+            0 == identity k
     in
     if x then 1 else 0
 """)
@@ -197,8 +216,9 @@ f x =
 """, listOf("case x of\n        blah -> x"), 0, """
 f x =
     let
-        x1 = case x of
-                 blah -> x
+        x1 =
+            case x of
+                blah -> x
     in
     x1
 """)
@@ -211,7 +231,8 @@ f =
 """, listOf("""\extractMe -> ()""", """(\extractMe -> ())"""), 0, """
 f =
     let
-        x = \extractMe -> ()
+        x =
+            \extractMe -> ()
     in
     (x)
 """)
@@ -226,7 +247,8 @@ f =
 """, listOf("1", "{ field = 1\n    , field2 = 2\n    }"), 1, """
 f =
     let
-        x = { field = 1
+        x =
+            { field = 1
             , field2 = 2
             }
     in
@@ -243,7 +265,8 @@ f =
 """, listOf("1\n    +\n    2"), 0, """
 f =
     let
-        x = 1
+        x =
+            1
             +
             2
     in
@@ -260,7 +283,8 @@ f =
 """, listOf("1\n        +\n        2"), 0, """
 f =
     let
-        x = 1
+        x =
+            1
                 +
                 2
     in
@@ -274,7 +298,8 @@ module Foo exposing (f)
 
 f =
     <selection>let
-        x = 1
+        x =
+            1
     in
     2</selection>
 """, listOf("let\n    x = 1\nin\n2"), 0, """
@@ -282,10 +307,12 @@ module Foo exposing (f)
 
 f =
     let
-        x1 = let
-                 x = 1
-             in
-             2
+        x1 =
+            let
+                x =
+                    1
+            in
+            2
     in
     x1
 """)
@@ -302,7 +329,8 @@ selectWidget w = w
 """, listOf("3", "selectWidget 3"), 1, """
 f =
     let
-        widget = selectWidget 3
+        widget =
+            selectWidget 3
     in
     widget
 
@@ -316,7 +344,8 @@ f model =
 """, listOf("model", "model.currentPage", "model.currentPage.title"), 2, """
 f model =
     let
-        title = model.currentPage.title
+        title =
+            model.currentPage.title
     in
     title
 """)
@@ -328,7 +357,8 @@ f x =
 """, listOf("\"foo\""), 0, """
 f x =
     let
-        x1 = "foo"
+        x1 =
+            "foo"
     in
     x1
 """)

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -318,6 +318,53 @@ f =
 """)
 
 
+    fun `test extend a let with a multi-line expression`() = doTest("""
+f =
+    let
+        _ =
+            ()
+    in
+    [ 0{-caret-}
+    , 1
+    , 2
+    ]
+""", listOf("0", "[ 0\n    , 1\n    , 2\n    ]"), 1, """
+f =
+    let
+        _ =
+            ()
+
+        x =
+            [ 0
+            , 1
+            , 2
+            ]
+    in
+    x
+""")
+
+
+    fun `test indented multi-line expression`() = doTest("""
+f g =
+    g
+        [ 0{-caret-}
+        , 1
+        , 2
+        ]
+""", listOf("0", "[ 0\n        , 1\n        , 2\n        ]", "g\n        [ 0\n        , 1\n        , 2\n        ]"), 1, """
+f g =
+    let
+        x =
+            [ 0
+            , 1
+            , 2
+            ]
+    in
+    g
+        x
+""")
+
+
     // NAME SUGGESTIONS
 
 

--- a/src/test/resources/org/elm/lang/core/parser/fixtures/complete/FunctionCall.txt
+++ b/src/test/resources/org/elm/lang/core/parser/fixtures/complete/FunctionCall.txt
@@ -75,7 +75,7 @@ Elm File
         PsiWhiteSpace(' ')
         ElmNumberConstantExpr(NUMBER_CONSTANT_EXPR)
           PsiElement(NUMBER_LITERAL)('1')
-        PsiWhiteSpace(' ')
+      PsiWhiteSpace(' ')
       ElmOperator(OPERATOR)
         PsiElement(OPERATOR_IDENTIFIER)('+')
       PsiWhiteSpace(' ')


### PR DESCRIPTION
Suppose you have code like:
```elm
f x =
    if x > 0 && x < 100 then Just x else Nothing
```
... and you want to factor-out the `if`'s boolean predicate. You can now put the cursor anywhere in the boolean expression, press Cmd-Option-V (Ctrl-Alt-V on Windows/Linux), and the plugin will move the expression into a `let` like so:
```elm
f x =
    let
         isValid = x > 0 && x < 100
    in 
    if isValid then Just x else Nothing
```

This works for all expressions. And if you already have a `let`, it will just add another declaration to that `let`.

The plugin will automatically suggest names for the introduced variable based on the expression, and it will automatically invoke in-place rename so that you can provide a better name if desired.

## Implementation Notes

I followed intellij-rust very closely, but the code generation was trickier (partly due to Elm's whitespace-sensitive parsing and partly due to how intrusive adding a `let` is). It could benefit from some cleanup, but it will have to suffice for now.

I punted on the "replace all occurrences" feature as the code is already complicated enough as-is. I will implement it later.