### PR TITLE
Add recursion line marker

### DIFF
--- a/src/main/kotlin/org/elm/ide/icons/ElmIcons.kt
+++ b/src/main/kotlin/org/elm/ide/icons/ElmIcons.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.icons
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.IconLoader
 import javax.swing.Icon
 
@@ -29,6 +30,7 @@ object ElmIcons {
      */
     val EXPOSED_GUTTER = getIcon("elm-exposure.png")
 
+    val RECURSIVE_CALL = AllIcons.Gutter.RecursiveMethod!!
 
     // STRUCTURE VIEW ICONS
 

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProvider.kt
@@ -1,0 +1,60 @@
+package org.elm.ide.lineMarkers
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.util.FunctionUtil
+import org.elm.ide.icons.ElmIcons
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
+import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
+import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.resolve.ElmReferenceElement
+
+/**
+ * Put an icon in the gutter for top-level declarations (types, functions, values)
+ * that are exposed by the containing module.
+ */
+class ElmRecursiveCallLineMarkerProvider : LineMarkerProvider {
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
+
+    override fun collectSlowLineMarkers(
+            elements: List<PsiElement>,
+            result: MutableCollection<LineMarkerInfo<PsiElement>>
+    ) {
+        // we use the slow pass since we need to resolve references
+
+        val lines = mutableSetOf<Int>() // Only one marker per line
+
+        for (el in elements) {
+            if (el.elementType != LOWER_CASE_IDENTIFIER) continue
+            val qid = el.parent as? ElmValueQID ?: continue
+            if (qid.qualifiers.isNotEmpty()) continue
+            val valueExpr = qid.parent as? ElmValueExpr ?: continue
+            val functionCall = valueExpr.parent as? ElmFunctionCallExpr ?: continue
+            if (functionCall.target != valueExpr) continue
+
+            val ref = valueExpr.reference.resolve()
+            val nearestFunc = functionCall.ancestorsStrict.filterIsInstance<ElmValueDeclaration>()
+                    .firstOrNull()?.functionDeclarationLeft
+            if (nearestFunc != ref) continue // not recursive
+
+            val doc = PsiDocumentManager.getInstance(el.project).getDocument(el.containingFile) ?: continue
+            val lineNumber = doc.getLineNumber(el.textOffset)
+            if (lines.add(lineNumber)) {
+                result.add(LineMarkerInfo(
+                        el,
+                        el.textRange,
+                        ElmIcons.RECURSIVE_CALL,
+                        FunctionUtil.constant("Recursive call"),
+                        null,
+                        GutterIconRenderer.Alignment.RIGHT)
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
@@ -16,7 +16,7 @@ class LexicalValueReference(element: ElmReferenceElement)
     override fun resolveInner(): ElmNamedElement? =
             getCandidates().find { it.name == element.referenceName }
 
-    private fun getCandidates(): Array<ElmNamedElement> {
-        return ExpressionScope(element).getVisibleValues().toTypedArray()
+    private fun getCandidates(): List<ElmNamedElement> {
+        return ExpressionScope(element).getVisibleValues()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedConstructorReference.kt
@@ -20,11 +20,10 @@ class QualifiedConstructorReference(referenceElement: ElmReferenceElement, val u
     override val qualifierPrefix = upperCaseQID.qualifierPrefix
     override val nameWithoutQualifier = element.referenceName
 
-    private fun getCandidates(): Array<ElmNamedElement> {
+    private fun getCandidates(): List<ElmNamedElement> {
         // TODO [kl] depending on context, we may need to restrict the variants to just union constructors
         return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
                 .flatMap { it.getExposedConstructors() }
-                .toTypedArray()
     }
 
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedValueReference.kt
@@ -21,9 +21,8 @@ class QualifiedValueReference(element: ElmReferenceElement, val valueQID: ElmVal
     override val qualifierPrefix = valueQID.qualifierPrefix
     override val nameWithoutQualifier = element.referenceName
 
-    private fun getCandidates(): Array<ElmNamedElement> {
+    private fun getCandidates(): List<ElmNamedElement> {
         return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
                 .flatMap { it.getExposedValues() }
-                .toTypedArray()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
@@ -16,7 +16,7 @@ class SimpleTypeReference(element: ElmReferenceElement)
     override fun resolveInner(): ElmNamedElement? =
             getCandidates().find { it.name == element.referenceName }
 
-    private fun getCandidates(): Array<ElmNamedElement> {
-        return ModuleScope.getVisibleTypes(element.elmFile).all.toTypedArray()
+    private fun getCandidates(): List<ElmNamedElement> {
+        return ModuleScope.getVisibleTypes(element.elmFile).all
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
@@ -17,9 +17,7 @@ class SimpleUnionConstructorReference(element: ElmReferenceElement)
     override fun resolveInner(): ElmNamedElement? =
             getCandidates().find { it.name == element.referenceName }
 
-    private fun getCandidates(): Array<ElmNamedElement> =
+    private fun getCandidates(): List<ElmNamedElement> =
             ModuleScope.getVisibleConstructors(element.elmFile).all
-                    .filter { it is ElmUnionVariant }
-                    .toTypedArray()
-
+                    .filterIsInstance<ElmUnionVariant>()
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
@@ -14,8 +14,7 @@ class SimpleUnionOrRecordConstructorReference(element: ElmReferenceElement)
     override fun resolveInner(): ElmNamedElement? =
             getCandidates().find { it.name == element.referenceName }
 
-    private fun getCandidates(): Array<ElmNamedElement> {
-        return ModuleScope.getVisibleConstructors(element.elmFile).all.toTypedArray()
+    private fun getCandidates(): List<ElmNamedElement> {
+        return ModuleScope.getVisibleConstructors(element.elmFile).all
     }
-
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -225,6 +225,8 @@
         <codeInsight.typeInfo language="Elm" implementationClass="org.elm.ide.hints.ElmExpressionTypeProvider"/>
         <codeInsight.lineMarkerProvider language="Elm"
                                         implementationClass="org.elm.ide.lineMarkers.ElmExposureLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="Elm"
+                                        implementationClass="org.elm.ide.lineMarkers.ElmRecursiveCallLineMarkerProvider"/>
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
         <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.refactoring.ElmImportOptimizer"/>

--- a/src/test/kotlin/org/elm/ide/lineMarkers/ElmLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/lineMarkers/ElmLineMarkerProviderTestBase.kt
@@ -22,7 +22,7 @@ abstract class ElmLineMarkerProviderTestBase : ElmTestBase() {
         myFixture.doHighlighting()
         val expected = markersFrom(source)
         val actual = markersFrom(myFixture.editor, myFixture.project)
-        LightPlatformCodeInsightFixtureTestCase.assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
     }
 
     private fun markersFrom(text: String) =
@@ -40,7 +40,7 @@ abstract class ElmLineMarkerProviderTestBase : ElmTestBase() {
                     .sortedBy { it.first }
 
     private companion object {
-        val MARKER = "--> "
-        val COMPARE_SEPARATOR = " | "
+        const val MARKER = "--> "
+        const val COMPARE_SEPARATOR = " | "
     }
 }

--- a/src/test/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProviderTest.kt
@@ -1,6 +1,12 @@
 package org.elm.ide.lineMarkers
 
 class ElmRecursiveCallLineMarkerProviderTest : ElmLineMarkerProviderTestBase() {
+    fun `test non-recursive functions`() = doTestByText(
+            """
+f a = a
+g = f
+h = [h]
+""")
     fun `test top level functions`() = doTestByText(
             """
 f a = f (a - 1) --> Recursive call

--- a/src/test/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProviderTest.kt
@@ -1,0 +1,22 @@
+package org.elm.ide.lineMarkers
+
+class ElmRecursiveCallLineMarkerProviderTest : ElmLineMarkerProviderTestBase() {
+    fun `test top level functions`() = doTestByText(
+            """
+f a = f (a - 1) --> Recursive call
+g a =
+  g (a + 1) --> Recursive call
+h a = h ( h (a + 1) ) --> Recursive call
+""")
+
+    fun `test nested functions`() = doTestByText(
+            """
+top t =
+  let
+    f a = f (a - 1) --> Recursive call
+    g a =
+      g (a + 1) --> Recursive call
+  in
+    top t --> Recursive call
+""")
+}


### PR DESCRIPTION
This adds the standard gutter icons for recursive function calls.
![Capture](https://user-images.githubusercontent.com/1109214/62161544-53782a00-b2cb-11e9-972d-dc74b461e41b.PNG)

The first commit in this PR is a minor unrelated optimization, and can be removed or moved to a separate PR if you like.