### PR TITLE
Add intention to qualify unresolved references

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmUnresolvedReferenceAnnotator.kt
@@ -5,9 +5,13 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import org.elm.ide.intentions.AddImportIntention
+import org.elm.ide.intentions.AddQualifierIntention
 import org.elm.ide.intentions.MakeDeclarationIntention
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.psi.elements.ElmImportClause
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
+import org.elm.lang.core.psi.elements.ElmTypeRef
+import org.elm.lang.core.psi.elements.ElmValueExpr
 import org.elm.lang.core.resolve.reference.*
 import org.elm.lang.core.resolve.scope.GlobalScope
 import org.elm.lang.core.resolve.scope.ImportScope
@@ -56,15 +60,16 @@ class ElmUnresolvedReferenceAnnotator : Annotator {
             //
             // Most of the time an ElmReferenceElement is not the ancestor of any other ElmReferenceElement.
             // And in these cases, it's ok to treat the error as spanning the entire reference element.
-            // However, in cases like ElmParametricTypeRef, its children can also be reference elements,
+            // However, in cases like ElmTypeRef, its children can also be reference elements,
             // and so it is vital that we correctly mark the error only on the text range that
             // contributed the reference.
             val errorRange = when (element) {
                 is ElmTypeRef -> element.upperCaseQID.textRange
                 else -> element.textRange
             }
-            holder.createErrorAnnotation(errorRange, "Unresolved reference '${ref.canonicalText}'")
-                    .also { it.registerFix(AddImportIntention()) }
+            val annotation = holder.createErrorAnnotation(errorRange, "Unresolved reference '${ref.canonicalText}'")
+            annotation.registerFix(AddQualifierIntention())
+            annotation.registerFix(AddImportIntention())
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/intentions/AddQualifierIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/AddQualifierIntention.kt
@@ -1,0 +1,126 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.psi.elements.Flavor.*
+import org.elm.lang.core.resolve.ElmReferenceElement
+import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.resolve.scope.VisibleNames
+import org.elm.lang.core.types.moduleName
+import org.elm.openapiext.isUnitTestMode
+import org.elm.openapiext.runWriteCommandAction
+import org.elm.openapiext.toPsiFile
+import org.jetbrains.annotations.TestOnly
+
+class AddQualifierIntention : ElmAtCaretIntentionActionBase<AddQualifierIntention.Context>() {
+
+    data class Context(
+            val candidates: List<String>,
+            val referenceName: String,
+            val qid: ElmQID
+    )
+
+    override fun getText() = "Qualify name"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val file = editor.toPsiFile(project) as? ElmFile ?: error("no file: should not happen")
+        if (element.ancestors.any { it is ElmModuleDeclaration || it is ElmPortAnnotation || it is ElmImportClause }) {
+            return null
+        }
+
+        val qid = element.parentOfType<ElmQID>() ?: return null
+        if (qid.isQualified) return null
+
+        val typeRef = qid.parentOfType<ElmTypeRef>()
+        if (typeRef != null) {
+            return makeContext(file, qid, typeRef, ModuleScope.getReferencableTypes(file))
+        }
+
+        val valueRef = qid.parentOfType<ElmValueExpr>() ?: return null
+
+        return when (valueRef.flavor) {
+            QualifiedValue, QualifiedConstructor -> null
+            BareValue -> {
+                makeContext(file, qid, valueRef, ModuleScope.getReferencableValues(file))
+            }
+            BareConstructor -> {
+                makeContext(file, qid, valueRef, ModuleScope.getReferencableConstructors(file))
+            }
+        }
+    }
+
+    private fun makeContext(file: ElmFile, qid: ElmQID, ref: ElmReferenceElement, names: VisibleNames): Context? {
+        val name = ref.referenceName
+        val candidates = (names.global + names.imported)
+                .filter { it.name == name }
+                .mapNotNull { ModuleScope.getQualifierForName(file, it.moduleName, name) }
+                .filter { it.isNotEmpty() }
+        if (candidates.isEmpty()) return null
+        return Context(candidates, name, qid)
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        when (context.candidates.size) {
+            0 -> error("should not happen: must be at least one candidate")
+            1 -> addQualifier(project, context, context.candidates.first())
+            else -> promptToSelectCandidate(project, editor, context)
+        }
+    }
+
+    private fun promptToSelectCandidate(project: Project, editor: Editor, context: Context) {
+        require(context.candidates.isNotEmpty())
+
+        val picker = if (isUnitTestMode) {
+            MOCK ?: error("You must set mock UI via `withMockQualifierPickerUI`")
+        } else {
+            RealQualifierPickerUI(editor, context)
+        }
+        picker.choose(context.candidates) { qualifier ->
+            project.runWriteCommandAction {
+                addQualifier(project, context, qualifier)
+            }
+        }
+    }
+
+    private fun addQualifier(project: Project, context: Context, qualifier: String) {
+        val factory = ElmPsiFactory(project)
+        val newName = qualifier + context.referenceName
+        val newId = when (context.qid) {
+            is ElmUpperCaseQID -> factory.createUpperCaseQID(newName)
+            is ElmValueQID -> factory.createValueQID(newName)
+            else -> error("unexpected QID type")
+        }
+        context.qid.replace(newId)
+    }
+}
+
+interface QualifierPickerUI {
+    fun choose(qualifiers: List<String>, callback: (String) -> Unit)
+}
+
+private var MOCK: QualifierPickerUI? = null
+
+@TestOnly
+fun withMockQualifierPickerUI(mockUi: QualifierPickerUI, action: () -> Unit) {
+    MOCK = mockUi
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}
+
+private class RealQualifierPickerUI(val editor: Editor, val context: AddQualifierIntention.Context) : QualifierPickerUI {
+    override fun choose(qualifiers: List<String>, callback: (String) -> Unit) {
+        JBPopupFactory.getInstance().createPopupChooserBuilder(qualifiers)
+                .setTitle("Add qualifier to '${context.referenceName}':")
+                .setItemChosenCallback { callback(it) }
+                .setNamerForFiltering { it }
+                .createPopup().showInBestPositionFor(editor)
+    }
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
@@ -32,4 +32,6 @@ interface ElmQID : ElmPsiElement {
             return moduleName.startsWith("Elm.Kernel.")
                     || moduleName.startsWith("Native.") // TODO [drop 0.18] remove the "Native" clause
         }
+
+    val isQualified: Boolean
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
@@ -30,8 +30,7 @@ class ElmUpperCaseQID(node: ASTNode) : ElmPsiElementImpl(node), ElmQID, ElmUnion
      * module name in a module decl or import decl).
      *
      * TODO [kl] this double-duty is a bit strange. Maybe make a separate Psi element?
