### PR TITLE
Add support for 0.19.1

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -79,10 +79,10 @@ sealed class ElmProject(
 
     companion object {
 
-        fun parse(manifestPath: Path, toolchain: ElmToolchain, ignoreTestDeps: Boolean = false): ElmProject {
+        fun parse(manifestPath: Path, repo: ElmPackageRepository, ignoreTestDeps: Boolean = false): ElmProject {
             val inputStream = LocalFileSystem.getInstance().refreshAndFindFileByPath(manifestPath.toString())?.inputStream
                     ?: throw ProjectLoadException("Could not find file $manifestPath. Is the package installed?")
-            return parse(inputStream, manifestPath, toolchain, ignoreTestDeps)
+            return parse(inputStream, manifestPath, repo, ignoreTestDeps)
         }
 
         /**
@@ -90,7 +90,7 @@ sealed class ElmProject(
          *
          * @throws ProjectLoadException if the JSON cannot be parsed
          */
-        fun parse(inputStream: InputStream, manifestPath: Path, toolchain: ElmToolchain, ignoreTestDeps: Boolean = false): ElmProject {
+        fun parse(inputStream: InputStream, manifestPath: Path, repo: ElmPackageRepository, ignoreTestDeps: Boolean = false): ElmProject {
 
             if (manifestPath.endsWith(ELM_LEGACY_JSON)) {
                 val elmStuffPath = manifestPath.resolveSibling("elm-stuff")
@@ -114,8 +114,8 @@ sealed class ElmProject(
                     ElmApplicationProject(
                             manifestPath = manifestPath,
                             elmVersion = dto.elmVersion,
-                            dependencies = dto.dependencies.depsToPackages(toolchain),
-                            testDependencies = if (ignoreTestDeps) emptyList() else dto.testDependencies.depsToPackages(toolchain),
+                            dependencies = dto.dependencies.depsToPackages(repo),
+                            testDependencies = if (ignoreTestDeps) emptyList() else dto.testDependencies.depsToPackages(repo),
                             sourceDirectories = dto.sourceDirectories
                     )
                 }
@@ -133,8 +133,8 @@ sealed class ElmProject(
                     ElmPackageProject(
                             manifestPath = manifestPath,
                             elmVersion = dto.elmVersion,
-                            dependencies = dto.dependencies.constraintDepsToPackages(toolchain),
-                            testDependencies = if (ignoreTestDeps) emptyList() else dto.testDependencies.constraintDepsToPackages(toolchain),
+                            dependencies = dto.dependencies.constraintDepsToPackages(repo),
+                            testDependencies = if (ignoreTestDeps) emptyList() else dto.testDependencies.constraintDepsToPackages(repo),
                             sourceDirectories = listOf(Paths.get("src")),
                             name = dto.name,
                             version = dto.version,
@@ -210,34 +210,34 @@ class ElmPackageProject(
 ) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
 
 
-private fun ExactDependenciesDTO.depsToPackages(toolchain: ElmToolchain) =
-        direct.depsToPackages(toolchain) + indirect.depsToPackages(toolchain)
+private fun ExactDependenciesDTO.depsToPackages(repo: ElmPackageRepository) =
+        direct.depsToPackages(repo) + indirect.depsToPackages(repo)
 
 
-private fun Map<String, Version>.depsToPackages(toolchain: ElmToolchain) =
+private fun Map<String, Version>.depsToPackages(repo: ElmPackageRepository) =
         map { (name, version) ->
-            loadDependency(toolchain, name, version)
+            loadDependency(repo, name, version)
         }
 
-private fun Map<String, Constraint>.constraintDepsToPackages(toolchain: ElmToolchain) =
+private fun Map<String, Constraint>.constraintDepsToPackages(repo: ElmPackageRepository) =
         map { (name, constraint) ->
-            val version = toolchain.availableVersionsForPackage(name)
+            val version = repo.availableVersionsForPackage(name)
                     .filter { constraint.contains(it) }
                     .sorted()
                     .firstOrNull()
                     ?: throw ProjectLoadException("Could not load $name ($constraint). Is it installed?")
 
-            loadDependency(toolchain, name, version)
+            loadDependency(repo, name, version)
         }
 
-fun loadDependency(toolchain: ElmToolchain, name: String, version: Version): ElmPackageProject {
-    val manifestPath = toolchain.findPackageManifest(name, version)
+fun loadDependency(repo: ElmPackageRepository, name: String, version: Version): ElmPackageProject {
+    val manifestPath = repo.findPackageManifest(name, version)
             ?: throw ProjectLoadException("Could not load $name ($version): manifest not found")
     // TODO [kl] guard against circular dependencies
     // NOTE: we ignore the test dependencies of our dependencies because it is highly unlikely
     // that they have been installed by Elm in the local package cache (the user would have
     // to actually run the package's tests from within the package cache, which no one is going to do).
-    val elmProject = ElmProject.parse(manifestPath, toolchain, ignoreTestDeps = true) as? ElmPackageProject
+    val elmProject = ElmProject.parse(manifestPath, repo, ignoreTestDeps = true) as? ElmPackageProject
             ?: throw ProjectLoadException("Could not load $name ($version): expected a package!")
 
     return elmProject

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -124,7 +124,12 @@ data class ElmPackageRepository(val elmCompilerVersion: Version) {
      */
     private val globalPackageCacheDir: Path
         get() {
-            return Paths.get("$elmHomePath/$elmCompilerVersion/package/")
+            // In 0.19.0, the directory name was singular, but beginning in 0.19.1 it is now plural
+            val subDirName = when (elmCompilerVersion) {
+                Version(0, 19, 0) -> "package"
+                else -> "packages"
+            }
+            return Paths.get("$elmHomePath/$elmCompilerVersion/$subDirName/")
         }
 
     /**

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -73,33 +73,25 @@ data class ElmToolchain(
             elmCompilerPath != null && Files.isExecutable(elmCompilerPath)
 
     /**
-     * Path to directory for a package at a specific version, containing `elm.json`
+     * Path to Elm's global package cache directory
      */
-    fun packageVersionDir(name: String, version: Version): Path? {
-        // TODO [kl] stop hard-coding the compiler version
-        // it's ok to assume 19 here because this will never be called from 0.18 code,
-        // but even this assumption will not be safe once future 19 releases are made.
+    private fun globalPackageCacheDir(): Path {
         val compilerVersion = "0.19.0"
-
-        return Paths.get("$elmHomePath/$compilerVersion/package/$name/$version/")
+        return Paths.get("$elmHomePath/$compilerVersion/package/")
     }
 
     /**
      * Path to the manifest file for the Elm package [name] at version [version]
      */
     fun findPackageManifest(name: String, version: Version): Path? {
-        // TODO [kl] use compiler version to determine whether to use elm.json vs elm-package.json
-        return packageVersionDir(name, version)?.resolve(ELM_JSON)
+        return globalPackageCacheDir().resolve("$name/$version/$ELM_JSON")
     }
 
     /**
      * Path to directory for a package, containing one or more versions
      */
     fun availableVersionsForPackage(name: String): List<Version> {
-        // TODO [kl] stop hard-coding the compiler version
-        val compilerVersion = "0.19.0"
-
-        val files = File("$elmHomePath/$compilerVersion/package/$name/").listFiles()
+        val files = File("${globalPackageCacheDir()}/$name/").listFiles()
                 ?: return emptyList()
         return files.mapNotNull { Version.parseOrNull(it.name) }
     }

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -189,7 +189,9 @@ class ElmWorkspaceService(
      */
     private fun asyncLoadProject(manifestPath: Path): CompletableFuture<ElmProject> =
             runAsyncTask(intellijProject, "Loading Elm project '$manifestPath'") {
-                ElmProject.parse(manifestPath, settings.toolchain)
+                val compilerVersion = settings.toolchain.elmCLI?.queryVersion()?.orNull()
+                        ?: throw ProjectLoadException("Must specify a valid path to Elm binary in Settings")
+                ElmProject.parse(manifestPath, ElmPackageRepository(compilerVersion))
             }.whenComplete { _, error ->
                 // log the result
                 if (error == null) {

--- a/src/main/kotlin/org/elm/workspace/VersionUtil.kt
+++ b/src/main/kotlin/org/elm/workspace/VersionUtil.kt
@@ -34,6 +34,13 @@ data class Version(
                 else -> 0
             }
 
+    /**
+     * Compare two versions by only looking at major, minor and patch fields (ignores pre-release and build fields)
+     */
+    fun looseEquals(other: Version): Boolean =
+            x == other.x && y == other.y && z == other.z
+
+
     companion object {
         val UNKNOWN: Version = Version(0, 0, 0)
         val ELM_18: Version = Version(0, 18, 0) // TODO [drop 0.18]

--- a/src/test/kotlin/org/elm/lang/ElmTestBase.kt
+++ b/src/test/kotlin/org/elm/lang/ElmTestBase.kt
@@ -49,11 +49,8 @@ import org.elm.TestProject
 import org.elm.fileTreeFromText
 import org.elm.lang.core.psi.parentOfType
 import org.elm.openapiext.pathAsPath
-import org.elm.workspace.ElmProject
-import org.elm.workspace.ElmToolchain
+import org.elm.workspace.*
 import org.elm.workspace.ElmToolchain.Companion.ELM_JSON
-import org.elm.workspace.MinimalElmStdlibVariant
-import org.elm.workspace.elmWorkspace
 import org.intellij.lang.annotations.Language
 
 private val log = logger<ElmTestBase>()
@@ -236,13 +233,14 @@ abstract class ElmTestBase : LightPlatformCodeInsightFixtureTestCase(), ElmTestC
                 MinimalElmStdlibVariant.ensureElmStdlibInstalled(module.project, toolchain)
             } else {
                 log.debug("Configuring bare Elm project")
+                val elmCompilerVersion = Version(0, 19, 0)
                 @Language("JSON") val json = """
                     {
                         "type": "application",
                         "source-directories": [
                             "."
                         ],
-                        "elm-version": "0.19.0",
+                        "elm-version": "$elmCompilerVersion",
                         "dependencies": {
                             "direct": {},
                             "indirect": {}
@@ -256,7 +254,8 @@ abstract class ElmTestBase : LightPlatformCodeInsightFixtureTestCase(), ElmTestC
                 val contentRoot = contentEntry.file!!
                 val elmJsonFile = contentRoot.createChildData(contentRoot, ELM_JSON)
                 VfsUtil.saveText(elmJsonFile, json)
-                ElmProject.parse(json.byteInputStream(), elmJsonFile.pathAsPath, toolchain)
+                val repo = ElmPackageRepository(elmCompilerVersion)
+                ElmProject.parse(json.byteInputStream(), elmJsonFile.pathAsPath, repo)
             }
             module.project.elmWorkspace.setupForTests(toolchain, elmProject)
         }

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -50,7 +50,8 @@ interface ElmStdlibVariant {
         // Now return an `ElmProject` with a manifest path suitable for IntelliJ's "light"
         // integration tests which put everything at `/src` using the in-memory VFS.
         val inMemManifestPath = Paths.get("/src/$ELM_JSON")
-        val elmProj = ElmProject.parse(jsonManifest.byteInputStream(), inMemManifestPath, toolchain)
+        val repo = ElmPackageRepository(compilerVersion)
+        val elmProj = ElmProject.parse(jsonManifest.byteInputStream(), inMemManifestPath, repo)
         require(Paths.get(".") in elmProj.sourceDirectories) {
             "Since the elm.json file is stored in `/src` (in-memory VFS), `source-directories` must contain \".\""
         }

--- a/src/test/kotlin/org/elm/workspace/VersionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/VersionTest.kt
@@ -1,8 +1,8 @@
 package org.elm.workspace
 
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -46,6 +46,22 @@ class VersionTest {
     @Test
     fun `version compare ignores build metadata`() {
         assertTrue(Version.parse("1.0.0+foo").compareTo(Version.parse("1.0.0+bar")) == 0)
+    }
+
+    @Test
+    fun `loose version equality ignores pre-release fields and build metadata`() {
+        // loosely equal
+        assertTrue(Version.parse("1.0.0").looseEquals(Version.parse("1.0.0")))
+        assertTrue(Version.parse("1.0.0-alpha").looseEquals(Version.parse("1.0.0")))
+        assertTrue(Version.parse("1.0.0-alpha").looseEquals(Version.parse("1.0.0-beta")))
+        assertTrue(Version.parse("1.0.0-alpha+foo").looseEquals(Version.parse("1.0.0-beta")))
+        assertTrue(Version.parse("1.0.0-beta1").looseEquals(Version.parse("1.0.0-beta2")))
+
+        // not loosely equal
+        assertFalse(Version.parse("1.0.0").looseEquals(Version.parse("2.0.0")))
+        assertFalse(Version.parse("1.0.0").looseEquals(Version.parse("1.1.0")))
+        assertFalse(Version.parse("1.0.0").looseEquals(Version.parse("1.0.1")))
+        assertFalse(Version.parse("1.0.0").looseEquals(Version.parse("1.0.1-beta")))
     }
 
     @Test


### PR DESCRIPTION
The Elm compiler installs dependencies in `~/.elm/$CompilerVersionNumber`. Previously I hard-coded this as "0.19.0", but now we need to handle patch releases. This is done by running `elm --version` whenever we load an Elm project file. 

Prior to this change, it didn't really matter whether the user set a valid path to the Elm compiler in the IntelliJ settings, but now it is a requirement so that we can run `elm --version`. In such cases where things are misconfigured, we now show actionable error messages to the user via IntelliJ's editor notification system.