### PR TITLE
Fix ConcurrentModificationException in RecordFieldReferenceTable

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -10,7 +10,6 @@ import org.elm.lang.core.diagnostics.ElmDiagnostic
 import org.elm.lang.core.diagnostics.TypeArgumentCountError
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
-import java.util.concurrent.ConcurrentHashMap
 
 
 // Changes to type expressions always invalidate the whole project, since they influence inferred
@@ -257,7 +256,7 @@ class TypeExpression(
     private fun recordTypeDeclType(record: ElmRecordType): TyRecord {
         val fieldElements = record.fieldTypeList
         val fieldTys = fieldElements.associate { it.name to typeExpressionType(it.typeExpression) }
-        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(ConcurrentHashMap()) {
+        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(mutableMapOf()) {
             it.name to mutableSetOf<ElmNamedElement>(it)
         })
         val baseId = record.baseTypeIdentifier

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -10,6 +10,7 @@ import org.elm.lang.core.diagnostics.ElmDiagnostic
 import org.elm.lang.core.diagnostics.TypeArgumentCountError
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
+import java.util.concurrent.ConcurrentHashMap
 
 
 // Changes to type expressions always invalidate the whole project, since they influence inferred
@@ -256,7 +257,7 @@ class TypeExpression(
     private fun recordTypeDeclType(record: ElmRecordType): TyRecord {
         val fieldElements = record.fieldTypeList
         val fieldTys = fieldElements.associate { it.name to typeExpressionType(it.typeExpression) }
-        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(mutableMapOf()) {
+        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(ConcurrentHashMap()) {
             it.name to mutableSetOf<ElmNamedElement>(it)
         })
         val baseId = record.baseTypeIdentifier


### PR DESCRIPTION
I had originally used a ConcurrentHashMap as a shot in the dark to fix the CMEs that could show up in the RecordFieldReferenceTable.

After actually investigating, I found that there weren't actually concurrent modifications or tables that weren't frozen, but instead that sometimes a record ty was assigned to itself, which would cause the CME due to updating the same list we were iterating over. 

I wasn't able to minify this into a test, but I was able to reproduce in consistently in a large repo.

Fixes #489 
Fixes #496 
Fixes #494