-     * TODO [kl] also consider moving it into [ElmQID]
      */
-    val isQualified: Boolean
+    override val isQualified: Boolean
         get() = findChildByType<PsiElement>(ElmTypes.DOT) != null
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueQID.kt
@@ -31,6 +31,6 @@ class ElmValueQID(node: ASTNode) : ElmPsiElementImpl(node), ElmQID {
     val lowerCaseIdentifier: PsiElement
         get() = findNotNullChildByType(LOWER_CASE_IDENTIFIER)
 
-    val isQualified: Boolean
+    override val isQualified: Boolean
         get() = findChildByType<PsiElement>(DOT) != null
 }

--- a/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddImportIntentionTest.kt
@@ -267,7 +267,7 @@ main = bar + quux
 """)
 
 
-    fun `test verify unavailable when value not exposed`() = verifyUnavailable(
+    fun `test verify unavailable when value not exposed`() = doUnavailableTestWithFileTree(
             """
 --@ main.elm
 main = bar{-caret-}
@@ -277,7 +277,7 @@ bar = 42
 quux = 0
 """)
 
-    fun `test verify unavailable when value not exposed (qualified ref)`() = verifyUnavailable(
+    fun `test verify unavailable when value not exposed (qualified ref)`() = doUnavailableTestWithFileTree(
             """
 --@ main.elm
 main = Foo.bar{-caret-}
@@ -287,7 +287,7 @@ bar = 42
 quux = 0
 """)
 
-    fun `test verify unavailable when qualified ref alias is not possible`() = verifyUnavailable(
+    fun `test verify unavailable when qualified ref alias is not possible`() = doUnavailableTestWithFileTree(
             """
 --@ main.elm
 main = Foo.Bogus.bar{-caret-}
@@ -296,7 +296,7 @@ module Foo exposing (bar)
 bar = 0
 """)
 
-    fun `test verify unavailable on type annotation when local function hides external name`() = verifyUnavailable(
+    fun `test verify unavailable on type annotation when local function hides external name`() = doUnavailableTestWithFileTree(
             """
 --@ main.elm
 bar{-caret-} : Int -> Int
