### PR TITLE
Fix Pico injection exception on ElmTestRunConfigurationProducer

### DIFF
--- a/src/main/java/org/frawa/elmtest/run/ElmTestRunConfigurationProducer.java
+++ b/src/main/java/org/frawa/elmtest/run/ElmTestRunConfigurationProducer.java
@@ -2,7 +2,8 @@ package org.frawa.elmtest.run;
 
 import com.intellij.execution.Location;
 import com.intellij.execution.actions.ConfigurationContext;
-import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.execution.actions.LazyRunConfigurationProducer;
+import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.util.Ref;
 import com.intellij.psi.PsiElement;
@@ -13,14 +14,12 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.file.Path;
 import java.util.Optional;
 
-public class ElmTestRunConfigurationProducer extends RunConfigurationProducer<ElmTestRunConfiguration> {
+public class ElmTestRunConfigurationProducer extends LazyRunConfigurationProducer<ElmTestRunConfiguration> {
 
-    public ElmTestRunConfigurationProducer(@NotNull ElmTestConfigurationFactory configurationFactory) {
-        super(configurationFactory);
-    }
-
-    public ElmTestRunConfigurationProducer(@NotNull ElmTestRunConfigurationType configurationType) {
-        super(configurationType);
+    @NotNull
+    @Override
+    public ConfigurationFactory getConfigurationFactory() {
+        return new ElmTestConfigurationFactory(new ElmTestRunConfigurationType());
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -169,8 +169,11 @@
     ]]>
     </change-notes>
 
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="182.3684.2"/>
+    <!--
+    See http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
+    Note that the range is half-open: [since-build, until-build)
+     -->
+    <idea-version since-build="191.4212.41" until-build="193.*"/>
 
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
Fixes #444 

I raised the minimum IntelliJ version to 2019.1 because we have to subclass
`LazyRunConfigurationProducer`, which was introduced in 2019.1. Otherwise,
we would have to create multiple builds to support 2018, and I just
don't have the time to do that. Sorry.

I also have decided to introduce an upper-bound on the IntelliJ
compatibility version since their API is breaking more than I expected.