### PR TITLE
Properly qualify names in generated annotations

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -61,7 +61,7 @@ private fun documentationFor(decl: ElmFunctionDeclarationLeft): String? = buildS
         if (ty != null && ty !is TyUnknown) {
             b { append(id) }
             append(" : ")
-            append(ty.renderedText(true, false))
+            append(ty.renderedText(linkify = true, withModule = false))
             append("\n")
         }
 
@@ -85,7 +85,7 @@ private fun documentationFor(decl: ElmTypeDeclaration): String? = buildString {
         b { append("type") }
         append(" ", ty.name)
         for (param in ty.parameters) {
-            append(" ", param.renderedText(true, false))
+            append(" ", param.renderedText(linkify = true, withModule = false))
         }
         renderDefinitionLocation(decl)
     }
@@ -114,7 +114,7 @@ private fun documentationFor(decl: ElmTypeAliasDeclaration): String? = buildStri
         b { append("type alias") }
         append(" ").append(alias.name)
         for (type in alias.parameters) {
-            append(" ", ty.renderedText(true, false))
+            append(" ", ty.renderedText(linkify = true, withModule = false))
         }
         renderDefinitionLocation(decl)
     }
@@ -126,7 +126,7 @@ private fun documentationFor(decl: ElmTypeAliasDeclaration): String? = buildStri
             section("Fields") {
                 for ((fieldName, fieldTy) in ty.fields) {
                     append("\n<p><code>$fieldName</code> : ")
-                    append(fieldTy.renderedText(true, false))
+                    append(fieldTy.renderedText(linkify = true, withModule = false))
                 }
             }
         }
@@ -143,7 +143,7 @@ private fun documentationForParameter(element: ElmNamedElement): String? = build
         append(" ", element.name, " ")
 
         if (ty != null && ty !is TyUnknown) {
-            append(": ", ty.renderedText(true, false), "\n")
+            append(": ", ty.renderedText(linkify = true, withModule = false), "\n")
         }
 
         i { append("of function ") }
