### PR TITLE
IntelliJ 2019.2 fix: drop IntelliJ's UI DSL

### DIFF
--- a/src/main/kotlin/org/elm/utils/LayoutUI.kt
+++ b/src/main/kotlin/org/elm/utils/LayoutUI.kt
@@ -1,0 +1,92 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elm.utils
+
+import com.intellij.openapi.ui.LabeledComponent
+import com.intellij.ui.IdeBorderFactory
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import javax.swing.BoxLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/*
+ * IntelliJ has a new UI DSL (http://www.jetbrains.org/intellij/sdk/docs/user_interface_components/kotlin_ui_dsl.html)
+ * but it has been evolving a lot and there are API incompatibilities between 2019.2
+ * and previous releases. So I've decided to use this simple layout util from intellij-rust
+ * until we can fully adopt 2019.2 as our minimum IDE version. At which time, this file
+ * can and should be deleted.
+ */
+
+const val HGAP = 30
+const val VERTICAL_OFFSET = 2
+const val HORIZONTAL_OFFSET = 5
+
+
+fun layout(block: ElmLayoutUIBuilder.() -> Unit): JPanel {
+    val panel = JPanel(BorderLayout())
+    val innerPanel = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+    }
+    panel.add(innerPanel, BorderLayout.NORTH)
+    val builder = ElmLayoutUIBuilderImpl(innerPanel).apply(block)
+    UIUtil.mergeComponentsWithAnchor(builder.labeledComponents)
+    return panel
+}
+
+
+interface ElmLayoutUIBuilder {
+    fun row(text: String = "", component: JComponent, toolTip: String = "")
+    fun block(text: String, block: ElmLayoutUIBuilder.() -> Unit)
+}
+
+
+private class ElmLayoutUIBuilderImpl(
+        val panel: JPanel,
+        val labeledComponents: MutableList<LabeledComponent<*>> = mutableListOf()
+) : ElmLayoutUIBuilder {
+
+    override fun block(text: String, block: ElmLayoutUIBuilder.() -> Unit) {
+        val blockPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            border = IdeBorderFactory.createTitledBorder(text, false)
+        }
+        ElmLayoutUIBuilderImpl(blockPanel, labeledComponents).apply(block)
+        panel.add(blockPanel)
+    }
+
+    override fun row(text: String, component: JComponent, toolTip: String) {
+        val labeledComponent = LabeledComponent.create(component, text, BorderLayout.WEST).apply {
+            (layout as? BorderLayout)?.hgap = HGAP
+            border = JBUI.Borders.empty(VERTICAL_OFFSET, HORIZONTAL_OFFSET)
+            toolTipText = toolTip.trimIndent()
+        }
+        labeledComponents += labeledComponent
+        panel.add(labeledComponent)
+    }
+}


### PR DESCRIPTION
There was an API incompatibility between 2019.1 and 2019.2 when
invoking a custom JComponent. The easiest fix was to switch over to
intellij-rust's lightweight UI DSL.