### PR TITLE
Reduce stubs boilerplate

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.stubs.StubElement
 import org.elm.lang.core.ElmFileType
 import org.elm.lang.core.ElmLanguage
 import org.elm.lang.core.lookup.ClientLocation
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
 import org.elm.lang.core.stubs.*
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.toPsiFile
@@ -65,7 +66,7 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
             getStubOrPsiChild(ElmModuleDeclarationStub.Type)
 
     fun getValueDeclarations() =
-            getStubOrPsiChildren(ElmValueDeclarationStub.Type, emptyArray())
+            stubDirectChildrenOfType<ElmValueDeclaration>()
 
     fun getTypeDeclarations() =
             getStubOrPsiChildren(ElmTypeDeclarationStub.Type, emptyArray())

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -5,15 +5,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
-import com.intellij.psi.impl.DebugUtil
-import com.intellij.psi.impl.source.tree.SharedImplUtil
-import com.intellij.psi.stubs.IStubElementType
-import com.intellij.psi.stubs.StubElement
 import org.elm.lang.core.ElmFileType
 import org.elm.lang.core.ElmLanguage
 import org.elm.lang.core.lookup.ClientLocation
-import org.elm.lang.core.psi.elements.ElmValueDeclaration
-import org.elm.lang.core.stubs.*
+import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.stubs.ElmFileStub
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.toPsiFile
 import org.elm.workspace.ElmPackageProject
@@ -63,77 +59,23 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
         }
 
     fun getModuleDecl() =
-            getStubOrPsiChild(ElmModuleDeclarationStub.Type)
+            stubDirectChildrenOfType<ElmModuleDeclaration>().firstOrNull()
 
     fun getValueDeclarations() =
             stubDirectChildrenOfType<ElmValueDeclaration>()
 
     fun getTypeDeclarations() =
-            getStubOrPsiChildren(ElmTypeDeclarationStub.Type, emptyArray())
+            stubDirectChildrenOfType<ElmTypeDeclaration>()
 
     fun getTypeAliasDeclarations() =
-            getStubOrPsiChildren(ElmTypeAliasDeclarationStub.Type, emptyArray())
+            stubDirectChildrenOfType<ElmTypeAliasDeclaration>()
 
     fun getPortAnnotations() =
-            getStubOrPsiChildren(ElmPortAnnotationStub.Type, emptyArray())
+            stubDirectChildrenOfType<ElmPortAnnotation>()
 
     fun getInfixDeclarations() =
-            getStubOrPsiChildren(ElmInfixDeclarationStub.Type, emptyArray())
+            stubDirectChildrenOfType<ElmInfixDeclaration>()
 
