### PR TITLE
Unify types for case branches individually.

### DIFF
--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionPartialProgramTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionPartialProgramTest.kt
@@ -80,7 +80,7 @@ main : ()
 main =
     case<error descr="<expression> expected, got 'of'"> </error> of
         1 -> <error descr="Type mismatch.Required: ()Found: String">""</error>
-        _ -> <error descr="Type mismatch.Required: StringFound: number">1</error>
+        _ -> <error descr="Type mismatch.Required: ()Found: number">1</error>
 """)
 
     fun `test case branch with pattern error`() = checkByText("""

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
@@ -391,7 +391,7 @@ main : Maybe a
 main = Nothing
 """)
 
-    fun `test mismatched value type from union case`() = checkByText("""
+    fun `test mismatched value type from union variant`() = checkByText("""
 type Foo = Bar
 main : Maybe a
 main = <error descr="Type mismatch.Required: Maybe aFound: Foo">Bar</error>

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -326,6 +326,15 @@ main =
         _ -> ()
 """)
 
+    fun `test case branches with multiple mismatched types`() = checkByText("""
+main : ()
+main =
+    case () of
+        "" -> <error descr="Type mismatch.Required: ()Found: String">""</error>
+        "x" -> <error descr="Type mismatch.Required: ()Found: String">""</error>
+        _ -> ()
+""")
+
     fun `test case branches with mismatched types from pattern`() = checkByText("""
 main =
     case Just 42 of

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -455,7 +455,8 @@ main : Qux -> ()
 main arg =
     case arg of
         <error descr="Type mismatch.Required: Foo aFound: Qux">Bar (Just {x})</error> -> x
-        Baz x -> x
+        <error descr="Type mismatch.Required: Foo aFound: Qux">Baz x</error> -> x
+        Qux -> ()
         _ -> ()
 """)
 


### PR DESCRIPTION
As discussed in [460][issue], type errors for individual case branches were confusing in some cases. This commit delays unifying individual branches until all branches in a case are complete, so we can unify each branch with the case expression type rather than just the first branch.

Fixes #460

[issue]: https://github.com/klazuka/intellij-elm/issues/460#issuecomment-519163351