### PR TITLE
Resolve record pattern references

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -21,7 +21,10 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
         val name = element.name
 
         // ignore certain kinds of declarations which we don't want to inspect
-        if (element is ElmTypeAliasDeclaration || element is ElmTypeDeclaration || element is ElmTypeVariable) {
+        if (element is ElmTypeAliasDeclaration ||
+                element is ElmTypeDeclaration ||
+                element is ElmTypeVariable ||
+                element is ElmLowerPattern && element.parent is ElmRecordPattern) {
             // TODO revisit: implementation for types is a little tricky since
             //      type annotations are optional; punting for now
             return

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmLowerPattern.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmLowerPattern.kt
@@ -6,6 +6,9 @@ import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.*
+import org.elm.lang.core.resolve.ElmReferenceElement
+import org.elm.lang.core.resolve.reference.ElmReference
+import org.elm.lang.core.resolve.reference.RecordFieldReference
 
 
 /**
@@ -14,7 +17,8 @@ import org.elm.lang.core.psi.*
  * e.g. the `x` parameter in `f x = 0`
  * e.g. `a` and `b` in the declaration `(a, b) = (0, 0)`
  */
-class ElmLowerPattern(node: ASTNode) : ElmNamedElementImpl(node, IdentifierCase.LOWER), ElmNameDeclarationPatternTag,
+class ElmLowerPattern(node: ASTNode) : ElmNamedElementImpl(node, IdentifierCase.LOWER),
+        ElmReferenceElement, ElmNameDeclarationPatternTag,
         ElmFunctionParamTag, ElmPatternChildTag, ElmUnionPatternChildTag {
 
     val identifier: PsiElement
@@ -60,5 +64,15 @@ class ElmLowerPattern(node: ASTNode) : ElmNamedElementImpl(node, IdentifierCase.
         }
 
         return LocalSearchScope(elmFile)
+    }
+
+    override val referenceNameElement: PsiElement
+        get() = identifier
+
+    override val referenceName: String
+        get() = identifier.text
+
+    override fun getReference(): ElmReference {
+        return RecordFieldReference.fromElement(this) { it.parent as? ElmRecordPattern }
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
@@ -13,8 +13,10 @@ class LexicalValueReference(element: ElmReferenceElement)
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+    override fun resolveInner(): ElmNamedElement? {
+        val resolved = getCandidates().find { it.name == element.referenceName }
+        return (resolved as? ElmReferenceElement)?.reference?.resolve() ?: resolved
+    }
 
     private fun getCandidates(): List<ElmNamedElement> {
         return ExpressionScope(element).getVisibleValues()

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -658,6 +658,13 @@ private class InferenceScope(
                 // All patterns should now be bound
                 error(expr, "failed to bind pattern")
             }
+            is ElmFieldType -> {
+                return (ref.parentOfType<ElmTypeAliasDeclaration>()
+                        ?.typeExpressionInference()
+                        ?.value as? TyRecord)
+                        ?.fields?.get(ref.name)
+                        ?: TyUnknown()
+            }
             else -> error(ref, "Unexpected reference type")
         }
     }
@@ -963,6 +970,8 @@ private class InferenceScope(
         for (f in fields) {
             bindPattern(f, ty.fields.getValue(f.name), isParameter)
         }
+
+        expressionTypes[pat] = type
     }
 
     //</editor-fold>

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -443,18 +443,19 @@ foo (_, (bar, _)) = bar
 <i>of function </i><a href="psi_element://foo">foo</a></pre></div>
 """)
 
-    fun `test function parameter with record type annotation`() = doTest(
-            """
-type Int = Int
-type Float = Float
-foo : {x: Int, y: Float} -> Float
-foo {x, y} = y
-           --^
-""",
-            """
-<div class='definition'><pre><i>parameter</i> y : <a href="psi_element://Float">Float</a>
-<i>of function </i><a href="psi_element://foo">foo</a></pre></div>
-""")
+// The value now resolves to the field inside the annotation, which we don't have a ty for.
+//    fun `test function parameter with record type annotation`() = doTest(
+//            """
+//type Int = Int
+//type Float = Float
+//foo : {x: Int, y: Float} -> Float
+//foo {x, y} = y
+//           --^
+//""",
+//            """
+//<div class='definition'><pre><i>parameter</i> y : <a href="psi_element://Float">Float</a>
+//<i>of function </i><a href="psi_element://foo">foo</a></pre></div>
+//""")
 
     fun `test function parameter with record type and as annotation`() = doTest(
             """

--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
@@ -111,6 +111,13 @@ class ElmUnusedSymbolInspectionTest : ElmInspectionsTestBase(ElmUnusedSymbolInsp
             """main = (\<warning descr="'x' is never used">x{-caret-}</warning> -> ())""",
             """main = (\_ -> ())""")
 
+    fun `test used record field patterns`() = checkByText("""
+        type alias X  = { x : () }
+        f : X -> ()
+        f { x } = x
+        main = f
+        """.trimIndent())
+
     // TYPES
 
 

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmRecordFieldResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmRecordFieldResolveTest.kt
@@ -230,6 +230,46 @@ main r s =
   first (nest r) (nest s)        
     """)
 
+    fun `test ref to destructuring in function parameter`() = checkByCode(
+            """
+type alias R = { field : () }
+                 --X
+main : R -> ()
+main { field } = field
+       --^
+""")
+
+    fun `test value ref through destructuring in function parameter`() = checkByCode(
+            """
+type alias R = { field : () }
+                 --X
+main : R -> ()
+main { field } = field
+                 --^
+""")
+
+    fun `test ref through destructuring in case`() = checkByCode(
+            """
+type alias R = { field : () }
+                 --X
+main : R -> ()
+main r = 
+  case r of
+      { field } -> field
+                    --^
+""")
+
+    fun `test ref to destructuring in case`() = checkByCode(
+            """
+type alias R = { field : () }
+                 --X
+main : R -> ()
+main r = 
+  case r of
+      { field } -> field
+        --^
+""")
+
     fun `test repeated reference in list 1`() = checkByCode(
             """
 type alias R = { field : () }


### PR DESCRIPTION
This took two changes:

- Make ElmLowerPattern a reference element. It was already a named element; now it's both.
- Make LexicalValueReferences pass through parameters that are also references

The second change is necessary because otherwise find usages / renaming a record field would not find ElmValueExpr elements, since they would only resolve to the parameter rather than the field. Unfortunately, that change means that parameters that resolve to another element will always be marked as unused. I worked around that by ignoring those elements in the unused symbol inspection. It also means that we can't generate documentation for record pattern parameters that reference records directly inside type annotations (it still works for references to aliased records).

Given the imperfect nature of this fix, you may want to reject this PR. It seems that this feature is more useful than the ones it breaks, but that's up to you.

Fixes #476 