### PR TITLE
Use type annotations when inferring recursive functions.

### DIFF
--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -269,6 +269,15 @@ main =
     ()
 """)
 
+    fun `test mapping over recursive container in annotated function`() = checkByText("""
+type Box a = Box a
+type Tree a = Node (List (Tree a))
+
+main : Tree (Box a) -> Box (Tree a)
+main (Node trees) =
+    <error descr="Type mismatch.Required: Box (Tree a)Found: List (Box (Tree a))">List.map main trees</error>
+""")
+
     fun `test uncurrying function passed as argument`() = checkByText("""
 foo : a -> a
 foo a = a


### PR DESCRIPTION
Currently, we are returning `TyUnknown` for all referenced recursive value declarations to avoid infinite loops. This is overly cautious and results in some false negatives.

This commit uses type annotations for recursive functions when available, since there's no risk of a loop in that case. We still return `TyUnknown` when no annotation is present.

Fixes #499