### PR TITLE
Fix case where record field reference wouldn't resolve

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
@@ -1,12 +1,15 @@
 package org.elm.lang.core.types
 
 import org.elm.lang.core.psi.ElmNamedElement
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A table that tracks references for [TyRecord] fields. Can be [frozen] to prevent updates.
  */
 data class RecordFieldReferenceTable(
-        private val refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = mutableMapOf(),
+        // We use a ConcurrentHashMap even through writes are constrained to a single thread, since
+        // copies can occur concurrently with a write.
+        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = ConcurrentHashMap(),
         val frozen: Boolean = false
 ) {
     /** Get all references for a [field], or an empty list if there are none. */
@@ -17,7 +20,9 @@ data class RecordFieldReferenceTable(
     /** Add all references from [other] to this table. Has no effect if [frozen]. */
     fun addAll(other: RecordFieldReferenceTable) {
         if (frozen) return
-        combine(other)
+        for ((field, refs) in other.refsByField) {
+            refsByField.getOrPut(field) { mutableSetOf() } += refs
+        }
     }
 
     /** Return true if this table contains no references */
@@ -25,12 +30,8 @@ data class RecordFieldReferenceTable(
 
     /** Create a new table with references from this table and [other] */
     operator fun plus(other: RecordFieldReferenceTable): RecordFieldReferenceTable {
-        return copy().apply { combine(other) }
+        return copy(frozen = false).apply { addAll(other) }
     }
 
-    private fun combine(other: RecordFieldReferenceTable) {
-        for ((field, refs) in other.refsByField) {
-            refsByField.getOrPut(field) { mutableSetOf() } += refs
-        }
-    }
+    fun copy(frozen: Boolean = this.frozen) = RecordFieldReferenceTable(refsByField.toMutableMap(), frozen)
 }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1060,17 +1060,23 @@ private class InferenceScope(
 
     private fun recordAssignable(ty1: TyRecord, ty2: TyRecord): Boolean {
         val result = calcRecordDiff(ty1, ty2).isEmpty()
-        // Subset record tys are created from extension record declarations or field accessor
-        // functions. If we're assigning a concrete record to a subset, set the type of the
-        // extension base var to the concrete record.
-        if (result && !ty1.isSubset && ty2.baseTy is TyVar) {
-            trackReplacement(ty1, ty2.baseTy)
-        }
         if (result) {
+            // Subset record tys are created from extension record declarations or field accessor
+            // functions.
+            // If we're assigning a concrete record to a subset, set the type of the extension base
+            // var to the concrete record.
+            if (!ty1.isSubset && ty2.baseTy is TyVar) {
+                trackReplacement(ty1, ty2.baseTy)
+            }
+            // Do the same in the inverse case
+            if (ty1.baseTy is TyVar && !ty2.isSubset) {
+                trackReplacement(ty1.baseTy, ty2)
+            }
             // If we assign a record value expression, we know what its field references resolve to
             ty1.fieldReferences.addAll(ty2.fieldReferences)
             ty2.fieldReferences.addAll(ty1.fieldReferences)
         }
+
         return result
     }
 

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmRecordFieldResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmRecordFieldResolveTest.kt
@@ -265,4 +265,24 @@ main =
         --^                               
     ]
 """)
+
+    fun `test nested extension aliases with funcion in type variable passed through another variable via forward pipeline`() = checkByCode(
+            """
+infix left  0 (|>) = apR
+apR : a -> (a -> b) -> b
+apR x f = f x
+
+type alias R = { field : () }
+                  --X
+type alias Outer r = { r : Type (r -> r) }
+type Type a = Type a
+
+foo : Outer r -> Outer r
+foo r = r
+
+main : Outer R
+main =
+    { r = Type (\r -> { r | field = () }) } |> foo 
+                             --^                               
+""")
 }


### PR DESCRIPTION
To my surprise, it turns out that if you try _really_ hard, you can in fact assign an extension record to a concrete record before the concrete record is unified with a type annotation. This commit now tracks replacements for that case.

Note that this didn't affect inference correctness, it just prevented us from propagating field references.

Fixes #475