### PR TITLE
Fix inference errors in field patterns of unannotated records

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -936,13 +936,14 @@ private class InferenceScope(
         val fields = pat.lowerPatternList
 
         val ty = bindIfVar(pat, type) {
-            TyRecord(
-                    fields = fields.zip(uniqueVars(fields.size)) { f, t -> f.name to t }.toMap(),
-                    baseTy = TyVar("a")
-            )
+            MutableTyRecord(fields = mutableMapOf(), baseTy = TyVar("a"))
         }
 
-        if (ty !is TyRecord || fields.any { it.name !in ty.fields }) {
+        if (ty is MutableTyRecord) {
+            fields.zip(uniqueVars(fields.size)).forEach { (field, v) ->
+                ty.fields.getOrPut(field.name) { v }
+            }
+        } else if (ty !is TyRecord || fields.any { it.name !in ty.fields }) {
             if (isInferable(ty)) {
                 val actualTyParams = fields.zip(uniqueVars(fields.size)) { f, v -> f.name to v }
                 val actualTy = TyRecord(actualTyParams.toMap())
@@ -960,8 +961,9 @@ private class InferenceScope(
             return
         }
 
+        val tyFields = (ty as? MutableTyRecord)?.fields ?: (ty as TyRecord).fields
         for (f in fields) {
-            bindPattern(f, ty.fields.getValue(f.name), isParameter)
+            bindPattern(f, tyFields.getValue(f.name), isParameter)
         }
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -310,7 +310,9 @@ private class InferenceScope(
                     val lAssignable = requireAssignable(l.start, l.ty, func.parameters[0], l.end)
                     val rAssignable = requireAssignable(r.start, r.ty, func.parameters[1], r.end)
                     val ty = when {
-                        lAssignable && rAssignable -> TypeReplacement.replace(func.partiallyApply(2), replacements)
+                        lAssignable && rAssignable -> {
+                            TypeReplacement.replace(func.partiallyApply(2), replacements, keepRecordsMutable = true)
+                        }
                         else -> TyUnknown()
                     }
                     TyAndRange(l.start, r.end, ty)
@@ -382,7 +384,7 @@ private class InferenceScope(
         }
 
         val resultTy = if (ok) {
-            TypeReplacement.replace(targetTy.partiallyApply(arguments.size), replacements)
+            TypeReplacement.replace(targetTy.partiallyApply(arguments.size), replacements, keepRecordsMutable = true)
         } else {
             TyUnknown()
         }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -14,7 +14,8 @@ class TypeReplacement(
         replacements: Map<TyVar, Ty>,
         private val freshen: Boolean,
         private val varsToRemainRigid: Collection<TyVar>?,
-        private val freeze: Boolean
+        private val freeze: Boolean,
+        private val keepRecordsMutable: Boolean
 ) {
     companion object {
         /**
@@ -22,15 +23,33 @@ class TypeReplacement(
          *
          * @param varsToRemainRigid If given, all [TyVar]s will be replaced with flexible copies,
          *  except for vars that occur in this collection, which will be left unchanged.
+         * @param freeze If true, make all record field reference tables frozen
+         * @param keepRecordsMutable If false, [MutableTyRecord]s will be replaces with [TyRecord]s
          */
-        fun replace(ty: Ty, replacements: Map<TyVar, Ty>, varsToRemainRigid: Collection<TyVar>? = null, freeze: Boolean = false): Ty {
+        fun replace(
+                ty: Ty,
+                replacements: Map<TyVar, Ty>,
+                varsToRemainRigid: Collection<TyVar>? = null,
+                freeze: Boolean = false,
+                keepRecordsMutable: Boolean = false
+        ): Ty {
             if (varsToRemainRigid == null && replacements.isEmpty() || !tyWouldChange(ty, freeze)) return ty
-            return TypeReplacement(replacements, freshen = false, varsToRemainRigid = varsToRemainRigid, freeze = freeze).replace(ty)
+            return TypeReplacement(
+                    replacements,
+                    freshen = false,
+                    varsToRemainRigid = varsToRemainRigid,
+                    freeze = freeze,
+                    keepRecordsMutable = keepRecordsMutable
+            ).replace(ty)
         }
 
-        fun replace(ty: Ty, replacements: DisjointSet, varsToRemainRigid: Collection<TyVar>? = null, freeze: Boolean = false): Ty {
-            return replace(ty = ty, replacements = replacements.asMap(), varsToRemainRigid = varsToRemainRigid, freeze = freeze)
-        }
+        fun replace(
+                ty: Ty,
+                replacements: DisjointSet,
+                varsToRemainRigid: Collection<TyVar>? = null,
+                freeze: Boolean = false,
+                keepRecordsMutable: Boolean = false
+        ): Ty = replace(ty, replacements.asMap(), varsToRemainRigid, freeze, keepRecordsMutable)
 
         /**
          * Replace all [TyVar]s in a [ty] with new copies with the same names.
@@ -47,7 +66,7 @@ class TypeReplacement(
          */
         fun freshenVars(ty: Ty, freeze: Boolean = false): Ty {
             if (!tyWouldChange(ty, freeze)) return ty
-            return TypeReplacement(emptyMap(), freshen = true, varsToRemainRigid = null, freeze = freeze).replace(ty)
+            return TypeReplacement(emptyMap(), freshen = true, varsToRemainRigid = null, freeze = freeze, keepRecordsMutable = false).replace(ty)
         }
 
         /**
@@ -59,7 +78,7 @@ class TypeReplacement(
          */
         fun flexify(ty: Ty): Ty {
             if (ty.allVars(true).none()) return ty
-            return TypeReplacement(emptyMap(), freshen = false, varsToRemainRigid = emptyList(), freeze = false).replace(ty)
+            return TypeReplacement(emptyMap(), freshen = false, varsToRemainRigid = emptyList(), freeze = false, keepRecordsMutable = false).replace(ty)
         }
 
         /**
@@ -69,7 +88,7 @@ class TypeReplacement(
          */
         fun freeze(ty: Ty): Ty {
             if (ty.traverse(true).none { it.isUnfrozenRecord() }) return ty
-            return TypeReplacement(emptyMap(), freshen = false, varsToRemainRigid = emptyList(), freeze = false).replace(ty)
+            return TypeReplacement(emptyMap(), freshen = false, varsToRemainRigid = emptyList(), freeze = false, keepRecordsMutable = false).replace(ty)
         }
 
         private fun tyWouldChange(ty: Ty, freeze: Boolean): Boolean {
@@ -95,9 +114,9 @@ class TypeReplacement(
             is TyFunction -> replaceFunction(ty)
             is TyUnknown -> TyUnknown(replace(ty.alias))
             is TyUnion -> replaceUnion(ty)
-            is TyRecord -> replaceRecord(ty)
+            is TyRecord -> replaceRecord(ty.fields, ty.baseTy, ty.alias, ty.fieldReferences, wasMutable = false)
             is TyUnit, TyInProgressBinding -> ty
-            is MutableTyRecord -> replaceRecord(ty.toRecord())
+            is MutableTyRecord -> replaceRecord(ty.fields, ty.baseTy, null, ty.fieldReferences, wasMutable = true)
         }
         // If we didn't change anything, return the original ty to avoid duplicating the object
         return if (replaced == ty) ty else replaced
@@ -133,41 +152,45 @@ class TypeReplacement(
         return TyUnion(ty.module, ty.name, parameters, replace(ty.alias))
     }
 
-    private fun replaceRecord(ty: TyRecord): TyRecord {
-        val replacedBase = if (ty.baseTy == null || ty.baseTy !is TyVar) null else getReplacement(ty.baseTy)
+    private fun replaceRecord(
+            fields: Map<String, Ty>,
+            baseTy: Ty?,
+            alias: AliasInfo?,
+            fieldReferences: RecordFieldReferenceTable,
+            wasMutable: Boolean
+    ): Ty {
+        val replacedBase = if (baseTy == null || baseTy !is TyVar) null else getReplacement(baseTy)
         val newBaseTy = when (replacedBase) {
             // If the base ty of the argument is a record, use it's base ty, which might be null.
             is TyRecord -> replacedBase.baseTy
             // If it wasn't substituted, leave it as-is
-            null -> ty.baseTy
+            null -> baseTy
             // If it's another variable, use it
             else -> replacedBase
         }
 
-        val declaredFields = ty.fields.mapValues { (_, it) -> replace(it) }
+        val declaredFields = fields.mapValues { (_, it) -> replace(it) }
         val baseFields = (replacedBase as? TyRecord)?.fields.orEmpty()
         val baseFieldRefs = (replacedBase as? TyRecord)?.fieldReferences
 
-        var fieldReferences = when {
-            baseFieldRefs == null || baseFieldRefs.isEmpty() -> ty.fieldReferences
-            ty.fieldReferences.frozen -> ty.fieldReferences + baseFieldRefs
+        var newFieldReferences = when {
+            baseFieldRefs == null || baseFieldRefs.isEmpty() -> fieldReferences
+            fieldReferences.frozen -> fieldReferences + baseFieldRefs
             else -> {
                 // The new record shares its references table with the old record. That allows us to track
                 // references back to expressions inside nested declarations even when the record has been
                 // freshened or replaced.
-                ty.fieldReferences.apply { addAll(baseFieldRefs) }
+                fieldReferences.apply { addAll(baseFieldRefs) }
             }
         }
 
-        if (freeze && !fieldReferences.frozen) {
-            fieldReferences = fieldReferences.copy(frozen = true)
+        if (freeze && !newFieldReferences.frozen) {
+            newFieldReferences = newFieldReferences.copy(frozen = true)
         }
-        return TyRecord(
-                fields = baseFields + declaredFields,
-                baseTy = newBaseTy,
-                alias = replace(ty.alias),
-                fieldReferences = fieldReferences
-        )
+        val newFields = baseFields + declaredFields
+        val newAlias = replace(alias)
+        return if (wasMutable && keepRecordsMutable) MutableTyRecord(newFields.toMutableMap(), newBaseTy, newFieldReferences)
+        else TyRecord(newFields, newBaseTy, newAlias, newFieldReferences)
     }
 
     // When we replace a var, the new ty may itself contain vars, and so we need to recursively

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
@@ -290,6 +290,15 @@ main : ()
 main = foo .x
 """)
 
+    fun `test field accessor as argument to type var in pipeline`() = checkByText("""
+foo : (a -> ()) -> a -> a
+foo _ a = a
+
+main : ()
+main =
+    <error descr="Type mismatch.Required: ()Found: { a | f2 : (), f1 : () }">{ f1 = (), f2 = () } |> foo .f2</error>
+""")
+
     fun `test correct value type from parametric record alias`() = checkByText("""
 type alias A a = {x: a, y: ()}
 main : A Float

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
@@ -290,15 +290,6 @@ main : ()
 main = foo .x
 """)
 
-    fun `test field accessor as argument to type var in pipeline`() = checkByText("""
-foo : (a -> ()) -> a -> a
-foo _ a = a
-
-main : ()
-main =
-    <error descr="Type mismatch.Required: ()Found: { a | f2 : (), f1 : () }">{ f1 = (), f2 = () } |> foo .f2</error>
-""")
-
     fun `test correct value type from parametric record alias`() = checkByText("""
 type alias A a = {x: a, y: ()}
 main : A Float

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -526,6 +526,17 @@ foo f =
        Quz x -> bar x
 """)
 
+    fun `test case branches with record pattern on different field than previously accessed through pipeline`() = checkByText("""
+foo : (a -> ()) -> a -> a
+foo _ a = a
+
+main : String
+main =
+    case { f1 = (), f2 = () } |> foo .f2 of
+        { f1 }  ->
+            <error descr="Type mismatch.Required: StringFound: ()">f1</error>
+""")
+
     fun `test case branch with record pattern from previous mutable record`() = checkByText("""
 foo r =
     let

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -526,6 +526,19 @@ foo f =
        Quz x -> bar x
 """)
 
+    fun `test case branch with record pattern from previous mutable record`() = checkByText("""
+foo r =
+    let
+        f = r.f1
+    in
+    case r of
+        { f2 } -> r
+
+main : ()
+main = 
+  <error descr="Type mismatch.Required: ()Found: { f1 : (), f2 : String }">foo { f1 = (), f2 = "" }</error>
+""")
+
     fun `test invalid return value from cons pattern`() = checkByText("""
 main : ()
 main =


### PR DESCRIPTION
- Check for MutableTyRecord when binding field patterns
- Keep records mutable when replacing function calls

Fixes #480