@@ -210,7 +210,7 @@ private fun documentationFor(element: ElmInfixDeclaration): String? {
 private fun StringBuilder.renderVariantParameters(parameters: List<Ty>) {
     if (parameters.isNotEmpty()) {
         parameters.joinTo(this, " ", prefix = " ") {
-            val renderedText = it.renderedText(true, false)
+            val renderedText = it.renderedText(linkify = true, withModule = false)
             if (it is TyUnion && it.parameters.isNotEmpty()) "($renderedText)" else renderedText
         }
     }

--- a/src/main/kotlin/org/elm/ide/hints/ElmExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/elm/ide/hints/ElmExpressionTypeProvider.kt
@@ -19,7 +19,7 @@ class ElmExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
 
     override fun getInformationHint(element: PsiElement): String {
         val ty = (element as? ElmPsiElement)?.findTy() ?: return errorHint
-        return StringUtil.escapeXmlEntities(ty.renderedText(false, false))
+        return StringUtil.escapeXmlEntities(ty.renderedText())
     }
 
     override fun getExpressionsAt(elementAt: PsiElement): List<PsiElement> {

--- a/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
+++ b/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
@@ -114,8 +114,8 @@ class ElmParameterInfoHandler : ParameterInfoHandler<PsiElement, ElmParametersDe
 class ElmParametersDescription(private val name: String?, private val ty: Ty) {
     val presentText: String
         get() =
-            if (name == null) ty.renderedText(false, false)
-            else "$name : ${ty.renderedText(false, false)}"
+            if (name == null) ty.renderedText()
+            else "$name : ${ty.renderedText()}"
 
     val rangeToHighlight: TextRange
         get() = TextRange(0, name?.length ?: 0)

--- a/src/main/kotlin/org/elm/ide/intentions/MakeAnnotationIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MakeAnnotationIntention.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
 import org.elm.lang.core.psi.elements.ElmValueDeclaration
-import org.elm.lang.core.psi.endOffset
 import org.elm.lang.core.psi.parentOfType
 import org.elm.lang.core.psi.startOffset
 import org.elm.lang.core.types.Ty
@@ -41,7 +40,7 @@ class MakeAnnotationIntention : ElmAtCaretIntentionActionBase<MakeAnnotationInte
     override fun invoke(project: Project, editor: Editor, context: Context) {
         val (fdl, valueDeclaration, ty) = context
         val indent = editor.getIndent(valueDeclaration.startOffset)
-        val code = "${fdl.name} : ${ty.renderedText(false, false).replace("→", "->")}\n$indent"
+        val code = "${fdl.name} : ${ty.renderedText(elmFile = fdl.elmFile).replace("→", "->")}\n$indent"
         project.runWriteCommandAction {
             editor.document.insertString(valueDeclaration.startOffset, code)
         }

--- a/src/main/kotlin/org/elm/ide/intentions/MakeDecoderIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MakeDecoderIntention.kt
@@ -44,7 +44,7 @@ private class DecoderGenerator(
             for (f in funcsByTy.values) {
                 append("\n\n\n")
                 append("-- TODO: double-check generated code\n")
-                append("${f.name} : ${qual("Decoder")} ${f.qualifier}${f.paramTy.renderedText(false, false)}\n")
+                append("${f.name} : ${qual("Decoder")} ${f.qualifier}${f.paramTy.renderedText()}\n")
                 append("${f.name} =\n")
                 append(f.body)
             }
@@ -71,7 +71,7 @@ private class DecoderGenerator(
         is TyTuple -> generateTuple(ty)
         is TyUnit -> "(${qual("succeed")} ())"
         is TyFunction, TyInProgressBinding, is MutableTyRecord, is TyUnknown -> {
-            "(Debug.todo \"Can't generate decoder for type ${ty.renderedText(false, false)}\")"
+            "(Debug.todo \"Can't generate decoder for type ${ty.renderedText()}\")"
         }
     }
 
@@ -138,7 +138,7 @@ private class DecoderGenerator(
                 |                $branches
                 |
                 |                _ ->
-                |                    ${qual("fail")} ("unknown value for ${ty.renderedText(false, false)}: " ++ id)
+                |                    ${qual("fail")} ("unknown value for ${ty.renderedText()}: " ++ id)
                 |    in
                 |    ${qual("string")} |> ${qual("andThen")} get
                 """.trimMargin()

--- a/src/main/kotlin/org/elm/ide/intentions/MakeEncoderIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MakeEncoderIntention.kt
@@ -44,7 +44,7 @@ private class EncoderGenerator(
             for (f in funcsByTy.values) {
                 append("\n\n\n")
                 append("-- TODO: double-check generated code\n")
-                append("${f.name} : ${f.qualifier}${f.paramTy.renderedText(false, false)} -> ${qual("Value")}\n")
+                append("${f.name} : ${f.qualifier}${f.paramTy.renderedText()} -> ${qual("Value")}\n")
                 append("${f.name} ${f.paramName} =\n")
                 append(f.body)
             }
@@ -59,7 +59,7 @@ private class EncoderGenerator(
         is TyTuple -> generateTuple(ty)
         is TyUnit -> "(\\_ -> ${qual("null")})"
         is TyFunction, TyInProgressBinding, is MutableTyRecord, is TyUnknown -> {
-            "(\\_ -> Debug.todo \"Can't generate encoder for type ${ty.renderedText(false, false)}\")"
+            "(\\_ -> Debug.todo \"Can't generate encoder for type ${ty.renderedText()}\")"
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordFieldSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordFieldSuggestor.kt
@@ -53,5 +53,5 @@ object ElmRecordFieldSuggestor : Suggestor {
 
 private fun CompletionResultSet.add(str: String, field: Ty) {
     addElement(LookupElementBuilder.create(str)
-            .withTypeText(field.renderedText(false, false)))
+            .withTypeText(field.renderedText()))
 }

--- a/src/main/kotlin/org/elm/lang/core/diagnostics/ElmDiagnostic.kt
+++ b/src/main/kotlin/org/elm/lang/core/diagnostics/ElmDiagnostic.kt
@@ -80,7 +80,7 @@ class RecordBaseIdError(
 ) : ElmDiagnostic(element) {
     override val message: String
         get() {
-            val expectedRendered = actual.renderedText(false, false)
+            val expectedRendered = actual.renderedText()
             return "Type must be a record.<br>Found: $expectedRendered"
         }
 }
@@ -91,7 +91,7 @@ class FieldAccessOnNonRecordError(
 ) : ElmDiagnostic(element) {
     override val message: String
         get() {
-            val expectedRendered = actual.renderedText(false, false)
+            val expectedRendered = actual.renderedText()
             return "Value is not a record, cannot access fields.<br>Type: $expectedRendered"
         }
 }
@@ -116,12 +116,12 @@ class TypeMismatchError(
 ) : ElmDiagnostic(element, endElement) {
     override val message: String
         get() {
-            var expectedRendered = expected.renderedText(false, false)
-            var foundRendered = actual.renderedText(false, false)
+            var expectedRendered = expected.renderedText()
+            var foundRendered = actual.renderedText()
 
             if (expectedRendered == foundRendered || tysAreAmbiguousUnions(actual, expected)) {
-                expectedRendered = expected.renderedText(false, true)
-                foundRendered = actual.renderedText(false, true)
+                expectedRendered = expected.renderedText(linkify = false, withModule = true)
+                foundRendered = actual.renderedText(linkify = false, withModule = true)
             }
             val message = if (patternBinding) {
                 "Invalid pattern." +
@@ -144,20 +144,20 @@ class TypeMismatchError(
     private fun renderRecordDiff(recordDiff: RecordDiff) = buildString {
         if (recordDiff.extra.isNotEmpty()) {
             append("<br>Extra fields: ")
-            append(TyRecord(fields = recordDiff.extra).renderedText(false, false))
+            append(TyRecord(fields = recordDiff.extra).renderedText())
         }
         if (recordDiff.missing.isNotEmpty()) {
             append("<br>Missing fields: ")
-            append(TyRecord(fields = recordDiff.missing).renderedText(false, false))
+            append(TyRecord(fields = recordDiff.missing).renderedText())
         }
         if (recordDiff.mismatched.isNotEmpty()) {
             append("<br>Mismatched fields: ")
             for ((k, v) in recordDiff.mismatched) {
                 append("<br>&nbsp;&nbsp;Field ").append(k).append(":")
                 append("<br>&nbsp;&nbsp;&nbsp;&nbsp;Required: ")
-                append(v.second.renderedText(false, false))
+                append(v.second.renderedText())
                 append("<br>&nbsp;&nbsp;&nbsp;&nbsp;Found: ")
-                append(v.first.renderedText(false, false))
+                append(v.first.renderedText())
             }
         }
     }

--- a/src/test/kotlin/org/elm/ide/intentions/MakeAnnotationIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MakeAnnotationIntentionTest.kt
@@ -182,4 +182,19 @@ f =
     in
         function
 """)
+
+    fun `test qualified name`() = doAvailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo as F
+main{-caret-} i = F.foo i
+--@ Foo.elm
+module Foo exposing (..)
+type alias Bar = { i : Int }
+foo i = Bar i
+""", """
+import Foo as F
+main : Int -> F.Bar
+main i = F.foo i
+""")
 }


### PR DESCRIPTION
Previously, rendered types were never qualified in the annotation, which was incorrect in some cases.