### PR TITLE
Some syntax highlighting improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         jvmTarget = javaTargetVersion
         languageVersion = "1.3"
         apiVersion = "1.3"
+        freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }
 }
 

--- a/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
@@ -28,8 +28,8 @@ class ElmColorSettingsPage : ColorSettingsPage {
     // special tags in [demoText] for semantic highlighting
             mapOf(
                     "sig_left" to ElmColor.TYPE_ANNOTATION_NAME,
-                    "type" to ElmColor.TYPE_ANNOTATION_SIGNATURE_TYPES,
-                    "variant" to ElmColor.TYPE_CONSTRUCTOR,
+                    "type" to ElmColor.TYPE_EXPR,
+                    "variant" to ElmColor.UNION_VARIANT,
                     "accessor" to ElmColor.RECORD_FIELD_ACCESSOR,
                     "field" to ElmColor.RECORD_FIELD,
                     "func_decl" to ElmColor.DEFINITION_NAME

--- a/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
@@ -27,7 +27,6 @@ class ElmColorSettingsPage : ColorSettingsPage {
     override fun getAdditionalHighlightingTagToDescriptorMap() =
     // special tags in [demoText] for semantic highlighting
             mapOf(
-                    "sig_left" to ElmColor.TYPE_ANNOTATION_NAME,
                     "type" to ElmColor.TYPE_EXPR,
                     "variant" to ElmColor.UNION_VARIANT,
                     "accessor" to ElmColor.RECORD_FIELD_ACCESSOR,
@@ -56,7 +55,7 @@ type Msg <type>a</type>
     = <variant>ModeA</variant>
     | <variant>ModeB</variant> <type>Maybe a</type>
 
-<sig_left>update</sig_left> : <type>Msg</type> -> <type>Model</type> -> ( <type>Model</type>, <type>Cmd Msg</type> )
+<func_decl>update</func_decl> : <type>Msg</type> -> <type>Model</type> -> ( <type>Model</type>, <type>Cmd Msg</type> )
 <func_decl>update</func_decl> msg model =
     case msg of
         <variant>ModeA</variant> ->
@@ -67,7 +66,7 @@ type Msg <type>a</type>
             }
                 ! []
 
-<sig_left>view</sig_left> : <type>Model</type> -> <type>Html.Html Msg</type>
+<func_decl>view</func_decl> : <type>Model</type> -> <type>Html.Html Msg</type>
 <func_decl>view</func_decl> model =
     let
         <func_decl>itemify</func_decl> label =

--- a/src/main/kotlin/org/elm/ide/color/ElmColors.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColors.kt
@@ -1,9 +1,9 @@
 package org.elm.ide.color
 
-import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
 import com.intellij.openapi.editor.HighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
 
 enum class ElmColor(humanName: String, default: TextAttributesKey) {
 
@@ -51,7 +51,7 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
     TYPE_EXPR("Type", Default.CLASS_REFERENCE),
 
     RECORD_FIELD("Records//Field", Default.INSTANCE_FIELD),
-    RECORD_FIELD_ACCESSOR("Record//Field Accessor", Default.STATIC_FIELD);
+    RECORD_FIELD_ACCESSOR("Records//Field Accessor", Default.STATIC_FIELD);
 
 
     val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.elm.$name", default)

--- a/src/main/kotlin/org/elm/ide/color/ElmColors.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColors.kt
@@ -32,24 +32,23 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
     DEFINITION_NAME("Definition Name", Default.FUNCTION_DECLARATION),
 
     /**
-     * The uppercase identifier for a type constructors and union variants
-     */
-    TYPE_CONSTRUCTOR("Type", Default.CLASS_NAME),
-
-    /**
-     * The lowercase identifier name in a type annotation.
+     * The lowercase identifier name on the left-hand side of a type annotation.
      *
      * e.g. 'foo' in 'foo : String -> Cmd msg'
      */
-    TYPE_ANNOTATION_NAME("Type Annotation//Name", Default.FUNCTION_DECLARATION),
+    TYPE_ANNOTATION_NAME("Type Annotation Name", Default.FUNCTION_DECLARATION),
 
     /**
-     * Both uppercase and lowercase identifiers appearing on the right-hand side
-     * of a top-level type annotation.
+     * The uppercase identifier for a union (custom type) variant
+     */
+    UNION_VARIANT("Custom Type Variant", Default.IDENTIFIER),
+
+    /**
+     * Type expressions
      *
      * e.g. 'String' and 'Cmd msg' in 'foo : String -> Cmd msg'
      */
-    TYPE_ANNOTATION_SIGNATURE_TYPES("Type Annotation//Signature", Default.CLASS_REFERENCE),
+    TYPE_EXPR("Type", Default.CLASS_REFERENCE),
 
     RECORD_FIELD("Records//Field", Default.INSTANCE_FIELD),
     RECORD_FIELD_ACCESSOR("Record//Field Accessor", Default.STATIC_FIELD);

--- a/src/main/kotlin/org/elm/ide/color/ElmColors.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColors.kt
@@ -32,13 +32,6 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
     DEFINITION_NAME("Definition Name", Default.FUNCTION_DECLARATION),
 
     /**
-     * The lowercase identifier name on the left-hand side of a type annotation.
-     *
-     * e.g. 'foo' in 'foo : String -> Cmd msg'
-     */
-    TYPE_ANNOTATION_NAME("Type Annotation Name", Default.FUNCTION_DECLARATION),
-
-    /**
      * The uppercase identifier for a union (custom type) variant
      */
     UNION_VARIANT("Custom Type Variant", Default.IDENTIFIER),

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -27,11 +27,11 @@ class ElmSyntaxHighlightAnnotator : Annotator {
     }
 
     private fun highlightTypeExpr(holder: AnnotationHolder, element: PsiElement) {
-        highlightElement(holder, element, ElmColor.TYPE_ANNOTATION_SIGNATURE_TYPES)
+        highlightElement(holder, element, ElmColor.TYPE_EXPR)
     }
 
     private fun highlightTypeConstructor(holder: AnnotationHolder, element: PsiElement) {
-        highlightElement(holder, element, ElmColor.TYPE_CONSTRUCTOR)
+        highlightElement(holder, element, ElmColor.UNION_VARIANT)
     }
 
     private fun highlightUpperCaseQID(holder: AnnotationHolder, element: ElmUpperCaseQID) {
@@ -47,7 +47,7 @@ class ElmSyntaxHighlightAnnotator : Annotator {
                 ElmImportClause::class.java,
                 ElmModuleDeclaration::class.java) != null
         if (!isModuleName) {
-            highlightElement(holder, element, ElmColor.TYPE_CONSTRUCTOR)
+            highlightElement(holder, element, ElmColor.UNION_VARIANT)
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -65,7 +65,7 @@ class ElmSyntaxHighlightAnnotator : Annotator {
 
     private fun highlightTypeAnnotation(holder: AnnotationHolder, typeAnnotation: ElmTypeAnnotation) {
         typeAnnotation.lowerCaseIdentifier?.let {
-            highlightElement(holder, it, ElmColor.TYPE_ANNOTATION_NAME)
+            highlightElement(holder, it, ElmColor.DEFINITION_NAME)
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -79,8 +79,7 @@ class ElmSyntaxHighlightAnnotator : Annotator {
     }
 
     private fun highlightElement(holder: AnnotationHolder, element: PsiElement, color: ElmColor) {
-        val msg = "Highlighting %-60s \"%-20s\" with %s".format(element, element.text, color)
-        println(msg)
+        //println("Highlighting %-60s \"%-20s\" with %s".format(element, element.text, color))
         holder.createInfoAnnotation(element, null).textAttributes = color.textAttributesKey
     }
 }

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -36,7 +36,7 @@ class ElmSyntaxHighlightAnnotator : Annotator {
 
     private fun highlightUpperCaseQID(holder: AnnotationHolder, element: ElmUpperCaseQID) {
         val isTypeExpr = PsiTreeUtil.getParentOfType(element,
-                ElmTypeAnnotation::class.java,
+                ElmTypeExpression::class.java,
                 ElmUnionVariant::class.java)
         if (isTypeExpr != null) {
             highlightTypeExpr(holder, element)
@@ -79,6 +79,8 @@ class ElmSyntaxHighlightAnnotator : Annotator {
     }
 
     private fun highlightElement(holder: AnnotationHolder, element: PsiElement, color: ElmColor) {
+        val msg = "Highlighting %-60s \"%-20s\" with %s".format(element, element.text, color)
+        println(msg)
         holder.createInfoAnnotation(element, null).textAttributes = color.textAttributesKey
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElementTags.kt
@@ -25,7 +25,7 @@ interface ElmOperandTag : ElmPsiElement, ElmBinOpPartTag
 interface ElmBinOpPartTag : ElmPsiElement
 
 /** An element that can be the parameter of an [ElmFunctionDeclarationLeft], [ElmAnonymousFunctionExpr], or [ElmCaseOfBranch] */
-interface ElmNameDeclarationPatternTag : ElmNamedElement
+interface ElmNameDeclarationPatternTag : ElmNameIdentifierOwner
 
 /** A function being called as the child of a [ElmFunctionCallExpr] */
 interface ElmFunctionCallTargetTag : ElmAtomTag

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
@@ -1,7 +1,6 @@
 package org.elm.lang.core.psi
 
 import com.intellij.psi.PsiElement
-import org.elm.lang.core.psi.elements.ElmUpperCaseQID
 
 /**
  * Marker interface for Qualified ID elements (QIDs)
@@ -13,14 +12,15 @@ import org.elm.lang.core.psi.elements.ElmUpperCaseQID
 interface ElmQID : ElmPsiElement {
     val upperCaseIdentifierList: List<PsiElement>
 
+    /**
+     * The upper-case identifiers (if any) that qualify this identifier.
+     *
+     * e.g. `Json` and `Decode` in the expression `Json.Decode.maybe`
+     */
+    val qualifiers: List<PsiElement>
+
     val qualifierPrefix: String
-        get() {
-            val frontParts = if (this is ElmUpperCaseQID)
-                upperCaseIdentifierList.dropLast(1)
-            else
-                upperCaseIdentifierList
-            return frontParts.joinToString(".") { it.text }
-        }
+        get() = qualifiers.joinToString(".") { it.text }
 
     /** Returns true if the qualified ID refers to Elm's "Kernel" modules,
      * which are defined in Javascript. This is useful since we don't (currently)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
@@ -4,12 +4,8 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
-import org.elm.lang.core.psi.ElmExposableTag
-import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.ElmStubbedNamedElementImpl
+import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.OPERATOR_IDENTIFIER
-import org.elm.lang.core.psi.ElmValueAssigneeTag
-import org.elm.lang.core.psi.IdentifierCase
 import org.elm.lang.core.stubs.ElmOperatorDeclarationLeftStub
 
 // TODO [drop 0.18] delete this entire file
@@ -37,9 +33,9 @@ class ElmOperatorDeclarationLeft : ElmStubbedNamedElementImpl<ElmOperatorDeclara
         get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmPattern::class.java)
 
 
-    val namedParameters: List<ElmNamedElement>
+    val namedParameters: List<ElmNameIdentifierOwner>
         get() {
-            val results = mutableListOf<ElmNamedElement>()
+            val results = mutableListOf<ElmNameIdentifierOwner>()
             results.addAll(PsiTreeUtil.collectElementsOfType(this, ElmLowerPattern::class.java))
             return results
         }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
@@ -21,6 +21,9 @@ class ElmUpperCaseQID(node: ASTNode) : ElmPsiElementImpl(node), ElmQID, ElmUnion
     override val upperCaseIdentifierList: List<PsiElement>
         get() = findChildrenByType(UPPER_CASE_IDENTIFIER)
 
+    override val qualifiers: List<PsiElement>
+        get() = upperCaseIdentifierList.dropLast(1)
+
     /**
      * True if the identifier is qualified by a module name (in the case of union or
      * record constructors) or the module exists in a hierarchy (in the case of a pure

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -71,8 +71,8 @@ class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub>, ElmDocTa
      * @param includeParameters include names declared as parameters to the function
      *                          (also includes destructured names). The default is `true`
      */
-    fun declaredNames(includeParameters: Boolean = true): List<ElmNamedElement> {
-        val namedElements = mutableListOf<ElmNamedElement>()
+    fun declaredNames(includeParameters: Boolean = true): List<ElmNameIdentifierOwner> {
+        val namedElements = mutableListOf<ElmNameIdentifierOwner>()
 
         if (functionDeclarationLeft != null) {
             // the most common case, a named function or value declaration
@@ -88,7 +88,7 @@ class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub>, ElmDocTa
 
         } else if (pattern != null) {
             // value destructuring assignment (e.g. `(x,y) = (0,0)` in a let/in declaration)
-            namedElements.addAll(pattern!!.descendantsOfType<ElmNamedElement>())
+            namedElements.addAll(pattern!!.descendantsOfType<ElmNameIdentifierOwner>())
         }
 
         return namedElements

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueQID.kt
@@ -22,6 +22,9 @@ class ElmValueQID(node: ASTNode) : ElmPsiElementImpl(node), ElmQID {
     override val upperCaseIdentifierList: List<PsiElement>
         get() = findChildrenByType(UPPER_CASE_IDENTIFIER)
 
+    override val qualifiers: List<PsiElement>
+        get() = upperCaseIdentifierList
+
     /**
      * The value identifier
      */

--- a/src/main/resources/colorSchemes/ElmDarcula.xml
+++ b/src/main/resources/colorSchemes/ElmDarcula.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list>
-    <option name="org.elm.TYPE_ANNOTATION_SIGNATURE_TYPES">
+    <option name="org.elm.TYPE_EXPR">
         <value>
             <option name="FOREGROUND" value="#68B3C1"/>
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>
-    <option name="org.elm.TYPE_CONSTRUCTOR">
+    <option name="org.elm.UNION_VARIANT">
         <value>
             <option name="FOREGROUND" value="#96c876"/>
         </value>

--- a/src/main/resources/colorSchemes/ElmDefault.xml
+++ b/src/main/resources/colorSchemes/ElmDefault.xml
@@ -12,13 +12,13 @@
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>
-    <option name="org.elm.TYPE_ANNOTATION_SIGNATURE_TYPES">
+    <option name="org.elm.TYPE_EXPR">
         <value>
             <option name="FOREGROUND" value="#127b7e"/>
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>
-    <option name="org.elm.TYPE_CONSTRUCTOR">
+    <option name="org.elm.UNION_VARIANT">
         <value>
             <option name="FOREGROUND" value="#604578"/>
             <option name="FONT_TYPE" value="1"/>

--- a/src/main/resources/colorSchemes/ElmDefault.xml
+++ b/src/main/resources/colorSchemes/ElmDefault.xml
@@ -6,12 +6,6 @@
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>
-    <option name="org.elm.TYPE_ANNOTATION_NAME">
-        <value>
-            <option name="FOREGROUND" value="#333333"/>
-            <option name="FONT_TYPE" value="1"/>
-        </value>
-    </option>
     <option name="org.elm.TYPE_EXPR">
         <value>
             <option name="FOREGROUND" value="#127b7e"/>

--- a/src/main/resources/colorSchemes/ElmDefault.xml
+++ b/src/main/resources/colorSchemes/ElmDefault.xml
@@ -20,7 +20,7 @@
     </option>
     <option name="org.elm.UNION_VARIANT">
         <value>
-            <option name="FOREGROUND" value="#604578"/>
+            <option name="FOREGROUND" value="#004e64"/>
             <option name="FONT_TYPE" value="1"/>
         </value>
     </option>


### PR DESCRIPTION
- fixed a bug on record field types (they were getting the union variant color)
- cleaned up the names of things
- improved the union variant color in the Default/Light scheme
- simplified the user-facing choices

I also laid the groundwork for highlighting module qualifiers in SHA e692b91, but I had a hard time finding a color that worked well in all the contexts. So I punted. The problem is that the module qualifier color needs to work adjacent to 3 different things, each with their own color
- value identifier
- type expression
- union variant 

I'm sure that a good solution can be achieved, but it's just going to take more time. FWIW, here's the color scheme tool I was using in case anyone wants to take a stab at it: https://coolors.co/660e7a-127b7e-004e64-ffffff-000080