### PR TITLE
Add quick fix to rename unused patterns to _

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -54,10 +54,18 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
 
 
     private fun markAsUnused(holder: ProblemsHolder, element: ElmNameIdentifierOwner, name: String) {
+        val fixes = if (element is ElmLowerPattern) {
+            arrayOf(quickFix("Rename to _") { project, _ ->
+                element.replace(ElmPsiFactory(project).createAnythingPattern())
+            })
+        } else {
+            emptyArray()
+        }
         holder.registerProblem(
                 element.nameIdentifier,
                 "'$name' is never used",
-                ProblemHighlightType.LIKE_UNUSED_SYMBOL
+                ProblemHighlightType.LIKE_UNUSED_SYMBOL,
+                *fixes
         )
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -105,22 +105,23 @@ class ElmPsiFactory(private val project: Project) {
                     ?: error("Invalid upper-case identifier: `$text`")
 
     fun createUpperCaseQID(text: String): ElmUpperCaseQID =
-            createFromText<ElmModuleDeclaration>("module $text exposing (..)")
-                    ?.upperCaseQID
+            createFromText("module $text exposing (..)")
                     ?: error("Invalid upper-case QID: `$text`")
 
     fun createValueQID(text: String): ElmValueQID =
-            createFromText<ElmValueDeclaration>("f = $text")
-                    ?.expression
-                    ?.descendantOfType()
+            createFromText("f = $text")
                     ?: error("Invalid value QID: `$text`")
 
+    fun createAnythingPattern(): ElmAnythingPattern =
+            createFromText("f _ = 1")
+                    ?: error("Invalid anything pattern")
+
     fun createOperatorIdentifier(text: String): PsiElement =
-            createFromText("foo = x $text y", OPERATOR_IDENTIFIER)
+            createFromText("f = x $text y", OPERATOR_IDENTIFIER)
                     ?: error("Invalid operator identifier: `$text`")
 
     fun createGlslExpr(text: String): ElmGlslCodeExpr =
-            createFromText("foo = x $text y")
+            createFromText("f = x $text y")
                     ?: error("Invalid glsl expression: `$text`")
 
     fun createImport(moduleName: String, alias: String?): ElmImportClause {
@@ -130,8 +131,7 @@ class ElmPsiFactory(private val project: Project) {
     }
 
     fun createImportExposing(moduleName: String, exposedNames: List<String>): ElmImportClause =
-            "import $moduleName exposing (${exposedNames.joinToString(", ")})"
-                    .let { createFromText<ElmImportClause>(it) }
+            createFromText("import $moduleName exposing (${exposedNames.joinToString(", ")})")
                     ?: error("Failed to create import of $moduleName exposing $exposedNames")
 
     fun createCaseOfBranches(indent: String, patterns: List<String>): List<ElmCaseOfBranch> =
@@ -145,13 +145,13 @@ class ElmPsiFactory(private val project: Project) {
         //       Each line of newDeclBody must start with a non-whitespace character.
         val newDeclBodyIndented = newDeclBody.lines().joinToString("\n") { "$indent        $it" }
         val code = """
-foo =
-${indent}let
-${indent}    $newDeclName =
-$newDeclBodyIndented
-${indent}in
-${indent}$bodyText
-"""
+        |foo =
+        |${indent}let
+        |${indent}    $newDeclName =
+        |$newDeclBodyIndented
+        |${indent}in
+        |${indent}$bodyText
+        """.trimMargin()
         return createFromText<ElmValueDeclaration>(code)
                 ?.descendantOfType()
                 ?: error("Failed to create let/in wrapper")

--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
@@ -6,8 +6,8 @@ class ElmUnusedSymbolInspectionTest : ElmInspectionsTestBase(ElmUnusedSymbolInsp
 
     // FUNCTIONS
 
-    fun `test detects unused functions`() = checkByText("""
-        <warning descr="'f' is never used">f</warning> = g
+    fun `test detects unused functions`() = checkFixIsUnavailable("Rename to _", """
+        <warning descr="'f' is never used">f{-caret-}</warning> = g
         g = ()
         """.trimIndent())
 
@@ -99,16 +99,17 @@ class ElmUnusedSymbolInspectionTest : ElmInspectionsTestBase(ElmUnusedSymbolInsp
 
     // PARAMETERS
 
-    fun `test detects unused function parameters`() = checkByText("""
-        f <warning descr="'x' is never used">x</warning> = ()
+    fun `test renames unused function parameters`() = checkFixByText("Rename to _", """
+        f <warning descr="'x' is never used">x{-caret-}</warning> = ()
+        main = f
+        """.trimIndent(),"""
+        f _ = ()
         main = f
         """.trimIndent())
 
-
-    fun `test detects unused lambda parameters`() = checkByText("""
-        main = (\<warning descr="'x' is never used">x</warning> -> ())
-        """.trimIndent())
-
+    fun `test renames lambda parameters`() = checkFixByText("Rename to _",
+            """main = (\<warning descr="'x' is never used">x{-caret-}</warning> -> ())""",
+            """main = (\_ -> ())""")
 
     // TYPES
 
@@ -129,10 +130,26 @@ class ElmUnusedSymbolInspectionTest : ElmInspectionsTestBase(ElmUnusedSymbolInsp
         """.trimIndent())
 
 
-    fun `test detects unused union variant constructor`() = checkByText("""
+    fun `test detects unused union variant constructor`() = checkFixIsUnavailable("Rename to _", """
         type Foo = Bar | <warning descr="'Quux' is never used">Quux</warning>
         main : Foo
         main = Bar
+        """.trimIndent())
+
+    fun `test renames unused case branch patterns`() = checkFixByText("Rename to _", """
+        type T = T () ()
+        main : T -> ()
+        main t = 
+            case t of
+                T <warning descr="'x' is never used">x{-caret-}</warning> y ->
+                    y
+        """.trimIndent(), """
+        type T = T () ()
+        main : T -> ()
+        main t = 
+            case t of
+                T _ y ->
+                    y
         """.trimIndent())
 
 


### PR DESCRIPTION
The kotlin plugin provides a similar fix. This is more useful for case patterns than it is for function parameters, but there's no harm in providing it for both.

![Capture2](https://user-images.githubusercontent.com/1109214/62661924-4d1b2b00-b927-11e9-86d4-07714e0b408c.PNG)

![Capture](https://user-images.githubusercontent.com/1109214/62661755-ea299400-b926-11e9-8f9d-055c14e4c74a.PNG)
