### PR TITLE
Add ability to suppress inspections with comments

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmInspectionSuppressor.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmInspectionSuppressor.kt
@@ -1,0 +1,70 @@
+package org.elm.ide.inspections
+
+import com.intellij.codeInsight.daemon.impl.actions.AbstractBatchSuppressByNoInspectionCommentFix
+import com.intellij.codeInspection.InspectionSuppressor
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.codeInspection.SuppressionUtil
+import com.intellij.codeInspection.SuppressionUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import org.elm.lang.core.ElmLanguage
+import org.elm.lang.core.psi.*
+import org.elm.lang.core.psi.ElmTypes.VIRTUAL_END_DECL
+import org.elm.lang.core.psi.elements.ElmTypeAnnotation
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+
+class ElmInspectionSuppressor : InspectionSuppressor {
+    companion object {
+        private val SUPPRESS_REGEX = Regex("--" + SuppressionUtil.COMMON_SUPPRESS_REGEXP)
+    }
+
+    override fun getSuppressActions(element: PsiElement?, toolId: String): Array<out SuppressQuickFix> = arrayOf(
+            SuppressInspectionFix(toolId),
+            SuppressInspectionFix(SuppressionUtil.ALL)
+    )
+
+    override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean =
+            element.ancestors.filterIsInstance<ElmPsiElement>().firstOrNull { it.isTopLevel }
+                    ?.isSuppressedByComment(toolId)
+                    ?: false
+
+    private fun ElmPsiElement.isSuppressedByComment(toolId: String): Boolean {
+        return prevSiblings.takeWhile {
+            it is PsiWhiteSpace ||
+                    it is PsiComment ||
+                    it.elementType == VIRTUAL_END_DECL ||
+                    this is ElmValueDeclaration && it is ElmTypeAnnotation
+        }.filterIsInstance<PsiComment>().any { comment ->
+            val match = SUPPRESS_REGEX.matchEntire(comment.text)
+            match != null && SuppressionUtil.isInspectionToolIdMentioned(match.groupValues[1], toolId)
+        }
+    }
+
+    private class SuppressInspectionFix(
+            id: String
+    ) : AbstractBatchSuppressByNoInspectionCommentFix(id, /* replaceOthers = */ id == SuppressionUtil.ALL) {
+
+        init {
+            text = when (id) {
+                SuppressionUtil.ALL -> "Suppress all inspections for declaration"
+                else -> "Suppress for declaration with comment"
+            }
+        }
+
+        override fun getContainer(context: PsiElement?): PsiElement? {
+            if (context == null) return null
+            return context.ancestors.filterIsInstance<ElmPsiElement>().firstOrNull { it.isTopLevel }
+        }
+
+        override fun createSuppression(project: Project, element: PsiElement, container: PsiElement) {
+            val anchor = (container as? ElmValueDeclaration)?.typeAnnotation ?: container
+            val text = SuppressionUtilCore.SUPPRESS_INSPECTIONS_TAG_NAME + " " + myID
+            val comment = SuppressionUtil.createComment(project, text + "\n", ElmLanguage)
+            val parent = anchor.parent
+            parent.addBefore(comment, anchor)
+            parent.addBefore(ElmPsiFactory(element.project).createWhitespace("\n"), anchor)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -233,6 +233,9 @@
 
         <!-- Inspections -->
 
+        <lang.inspectionSuppressor language="Elm"
+                                   implementationClass="org.elm.ide.inspections.ElmInspectionSuppressor"/>
+
         <localInspection language="Elm" groupName="Elm"
                          displayName="Type checker"
                          enabledByDefault="true" level="ERROR"
@@ -265,7 +268,6 @@
             <className>org.elm.ide.intentions.AddExposureIntention</className>
             <category>Elm</category>
         </intentionAction>
-
         <intentionAction>
             <className>org.elm.ide.intentions.RemoveExposureIntention</className>
             <category>Elm</category>

--- a/src/test/kotlin/org/elm/ide/inspections/ElmInspectionSuppressorTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmInspectionSuppressorTest.kt
@@ -1,0 +1,26 @@
+package org.elm.ide.inspections
+
+class ElmInspectionSuppressorTest : ElmInspectionsTestBase(ElmUnusedSymbolInspection()) {
+
+    fun testWithoutSuppression() = checkByText("""
+type T = T ()
+<warning>f</warning> = g
+
+g : T -> () -> ()
+g t <warning>x</warning> = 
+  case t of
+      T <warning>u</warning> -> ()
+    """)
+
+    fun testSuppression() = checkByText("""
+type T = T ()
+-- noinspection ElmUnusedSymbol
+f = g
+
+-- noinspection ElmUnusedSymbol
+g : T -> () -> ()
+g t x = 
+  case t of
+      T u -> ()
+    """)
+}


### PR DESCRIPTION
Because elm-format does terrible things to comments within expressions, I chose to only support suppression comments at the declaration level, which will suppress all inspections within that declaration. And because manipulating indented psi elements is annoying, I chose to not support suppression comments on nested declarations. We could add that if we want, but it didn't seem that important.

![Capture](https://user-images.githubusercontent.com/1109214/62742264-c03da380-b9f2-11e9-83a3-b6179628ae1e.PNG)

---

![Capture2](https://user-images.githubusercontent.com/1109214/62742267-c29ffd80-b9f2-11e9-8be4-d3b5062984a1.PNG)


Fixes #206