@@ -321,7 +321,7 @@ main = 2 |. 3
 """)
 
 
-    protected fun check(@Language("Elm") before: String, @Language("Elm") after: String) {
+    private fun check(@Language("Elm") before: String, @Language("Elm") after: String) {
         val testProject = fileTreeFromText(before).createAndOpenFileWithCaretMarker()
 
         // auto-adding an import must be done using stubs only
@@ -333,7 +333,7 @@ main = 2 |. 3
         myFixture.checkResult(replaceCaretMarker(after).trim())
     }
 
-    protected fun checkAutoImportFixByTextWithMultipleChoice(
+    private fun checkAutoImportFixByTextWithMultipleChoice(
             @Language("Elm") before: String,
             expectedElements: Set<String>,
             choice: String,
@@ -341,7 +341,7 @@ main = 2 |. 3
     ) {
         var chooseItemWasCalled = false
 
-        withMockUI(object : ImportPickerUI {
+        withMockImportPickerUI(object : ImportPickerUI {
             override fun choose(candidates: List<Import>, callback: (Import) -> Unit) {
                 chooseItemWasCalled = true
                 val actualItems = candidates.map { it.moduleName }.toSet()
@@ -353,12 +353,5 @@ main = 2 |. 3
         }) { check(before, after) }
 
         check(chooseItemWasCalled) { "`chooseItem` was not called" }
-    }
-
-    protected fun verifyUnavailable(@Language("Elm") before: String) {
-        fileTreeFromText(before).createAndOpenFileWithCaretMarker()
-        check(intention.familyName !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
-            "\"$intention\" intention should not be available"
-        }
     }
 }

--- a/src/test/kotlin/org/elm/ide/intentions/AddQualifierIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddQualifierIntentionTest.kt
@@ -1,0 +1,233 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.vfs.VirtualFileFilter
+import org.elm.fileTreeFromText
+import org.intellij.lang.annotations.Language
+
+class AddQualifierIntentionTest : ElmIntentionTestBase(AddQualifierIntention()) {
+    fun `test value`() = check(
+            """
+--@ main.elm
+import Foo
+main = bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""",
+            """
+import Foo
+main = Foo.bar
+""")
+
+    fun `test type`() = check(
+            """
+--@ main.elm
+import Foo
+bar : Bar{-caret-} -> ()
+bar = ()
+--@ Foo.elm
+module Foo exposing (Bar)
+type Bar = Bar
+""",
+            """
+import Foo
+bar : Foo.Bar -> ()
+bar = ()
+""")
+
+    fun `test constructor`() = check(
+            """
+--@ main.elm
+import Foo
+main = BarVariant{-caret-}
+--@ Foo.elm
+module Foo exposing (Bar(..))
+type Bar = BarVariant
+""",
+            """
+import Foo
+main = Foo.BarVariant
+""")
+
+    fun `test qualified value`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+main = Foo.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""")
+
+
+    fun `test qualified type`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+f : Foo.Bar{-caret-} -> ()
+f bar = ()
+--@ Foo.elm
+module Foo exposing (Bar)
+type Bar = BarVariant
+""")
+
+
+    fun `test qualified constructor`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+main = Foo.BarVariant{-caret-}
+--@ Foo.elm
+module Foo exposing (Bar(..))
+type Bar = BarVariant
+""")
+
+    fun `test value wiht import alias`() = check(
+            """
+--@ main.elm
+import Foo as F
+main = bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""",
+            """
+import Foo as F
+main = F.bar
+""")
+
+
+    fun `test multiple qualifier candidates`() = checkFixByTextWithMultipleChoice(
+            """
+--@ main.elm
+import Foo
+import Bar
+import Baz
+main = quux{-caret-}
+--@ Foo.elm
+module Foo exposing (quux)
+quux = ()
+--@ Bar.elm
+module Bar exposing (quux)
+quux = ()
+--@ Baz.elm
+module Baz exposing (somethingElse)
+somethingElse = ()
+""",
+            listOf("Foo.", "Bar."),
+            "Bar.",
+            """
+import Foo
+import Bar
+import Baz
+main = Bar.quux
+""")
+
+    fun `test multiple qualifier candidates with aliases`() = checkFixByTextWithMultipleChoice(
+            """
+--@ main.elm
+import Foo
+import Bar as B
+main = quux{-caret-}
+--@ Foo.elm
+module Foo exposing (quux)
+quux = ()
+--@ Bar.elm
+module Bar exposing (quux)
+quux = ()
+""",
+            listOf("Foo.", "B."),
+            "B.",
+            """
+import Foo
+import Bar as B
+main = B.quux
+""")
+
+    fun `test binary infix operator`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+main = 2 **{-caret-} 3
+--@ Foo.elm
+module Foo exposing ((**))
+infix right 5 (**) = power
+power a b = List.product (List.repeat b a)
+""")
+
+    fun `test unavailable when value not exposed`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+main = bar{-caret-}
+--@ Foo.elm
+module Foo exposing (quux)
+bar = 42
+quux = 0
+""")
+
+    fun `test unavailable when qualified ref alias is not possible`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+main = Foo.Bogus.bar{-caret-}
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 0
+""")
+
+    fun `test unavailable on type annotation when local function hides external name`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+bar{-caret-} : Int -> Int
+bar = ()
+--@ Foo.elm
+module Foo exposing (bar)
+bar = 42
+""")
+
+    fun `test binary infix operator containing dot is never qualified`() = doUnavailableTestWithFileTree(
+            """
+--@ main.elm
+import Foo
+main = 2 |.{-caret-} 3
+--@ Foo.elm
+module Foo exposing (..)
+infix right 5 (|.) = power
+power a b = List.product (List.repeat b a)
+""")
+
+
+    private fun check(@Language("Elm") before: String, @Language("Elm") after: String) {
+        val testProject = fileTreeFromText(before).createAndOpenFileWithCaretMarker()
+
+        // adding a qualifier must be done using stubs only
+        checkAstNotLoaded(VirtualFileFilter { file ->
+            !file.path.endsWith(testProject.fileWithCaret)
+        })
+
+        myFixture.launchAction(intention)
+        myFixture.checkResult(replaceCaretMarker(after).trim())
+    }
+
+    private fun checkFixByTextWithMultipleChoice(
+            @Language("Elm") before: String,
+            expectedElements: List<String>,
+            choice: String,
+            @Language("Elm") after: String
+    ) {
+        var chooseItemWasCalled = false
+
+        withMockQualifierPickerUI(object : QualifierPickerUI {
+            override fun choose(qualifiers: List<String>, callback: (String) -> Unit) {
+                chooseItemWasCalled = true
+                assertEquals(qualifiers, expectedElements)
+                assertContainsElements(qualifiers, choice)
+                callback(choice)
+            }
+        }) { check(before, after) }
+
+        check(chooseItemWasCalled) { "`chooseItem` was not called" }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/intentions/AddQualifierIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/AddQualifierIntentionTest.kt
@@ -49,6 +49,26 @@ import Foo
 main = Foo.BarVariant
 """)
 
+    fun `test pattern`() = check(
+            """
+--@ main.elm
+import Foo
+main : Foo.Bar -> ()
+main b =
+  case b of
+      BarVariant{-caret-} -> ()
+--@ Foo.elm
+module Foo exposing (Bar(..))
+type Bar = BarVariant
+""",
+            """
+import Foo
+main : Foo.Bar -> ()
+main b =
+  case b of
+      Foo.BarVariant{-caret-} -> ()
+""")
+
     fun `test qualified value`() = doUnavailableTestWithFileTree(
             """
 --@ main.elm

--- a/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
@@ -36,6 +36,13 @@ abstract class ElmIntentionTestBase(val intention: IntentionAction) : ElmTestBas
         }
     }
 
+    protected fun doUnavailableTestWithFileTree(@Language("Elm") before: String) {
+        fileTreeFromText(before).createAndOpenFileWithCaretMarker()
+        check(intention.familyName !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
+            "\"$intention\" intention should not be available"
+        }
+    }
+
     private fun launchAction() {
         PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
         myFixture.launchAction(intention)


### PR DESCRIPTION
This intention is applicable to unresolved references to names defined in imported modules where the name isn't exposed in the current module. It will add the qualifier prefix necessary to make the reference resolve.

![Capture](https://user-images.githubusercontent.com/1109214/62736962-8e711080-b9e3-11e9-8716-610556fae656.PNG)

---

![Capture2](https://user-images.githubusercontent.com/1109214/62736970-92049780-b9e3-11e9-89dd-e7a794ec9a07.PNG)

---

![Capture3](https://user-images.githubusercontent.com/1109214/62736975-94ff8800-b9e3-11e9-8384-171a0c09cf83.PNG)

Fixes #419 