-
-    // TODO [kl] I had to copy a bunch of stuff from StubBasedPsiElementBase to work with
-    // children of this file in a stub-friendly way. I must be doing something strange.
-    // What do other plugin developers do?
-
-    /**
-     * NOTE: copied from [StubBasedPsiElementBase] and ported to Kotlin
-     *
-     * @return a child of specified type, taken from stubs (if this element is currently stub-based) or AST (otherwise).
-     */
-    @Suppress("UNCHECKED_CAST")
-    fun <Psi : PsiElement> getStubOrPsiChild(elementType: IStubElementType<out StubElement<*>, Psi>): Psi? {
-        val stub = getGreenStub()
-        if (stub != null) {
-            val element = stub.findChildStubByType<Psi, StubElement<*>>(elementType)
-            if (element != null) {
-                return element.getPsi() as Psi?
-            }
-        } else {
-            val childNode = node.findChildByType(elementType)
-            if (childNode != null) {
-                return childNode.psi as Psi
-            }
-        }
-        return null
-    }
-
-
-    /**
-     * NOTE: copied from [StubBasedPsiElementBase] and ported to Kotlin
-     *
-     * @return a not-null child of specified type, taken from stubs (if this element is currently stub-based) or AST (otherwise).
-     */
-    fun <S : StubElement<*>, Psi : PsiElement> getRequiredStubOrPsiChild(elementType: IStubElementType<S, Psi>): Psi {
-        return getStubOrPsiChild(elementType)
-                ?: error("Missing required child of type " + elementType + "; tree: " + DebugUtil.psiToString(this, false))
-    }
-
-
-    /**
-     * NOTE: copied from [StubBasedPsiElementBase] and ported to Kotlin
-     *
-     * @return children of specified type, taken from stubs (if this element is currently stub-based) or AST (otherwise).
-     */
-    inline fun <S : StubElement<*>, reified Psi : PsiElement> getStubOrPsiChildren(elementType: IStubElementType<S, out Psi>, array: Array<Psi>): List<Psi> {
-        val stub = greenStub
-        if (stub != null) {
-            return stub.getChildrenByType<Psi>(elementType, array).filterIsInstance<Psi>()
-        } else {
-            val nodes = SharedImplUtil.getChildrenOfType(node, elementType)
-            val psiElements = nodes.map { it.getPsi(Psi::class.java) }
-            return psiElements
-        }
-    }
 
     companion object {
         fun fromVirtualFile(file: VirtualFile, project: Project): ElmFile? =

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -112,7 +112,7 @@ class ElmPsiFactory(private val project: Project) {
     fun createValueQID(text: String): ElmValueQID =
             createFromText<ElmValueDeclaration>("f = $text")
                     ?.expression
-                    ?.childOfType()
+                    ?.descendantOfType()
                     ?: error("Invalid value QID: `$text`")
 
     fun createOperatorIdentifier(text: String): PsiElement =
@@ -137,7 +137,7 @@ class ElmPsiFactory(private val project: Project) {
     fun createCaseOfBranches(indent: String, patterns: List<String>): List<ElmCaseOfBranch> =
             patterns.joinToString("\n\n$indent", prefix = "foo = case 1 of\n\n$indent") { "$it ->\n$indent    " }
                     .let { createFromText<ElmValueDeclaration>(it) }
-                    ?.childOfType<ElmCaseOfExpr>()?.branches
+                    ?.descendantOfType<ElmCaseOfExpr>()?.branches
                     ?: error("Failed to create case of branches from $patterns")
 
     fun createLetInWrapper(indent: String, newDeclName: String, newDeclBody: String, bodyText: String): ElmLetInExpr {
@@ -153,7 +153,7 @@ ${indent}in
 ${indent}$bodyText
 """
         return createFromText<ElmValueDeclaration>(code)
-                ?.childOfType<ElmLetInExpr>()
+                ?.descendantOfType()
                 ?: error("Failed to create let/in wrapper")
     }
 
@@ -170,7 +170,7 @@ ${indent}$bodyText
     private inline fun <reified T : PsiElement> createFromText(code: String): T? =
             PsiFileFactory.getInstance(project)
                     .createFileFromText("DUMMY.elm", ElmFileType, code)
-                    .childOfType()
+                    .descendantOfType()
 
     private fun createFromText(code: String, elementType: IElementType): PsiElement? =
             PsiFileFactory.getInstance(project)

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedUnionConstructors.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedUnionConstructors.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmStubbedElement
 import org.elm.lang.core.psi.ElmTypes
-import org.elm.lang.core.stubs.ElmExposedUnionConstructorsStub
+import org.elm.lang.core.stubs.ElmPlaceholderStub
 
 
 /**
@@ -19,12 +19,12 @@ import org.elm.lang.core.stubs.ElmExposedUnionConstructorsStub
  * 2. [doubleDot] is not-null, in which case all constructors are exposed
  *    (e.g. `import App exposing Page(..)`)
  */
-class ElmExposedUnionConstructors : ElmStubbedElement<ElmExposedUnionConstructorsStub> {
+class ElmExposedUnionConstructors : ElmStubbedElement<ElmPlaceholderStub> {
 
     constructor(node: ASTNode) :
             super(node)
 
-    constructor(stub: ElmExposedUnionConstructorsStub, stubType: IStubElementType<*, *>) :
+    constructor(stub: ElmPlaceholderStub, stubType: IStubElementType<*, *>) :
             super(stub, stubType)
 
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -7,15 +7,15 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.*
-import org.elm.lang.core.stubs.ElmExposingListStub
+import org.elm.lang.core.stubs.ElmPlaceholderStub
 
 
-class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
+class ElmExposingList : ElmStubbedElement<ElmPlaceholderStub> {
 
     constructor(node: ASTNode) :
             super(node)
 
-    constructor(stub: ElmExposingListStub, stubType: IStubElementType<*, *>) :
+    constructor(stub: ElmPlaceholderStub, stubType: IStubElementType<*, *>) :
             super(stub, stubType)
 
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.icons.ElmIcons
 import org.elm.lang.core.psi.*
-import org.elm.lang.core.stubs.ElmValueDeclarationStub
+import org.elm.lang.core.stubs.ElmPlaceholderStub
 
 
 /**
@@ -22,12 +22,12 @@ import org.elm.lang.core.stubs.ElmValueDeclarationStub
  * to a pattern, possibly introducing multiple top-level names.
  * e.g. `(x,y) = (0,0)`
  */
-class ElmValueDeclaration : ElmStubbedElement<ElmValueDeclarationStub>, ElmDocTarget {
+class ElmValueDeclaration : ElmStubbedElement<ElmPlaceholderStub>, ElmDocTarget {
 
     constructor(node: ASTNode) :
             super(node)
 
-    constructor(stub: ElmValueDeclarationStub, stubType: IStubElementType<*, *>) :
+    constructor(stub: ElmPlaceholderStub, stubType: IStubElementType<*, *>) :
             super(stub, stubType)
 
     val modificationTracker = SimpleModificationTracker()

--- a/src/main/kotlin/org/elm/lang/core/stubs/ElmPlaceholderStub.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/ElmPlaceholderStub.kt
@@ -1,0 +1,43 @@
+package org.elm.lang.core.stubs
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.stubs.*
+import org.elm.lang.core.psi.ElmPsiElement
+
+
+/**
+ * The placeholder stub is used for any stub element which does not need to store additional data.
+ * It's only purpose is to decrease boilerplate for elements whose only reason they exist as a
+ * stub is to hold stub children.
+ */
+class ElmPlaceholderStub(
+        parent: StubElement<*>?,
+        elementType: IStubElementType<*, *>
+) : StubBase<ElmPsiElement>(parent, elementType) {
+
+    class Type<T : ElmPsiElement>(
+            name: String,
+            private val ctor: (ElmPlaceholderStub, IStubElementType<*, *>) -> T
+    ) : ElmStubElementType<ElmPlaceholderStub, T>(name) {
+
+        override fun shouldCreateStub(node: ASTNode) =
+                createStubIfParentIsStub(node)
+
+        override fun serialize(stub: ElmPlaceholderStub, dataStream: StubOutputStream) {
+            // nothing to write
+        }
+
+        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
+                ElmPlaceholderStub(parentStub, this)
+
+        override fun createPsi(stub: ElmPlaceholderStub) =
+                ctor(stub, this)
+
+        override fun createStub(psi: T, parentStub: StubElement<*>?) =
+                ElmPlaceholderStub(parentStub, this)
+
+        override fun indexStub(stub: ElmPlaceholderStub, sink: IndexSink) {
+            // no-op
+        }
+    }
+}

--- a/src/main/kotlin/org/elm/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/elm/lang/core/stubs/StubImplementations.kt
@@ -47,13 +47,13 @@ fun factory(name: String): ElmStubElementType<*, *> = when (name) {
     "FUNCTION_DECLARATION_LEFT" -> ElmFunctionDeclarationLeftStub.Type
     "OPERATOR_DECLARATION_LEFT" -> ElmOperatorDeclarationLeftStub.Type  // TODO [drop 0.18] remove this line
     "INFIX_DECLARATION" -> ElmInfixDeclarationStub.Type
-    "EXPOSING_LIST" -> ElmExposingListStub.Type
+    "EXPOSING_LIST" -> ElmPlaceholderStub.Type("EXPOSING_LIST", ::ElmExposingList)
     "EXPOSED_OPERATOR" -> ElmExposedOperatorStub.Type
     "EXPOSED_VALUE" -> ElmExposedValueStub.Type
     "EXPOSED_TYPE" -> ElmExposedTypeStub.Type
     "EXPOSED_UNION_CONSTRUCTOR" -> ElmExposedUnionConstructorStub.Type
-    "EXPOSED_UNION_CONSTRUCTORS" -> ElmExposedUnionConstructorsStub.Type
-    "VALUE_DECLARATION" -> ElmValueDeclarationStub.Type
+    "EXPOSED_UNION_CONSTRUCTORS" -> ElmPlaceholderStub.Type("EXPOSED_UNION_CONSTRUCTORS", ::ElmExposedUnionConstructors)
+    "VALUE_DECLARATION" -> ElmPlaceholderStub.Type("VALUE_DECLARATION", ::ElmValueDeclaration)
     "PORT_ANNOTATION" -> ElmPortAnnotationStub.Type
     else -> error("Unknown element $name")
 }
@@ -238,7 +238,6 @@ class ElmOperatorDeclarationLeftStub(parent: StubElement<*>?,
 }
 
 
-
 class ElmInfixDeclarationStub(parent: StubElement<*>?,
                               elementType: IStubElementType<*, *>,
                               override val name: String
@@ -263,35 +262,6 @@ class ElmInfixDeclarationStub(parent: StubElement<*>?,
 
         override fun indexStub(stub: ElmInfixDeclarationStub, sink: IndexSink) {
             sink.indexInfixDecl(stub)
-        }
-    }
-}
-
-
-class ElmExposingListStub(parent: StubElement<*>?,
-                          elementType: IStubElementType<*, *>
-) : StubBase<ElmExposingList>(parent, elementType) {
-
-    object Type : ElmStubElementType<ElmExposingListStub, ElmExposingList>("EXPOSING_LIST") {
-
-        override fun shouldCreateStub(node: ASTNode) =
-                createStubIfParentIsStub(node)
-
-        override fun serialize(stub: ElmExposingListStub, dataStream: StubOutputStream) {
-            // nothing to write
-        }
-
-        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
-                ElmExposingListStub(parentStub, this)
-
-        override fun createPsi(stub: ElmExposingListStub) =
-                ElmExposingList(stub, this)
-
-        override fun createStub(psi: ElmExposingList, parentStub: StubElement<*>?) =
-                ElmExposingListStub(parentStub, this)
-
-        override fun indexStub(stub: ElmExposingListStub, sink: IndexSink) {
-            // no-op
         }
     }
 }
@@ -422,62 +392,6 @@ class ElmExposedUnionConstructorStub(parent: StubElement<*>?,
                 ElmExposedUnionConstructorStub(parentStub, this, psi.referenceName)
 
         override fun indexStub(stub: ElmExposedUnionConstructorStub, sink: IndexSink) {
-            // no-op
-        }
-    }
-}
-
-class ElmExposedUnionConstructorsStub(parent: StubElement<*>?,
-                                      elementType: IStubElementType<*, *>
-) : StubBase<ElmExposedUnionConstructors>(parent, elementType) {
-
-    object Type : ElmStubElementType<ElmExposedUnionConstructorsStub, ElmExposedUnionConstructors>("EXPOSED_UNION_CONSTRUCTORS") {
-
-        override fun shouldCreateStub(node: ASTNode) =
-                createStubIfParentIsStub(node)
-
-        override fun serialize(stub: ElmExposedUnionConstructorsStub, dataStream: StubOutputStream) {
-            // nothing to write
-        }
-
-        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
-                ElmExposedUnionConstructorsStub(parentStub, this)
-
-        override fun createPsi(stub: ElmExposedUnionConstructorsStub) =
-                ElmExposedUnionConstructors(stub, this)
-
-        override fun createStub(psi: ElmExposedUnionConstructors, parentStub: StubElement<*>?) =
-                ElmExposedUnionConstructorsStub(parentStub, this)
-
-        override fun indexStub(stub: ElmExposedUnionConstructorsStub, sink: IndexSink) {
-            // no-op
-        }
-    }
-}
-
-class ElmValueDeclarationStub(parent: StubElement<*>?,
-                              elementType: IStubElementType<*, *>
-) : StubBase<ElmValueDeclaration>(parent, elementType) {
-
-    object Type : ElmStubElementType<ElmValueDeclarationStub, ElmValueDeclaration>("VALUE_DECLARATION") {
-
-        override fun shouldCreateStub(node: ASTNode) =
-                createStubIfParentIsStub(node)
-
-        override fun serialize(stub: ElmValueDeclarationStub, dataStream: StubOutputStream) {
-            // nothing to write
-        }
-
-        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
-                ElmValueDeclarationStub(parentStub, this)
-
-        override fun createPsi(stub: ElmValueDeclarationStub) =
-                ElmValueDeclaration(stub, this)
-
-        override fun createStub(psi: ElmValueDeclaration, parentStub: StubElement<*>?) =
-                ElmValueDeclarationStub(parentStub, this)
-
-        override fun indexStub(stub: ElmValueDeclarationStub, sink: IndexSink) {
             // no-op
         }
     }


### PR DESCRIPTION
Last night I started looking at putting type annotations into the stub system, but it was going to require a ton of boilerplate. Luckily intellij-rust has already dealt with the problem. This should make it a little bit easier to do.