### PR TITLE
Exclude ElmFieldType elements from the unused symbol inspection

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -24,6 +24,7 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
         if (element is ElmTypeAliasDeclaration ||
                 element is ElmTypeDeclaration ||
                 element is ElmTypeVariable ||
+                element is ElmFieldType ||
                 element is ElmLowerPattern && element.parent is ElmRecordPattern) {
             // TODO revisit: implementation for types is a little tricky since
             //      type annotations are optional; punting for now


### PR DESCRIPTION
It's not possible to resolve field references in all cases, so it's better not to report false positives.

Fixes #488