### PR TITLE
Remove inline class usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         jvmTarget = javaTargetVersion
         languageVersion = "1.3"
         apiVersion = "1.3"
-        freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }
 }
 

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -12,14 +12,10 @@ import org.elm.lang.core.psi.elements.*
 class ElmSyntaxHighlightAnnotator : Annotator {
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        Highlighter(holder).highlight(element)
+        holder.highlight(element)
     }
-}
 
-
-private inline class Highlighter(private val holder: AnnotationHolder) {
-
-    fun highlight(element: PsiElement) {
+    private fun AnnotationHolder.highlight(element: PsiElement) {
         when (element) {
             is ElmValueDeclaration -> valueDeclaration(element)
             is ElmTypeAnnotation -> typeAnnotation(element)
@@ -34,15 +30,15 @@ private inline class Highlighter(private val holder: AnnotationHolder) {
         }
     }
 
-    private fun typeExpr(element: PsiElement) {
+    private fun AnnotationHolder.typeExpr(element: PsiElement) {
         applyColor(element, ElmColor.TYPE_EXPR)
     }
 
-    private fun unionVariant(element: PsiElement) {
+    private fun AnnotationHolder.unionVariant(element: PsiElement) {
         applyColor(element, ElmColor.UNION_VARIANT)
     }
 
-    private fun upperCaseQID(element: ElmUpperCaseQID) {
+    private fun AnnotationHolder.upperCaseQID(element: ElmUpperCaseQID) {
         val isTypeExpr = PsiTreeUtil.getParentOfType(element,
                 ElmTypeExpression::class.java,
                 ElmUnionVariant::class.java)
@@ -59,28 +55,28 @@ private inline class Highlighter(private val holder: AnnotationHolder) {
         }
     }
 
-    private fun valueDeclaration(declaration: ElmValueDeclaration) {
+    private fun AnnotationHolder.valueDeclaration(declaration: ElmValueDeclaration) {
         declaration.declaredNames(includeParameters = false).forEach {
             applyColor(it.nameIdentifier, ElmColor.DEFINITION_NAME)
         }
     }
 
-    private fun typeAnnotation(typeAnnotation: ElmTypeAnnotation) {
+    private fun AnnotationHolder.typeAnnotation(typeAnnotation: ElmTypeAnnotation) {
         typeAnnotation.lowerCaseIdentifier?.let {
             applyColor(it, ElmColor.DEFINITION_NAME)
         }
     }
 
-    private fun field(element: PsiElement?) {
+    private fun AnnotationHolder.field(element: PsiElement?) {
         if (element == null) return
         applyColor(element, ElmColor.RECORD_FIELD)
     }
 
-    private fun fieldAccessorFunction(element: ElmFieldAccessorFunctionExpr) {
+    private fun AnnotationHolder.fieldAccessorFunction(element: ElmFieldAccessorFunctionExpr) {
         applyColor(element, ElmColor.RECORD_FIELD_ACCESSOR)
     }
 
-    private fun applyColor(element: PsiElement, color: ElmColor) {
-        holder.createInfoAnnotation(element, null).textAttributes = color.textAttributesKey
+    private fun AnnotationHolder.applyColor(element: PsiElement, color: ElmColor) {
+        createInfoAnnotation(element, null).textAttributes = color.textAttributesKey
     }
 }


### PR DESCRIPTION
As of kotlin 1.3.41, using inline classes causes a compiler warning about using them in production code due to api instability. This message pops up over your build or debug window every time you run a test in IntelliJ, which is pretty annoying during development.

This PR swaps out the inline class for extension methods, which are still terse, but don't use unstable language features. Feel free to close this PR if you'd prefer to keep the current implementation.