### PR TITLE
Improve unused import inspection

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -10,11 +10,12 @@ import com.intellij.psi.PsiElementVisitor
 import org.elm.ide.inspections.fixes.OptimizeImportsFix
 import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.elements.ElmExposedValue
+import org.elm.lang.core.psi.elements.ElmAsClause
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.parentOfType
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.LexicalValueReference
+import org.elm.lang.core.resolve.reference.QualifiedValueReference
 import org.elm.lang.core.resolve.scope.ModuleScope
 import java.util.concurrent.ConcurrentHashMap
 
@@ -43,6 +44,10 @@ class ElmUnusedImportInspection : LocalInspectionTool() {
         for (item in visitor.unusedExposedItems) {
             problemsHolder.markUnused(item, "'${item.text}' is exposed but unused")
         }
+
+        for (alias in visitor.unusedModuleAliases) {
+            problemsHolder.markUnused(alias, "Unused alias")
+        }
     }
 }
 
@@ -55,28 +60,29 @@ private fun ProblemsHolder.markUnused(elem: PsiElement, message: String) {
 class ImportVisitor(initialImports: List<ElmImportClause>) : PsiElementVisitor() {
 
     // IMPORTANT! IntelliJ's LocalInspectionTool requires that visitor implementations be thread-safe.
-    private val imports: ConcurrentHashMap<String, ElmImportClause>
-    private val exposing: ConcurrentHashMap<String, ElmExposedValue>
-
-    init {
-        imports = ConcurrentHashMap(initialImports.associateBy { it.moduleQID.text })
-        exposing = initialImports.mapNotNull { it.exposingList }
-                .flatMap { it.exposedValueList }
-                .associateBy { it.text }
-                .let { ConcurrentHashMap(it) }
-    }
+    private val imports = initialImports.associateByTo(ConcurrentHashMap()) { it.moduleQID.text }
+    private val exposing = initialImports.mapNotNull { it.exposingList }
+            .flatMap { it.exposedValueList }
+            .associateByTo(ConcurrentHashMap()) { it.text }
+    private val moduleAliases = initialImports.mapNotNull { it.asClause }
+            .associateByTo(ConcurrentHashMap()) { it.upperCaseIdentifier.text }
 
     /** Returns the list of unused imports. IMPORTANT: only valid *after* the visitor completes its traversal. */
     val unusedImports: List<ElmImportClause>
-        get() = imports.values.toList().filter { !it.safeToIgnore }
+        get() = imports.values.filter { !it.safeToIgnore }
 
     /** Returns the list of unused exposed items. IMPORTANT: only valid *after* the visitor completes its traversal. */
     val unusedExposedItems: List<ElmExposedItemTag>
-        get() = exposing.values.toList().filter {
-            val import = it.parentOfType<ElmImportClause>() ?: return@filter false
-            val alreadyReported = import in unusedImports
-            !alreadyReported && !import.safeToIgnore
-        }
+        get() = exposing.values.filter { notChildOfAlreadyReportedStatement(it) }
+
+    /** Returns the list of unused module aliases. IMPORTANT: only valid *after* the visitor completes its traversal. */
+    val unusedModuleAliases: List<ElmAsClause>
+        get() = moduleAliases.values.filter { notChildOfAlreadyReportedStatement(it) }
+
+    private fun notChildOfAlreadyReportedStatement(it: PsiElement) : Boolean {
+        val import = it.parentOfType<ElmImportClause>() ?: return false
+        return import !in unusedImports && !import.safeToIgnore
+    }
 
     override fun visitElement(element: PsiElement?) {
         super.visitElement(element)
@@ -84,15 +90,23 @@ class ImportVisitor(initialImports: List<ElmImportClause>) : PsiElementVisitor()
             // TODO possible performance optimization:
             //      Qualified refs may not need to be resolved as they have enough information to determine
             //      the target module name directly. But the refs may be cached, so...shrug
-            val resolved = element.reference.resolve() ?: return
+            val reference = element.reference
+            val resolved = reference.resolve() ?: return
             val resolvedModule = resolved.elmFile.getModuleDecl() ?: return
             val resolvedModuleName = resolvedModule.name
             imports.remove(resolvedModuleName)
 
             // For now we are just going to mark exposed values/functions which are unused
             // TODO expand this to types, union variant constructors, and operators
-            if (element.reference is LexicalValueReference) {
+            if (reference is LexicalValueReference) {
                 exposing.remove(element.referenceName)
+            }
+
+            if (reference is QualifiedValueReference) {
+                val identifierList = reference.valueQID.upperCaseIdentifierList
+                if (identifierList.size == 1) {
+                    moduleAliases.remove(identifierList[0].text)
+                }
             }
         }
     }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -1,13 +1,12 @@
 package org.elm.ide.inspections
 
-import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.LocalInspectionToolSession
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.codeInsight.actions.OptimizeImportsProcessor
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
-import org.elm.ide.inspections.fixes.OptimizeImportsFix
+import com.intellij.psi.PsiFile
 import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.elements.ElmAsClause
@@ -53,9 +52,17 @@ class ElmUnusedImportInspection : LocalInspectionTool() {
 
 
 private fun ProblemsHolder.markUnused(elem: PsiElement, message: String) {
-    registerProblem(elem, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, OptimizeImportsFix())
+    val file = elem.containingFile as? ElmFile ?: return
+    registerProblem(elem, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, OptimizeImportsFix(file))
 }
 
+private class OptimizeImportsFix(file: ElmFile) : LocalQuickFixOnPsiElement(file)  {
+    override fun getText() = "Optimize imports"
+    override fun getFamilyName() = name
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        OptimizeImportsProcessor(project, file).run()
+    }
+}
 
 class ImportVisitor(initialImports: List<ElmImportClause>) : PsiElementVisitor() {
 

--- a/src/main/kotlin/org/elm/ide/inspections/fixes/OptimizeImportsFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/fixes/OptimizeImportsFix.kt
@@ -40,5 +40,11 @@ class OptimizeImportsFix : LocalQuickFix {
             if (exposingList.allExposedItems.size <= 1) exposingList.delete()
             else exposingList.removeItem(item)
         }
+
+        for (alias in visitor.unusedModuleAliases) {
+            val parent = alias.parentOfType<ElmImportClause>() ?: continue
+            // Delete the alias and the preceding whitespace
+            parent.deleteChildRange(parent.moduleQID.nextSibling, alias)
+        }
     }
 }

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmImportOptimizer.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmImportOptimizer.kt
@@ -1,9 +1,9 @@
-package org.elm.ide.inspections.fixes
+package org.elm.ide.refactoring
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.openapi.project.Project
+import com.intellij.lang.ImportOptimizer
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
 import org.elm.ide.inspections.ImportVisitor
 import org.elm.lang.core.psi.ElmFile
@@ -13,13 +13,22 @@ import org.elm.lang.core.psi.parentOfType
 import org.elm.lang.core.psi.prevSiblings
 import org.elm.lang.core.resolve.scope.ModuleScope
 
-class OptimizeImportsFix : LocalQuickFix {
+class ElmImportOptimizer: ImportOptimizer {
+    override fun supports(file: PsiFile?): Boolean = file is ElmFile
 
-    override fun getName() = "Optimize imports"
-    override fun getFamilyName() = name
+    override fun processFile(file: PsiFile): Runnable {
+        true
+        return Runnable {
+            val documentManager = PsiDocumentManager.getInstance(file.project)
+            val document = documentManager.getDocument(file)
+            if (document != null) {
+                documentManager.commitDocument(document)
+            }
+            execute(file as ElmFile)
+        }
+    }
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val file = descriptor.psiElement?.containingFile as? ElmFile ?: return
+    private fun execute(file: ElmFile) {
         val visitor = ImportVisitor(ModuleScope.getImportDecls(file))
 
         file.accept(object : PsiRecursiveElementWalkingVisitor() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -214,6 +214,7 @@
                                         implementationClass="org.elm.ide.lineMarkers.ElmExposureLineMarkerProvider"/>
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
+        <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.refactoring.ElmImportOptimizer"/>
 
         <!-- Inspections -->
 

--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedImportInspectionTest.kt
@@ -56,6 +56,16 @@ class ElmUnusedImportInspectionTest : ElmInspectionsTestBase(ElmUnusedImportInsp
         bar = ()
     """.trimIndent())
 
+    fun `test with module alias`() = checkByFileTree("""
+        --@ Main.elm
+        import Foo <warning descr="Unused alias">as F</warning> exposing (foo)
+        main = foo
+        --^
+
+        --@ Foo.elm
+        module Foo exposing (..)
+        foo = ()
+    """.trimIndent())
 
     // https://github.com/klazuka/intellij-elm/issues/197
     fun `test issue 197 record update syntax also counts as usage of an exposed name`() = checkByFileTree("""


### PR DESCRIPTION
The first commit in this PR fixes #418.
The second commit hooks up the unused import inspection to the standard IntelliJ "Optimize Imports" mechanism, which enables the `Ctrl+Alt+O` shortcut. It also adds the "Optimize Imports" menu entry to the file explorer. Unfortunately, that menu action [only runs on files that register a formatter](https://github.com/JetBrains/intellij-community/blob/351994570e5f6e5d8cc57e8febe217d933a13a09/platform/lang-impl/src/com/intellij/codeInsight/actions/AbstractLayoutCodeProcessor.java#L154). That could probably be considered a bug in IntelliJ, but we should set up a formatter regardless.