### PR TITLE
Adjust syntax highlighting

### DIFF
--- a/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
@@ -30,6 +30,8 @@ class ElmColorSettingsPage : ColorSettingsPage {
                     "sig_left" to ElmColor.TYPE_ANNOTATION_NAME,
                     "sig_right" to ElmColor.TYPE_ANNOTATION_SIGNATURE_TYPES,
                     "type" to ElmColor.TYPE,
+                    "accessor" to ElmColor.RECORD_FIELD_ACCESSOR,
+                    "field" to ElmColor.RECORD_FIELD,
                     "func_decl" to ElmColor.DEFINITION_NAME
             ).mapValues { it.value.textAttributesKey }
 
@@ -37,7 +39,7 @@ class ElmColorSettingsPage : ColorSettingsPage {
             demoCodeText
 }
 
-private val demoCodeText = """
+private const val demoCodeText = """
 module Todo exposing (..)
 
 import Html exposing (div, h1, ul, li, text)
@@ -45,9 +47,9 @@ import Html exposing (div, h1, ul, li, text)
 -- a single line comment
 
 type alias <type>Model</type> =
-    { page : <type>Int</type>
-    , title : <type>String</type>
-    , stepper : <type>Int</type> -> <type>Int</type>
+    { <field>page</field> : <type>Int</type>
+    , <field>title</field> : <type>String</type>
+    , <field>stepper</field> : <type>Int</type> -> <type>Int</type>
     }
 
 type <type>Msg</type>
@@ -59,9 +61,9 @@ type <type>Msg</type>
     case msg of
         ModeA ->
             { model
-                | page = 0
-                , title = "Mode A"
-                , stepper = (\k -> k + 1)
+                | <field>page</field> = 0
+                , <field>title</field> = "Mode A"
+                , <field>stepper</field> = (\k -> k + 1)
             }
                 ! []
 
@@ -74,6 +76,6 @@ type <type>Msg</type>
         div []
             [ h1 [] [ text "Chapter One" ]
             , ul []
-                (List.map itemify model.items)
+                (List.map <accessor>.value</accessor> model.<field>items</field>)
             ]
 """

--- a/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
@@ -28,8 +28,8 @@ class ElmColorSettingsPage : ColorSettingsPage {
     // special tags in [demoText] for semantic highlighting
             mapOf(
                     "sig_left" to ElmColor.TYPE_ANNOTATION_NAME,
-                    "sig_right" to ElmColor.TYPE_ANNOTATION_SIGNATURE_TYPES,
-                    "type" to ElmColor.TYPE,
+                    "type" to ElmColor.TYPE_ANNOTATION_SIGNATURE_TYPES,
+                    "variant" to ElmColor.TYPE_CONSTRUCTOR,
                     "accessor" to ElmColor.RECORD_FIELD_ACCESSOR,
                     "field" to ElmColor.RECORD_FIELD,
                     "func_decl" to ElmColor.DEFINITION_NAME
@@ -46,20 +46,20 @@ import Html exposing (div, h1, ul, li, text)
 
 -- a single line comment
 
-type alias <type>Model</type> =
+type alias Model =
     { <field>page</field> : <type>Int</type>
     , <field>title</field> : <type>String</type>
     , <field>stepper</field> : <type>Int</type> -> <type>Int</type>
     }
 
-type <type>Msg</type>
-    = ModeA
-    | ModeB <type>Int</type>
+type Msg <type>a</type>
+    = <variant>ModeA</variant>
+    | <variant>ModeB</variant> <type>Maybe a</type>
 
-<sig_left>update</sig_left> : <sig_right>Msg</sig_right> -> <sig_right>Model</sig_right> -> ( <sig_right>Model</sig_right>, <sig_right>Cmd Msg</sig_right> )
+<sig_left>update</sig_left> : <type>Msg</type> -> <type>Model</type> -> ( <type>Model</type>, <type>Cmd Msg</type> )
 <func_decl>update</func_decl> msg model =
     case msg of
-        ModeA ->
+        <variant>ModeA</variant> ->
             { model
                 | <field>page</field> = 0
                 , <field>title</field> = "Mode A"
@@ -67,10 +67,10 @@ type <type>Msg</type>
             }
                 ! []
 
-<sig_left>view</sig_left> : <sig_right>Model</sig_right> -> <sig_right>Html.Html Msg</sig_right>
+<sig_left>view</sig_left> : <type>Model</type> -> <type>Html.Html Msg</type>
 <func_decl>view</func_decl> model =
     let
-        itemify label =
+        <func_decl>itemify</func_decl> label =
             li [] [ text label ]
     in
         div []

--- a/src/main/kotlin/org/elm/ide/color/ElmColors.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColors.kt
@@ -32,10 +32,9 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
     DEFINITION_NAME("Definition Name", Default.FUNCTION_DECLARATION),
 
     /**
-     * The uppercase identifier for a type in all contexts EXCEPT when appearing
-     * in a type annotation.
+     * The uppercase identifier for a type constructors and union variants
      */
-    TYPE("Type", Default.CLASS_NAME),
+    TYPE_CONSTRUCTOR("Type", Default.CLASS_NAME),
 
     /**
      * The lowercase identifier name in a type annotation.

--- a/src/main/kotlin/org/elm/ide/color/ElmColors.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColors.kt
@@ -1,48 +1,48 @@
 package org.elm.ide.color
 
-import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
 import com.intellij.openapi.editor.HighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.AttributesDescriptor
 
 enum class ElmColor(humanName: String, default: TextAttributesKey) {
 
-    KEYWORD("Keyword", DefaultLanguageHighlighterColors.KEYWORD),
+    KEYWORD("Keyword", Default.KEYWORD),
     BAD_CHAR("Bad Character", HighlighterColors.BAD_CHARACTER),
-    COMMENT("Comment", DefaultLanguageHighlighterColors.LINE_COMMENT),
-    STRING("String//String text", DefaultLanguageHighlighterColors.STRING),
-    VALID_STRING_ESCAPE("String//Valid escape sequence", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE),
-    INVALID_STRING_ESCAPE("String//Invalid escape sequence", DefaultLanguageHighlighterColors.INVALID_STRING_ESCAPE),
-    NUMBER("Number", DefaultLanguageHighlighterColors.NUMBER),
-    DOT("Punctuation//Dot", DefaultLanguageHighlighterColors.DOT),
-    ARROW("Punctuation//Arrows", DefaultLanguageHighlighterColors.OPERATION_SIGN),
-    OPERATOR("Operator", DefaultLanguageHighlighterColors.OPERATION_SIGN),
-    PARENTHESIS("Punctuation//Parentheses", DefaultLanguageHighlighterColors.PARENTHESES),
-    BRACES("Punctuation//Braces", DefaultLanguageHighlighterColors.BRACES),
-    BRACKETS("Punctuation//Brackets", DefaultLanguageHighlighterColors.BRACKETS),
-    COMMA("Punctuation//Comma", DefaultLanguageHighlighterColors.COMMA),
-    EQ("Punctuation//Equals", DefaultLanguageHighlighterColors.OPERATION_SIGN),
-    PIPE("Punctuation//Pipe", DefaultLanguageHighlighterColors.OPERATION_SIGN),
+    COMMENT("Comment", Default.LINE_COMMENT),
+    STRING("String//String text", Default.STRING),
+    VALID_STRING_ESCAPE("String//Valid escape sequence", Default.VALID_STRING_ESCAPE),
+    INVALID_STRING_ESCAPE("String//Invalid escape sequence", Default.INVALID_STRING_ESCAPE),
+    NUMBER("Number", Default.NUMBER),
+    DOT("Punctuation//Dot", Default.DOT),
+    ARROW("Punctuation//Arrows", Default.OPERATION_SIGN),
+    OPERATOR("Operator", Default.OPERATION_SIGN),
+    PARENTHESIS("Punctuation//Parentheses", Default.PARENTHESES),
+    BRACES("Punctuation//Braces", Default.BRACES),
+    BRACKETS("Punctuation//Brackets", Default.BRACKETS),
+    COMMA("Punctuation//Comma", Default.COMMA),
+    EQ("Punctuation//Equals", Default.OPERATION_SIGN),
+    PIPE("Punctuation//Pipe", Default.OPERATION_SIGN),
 
     /**
      * The name of a definition.
      *
      * e.g. 'foo' in 'foo x y = x * y'
      */
-    DEFINITION_NAME("Definition Name", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION),
+    DEFINITION_NAME("Definition Name", Default.FUNCTION_DECLARATION),
 
     /**
      * The uppercase identifier for a type in all contexts EXCEPT when appearing
      * in a type annotation.
      */
-    TYPE("Type", DefaultLanguageHighlighterColors.CLASS_NAME),
+    TYPE("Type", Default.CLASS_NAME),
 
     /**
      * The lowercase identifier name in a type annotation.
      *
      * e.g. 'foo' in 'foo : String -> Cmd msg'
      */
-    TYPE_ANNOTATION_NAME("Type Annotation//Name", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION),
+    TYPE_ANNOTATION_NAME("Type Annotation//Name", Default.FUNCTION_DECLARATION),
 
     /**
      * Both uppercase and lowercase identifiers appearing on the right-hand side
@@ -50,7 +50,10 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
      *
      * e.g. 'String' and 'Cmd msg' in 'foo : String -> Cmd msg'
      */
-    TYPE_ANNOTATION_SIGNATURE_TYPES("Type Annotation//Signature", DefaultLanguageHighlighterColors.CLASS_REFERENCE);
+    TYPE_ANNOTATION_SIGNATURE_TYPES("Type Annotation//Signature", Default.CLASS_REFERENCE),
+
+    RECORD_FIELD("Records//Field", Default.INSTANCE_FIELD),
+    RECORD_FIELD_ACCESSOR("Record//Field Accessor", Default.STATIC_FIELD);
 
 
     val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.elm.$name", default)

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -17,6 +17,10 @@ class ElmSyntaxHighlightAnnotator : Annotator {
             is ElmValueDeclaration -> highlightValueDeclaration(holder, element)
             is ElmTypeAnnotation -> highlightTypeAnnotation(holder, element)
             is ElmUpperCaseQID -> highlightUpperCaseQID(holder, element)
+            is ElmField -> highlightField(holder, element.lowerCaseIdentifier)
+            is ElmFieldType -> highlightField(holder, element.lowerCaseIdentifier)
+            is ElmFieldAccessExpr -> highlightField(holder, element.lowerCaseIdentifier)
+            is ElmFieldAccessorFunctionExpr -> highlightFieldAccessorFunction(holder, element)
         }
     }
 
@@ -26,8 +30,9 @@ class ElmSyntaxHighlightAnnotator : Annotator {
                 ElmTypeAnnotation::class.java,
                 ElmModuleDeclaration::class.java,
                 ElmImportClause::class.java) != null
-        if (!isModuleName)
+        if (!isModuleName) {
             highlightElement(holder, element, ElmColor.TYPE)
+        }
     }
 
     private fun highlightValueDeclaration(holder: AnnotationHolder, declaration: ElmValueDeclaration) {
@@ -53,6 +58,15 @@ class ElmSyntaxHighlightAnnotator : Annotator {
                 .forEach {
                     highlightElement(holder, it, ElmColor.TYPE_ANNOTATION_SIGNATURE_TYPES)
                 }
+    }
+
+    private fun highlightField(holder: AnnotationHolder, element: PsiElement?) {
+        if (element == null) return
+        highlightElement(holder, element, ElmColor.RECORD_FIELD)
+    }
+
+    private fun highlightFieldAccessorFunction(holder: AnnotationHolder, element: ElmFieldAccessorFunctionExpr) {
+        highlightElement(holder, element, ElmColor.RECORD_FIELD_ACCESSOR)
     }
 
     private fun highlightElement(holder: AnnotationHolder, element: PsiElement, color: ElmColor) {

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlighter.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlighter.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.highlight
 
+import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IElementType
@@ -16,7 +17,7 @@ class ElmSyntaxHighlighter : SyntaxHighlighterBase() {
     override fun getHighlightingLexer() =
             ElmIncrementalLexer()
 
-    override fun getTokenHighlights(tokenType: IElementType?) =
+    override fun getTokenHighlights(tokenType: IElementType?): Array<TextAttributesKey> =
             pack(map(tokenType)?.textAttributesKey)
 
     companion object {

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlighterFactory.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlighterFactory.kt
@@ -1,11 +1,11 @@
 package org.elm.ide.highlight
 
+import com.intellij.openapi.fileTypes.SingleLazyInstanceSyntaxHighlighterFactory
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
-class ElmSyntaxHighlighterFactory : SyntaxHighlighterFactory() {
-
-    override fun getSyntaxHighlighter(project: Project?, virtualFile: VirtualFile?) =
-            ElmSyntaxHighlighter()
+class ElmSyntaxHighlighterFactory : SingleLazyInstanceSyntaxHighlighterFactory() {
+    override fun createHighlighter(): SyntaxHighlighter = ElmSyntaxHighlighter()
 }

--- a/src/main/resources/colorSchemes/ElmDarcula.xml
+++ b/src/main/resources/colorSchemes/ElmDarcula.xml
@@ -6,7 +6,7 @@
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>
-    <option name="org.elm.TYPE">
+    <option name="org.elm.TYPE_CONSTRUCTOR">
         <value>
             <option name="FOREGROUND" value="#96c876"/>
         </value>

--- a/src/main/resources/colorSchemes/ElmDefault.xml
+++ b/src/main/resources/colorSchemes/ElmDefault.xml
@@ -18,7 +18,7 @@
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>
-    <option name="org.elm.TYPE">
+    <option name="org.elm.TYPE_CONSTRUCTOR">
         <value>
             <option name="FOREGROUND" value="#604578"/>
             <option name="FONT_TYPE" value="1"/>


### PR DESCRIPTION
- Use the same color for union variants everywhere
- Use the same color for type expressions everywhere
- Color record field access list instance fields
- Color field accessor functions like static fields

I chose not to color module names differently as suggested in #439, since other languages don't do that. That can always be added in another PR. Feel free to bikeshed.

### Before
![before_dark](https://user-images.githubusercontent.com/1109214/61834906-8daa7d00-ae2e-11e9-9baa-1429baf64fd5.PNG)

### After
![after_dark](https://user-images.githubusercontent.com/1109214/61834911-90a56d80-ae2e-11e9-88d5-e1a4e9f49dbf.PNG)
