### PR TITLE
Infer types of references to record pattern parameters without aliases

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
@@ -14,8 +14,17 @@ class LexicalValueReference(element: ElmReferenceElement)
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? {
-        val resolved = getCandidates().find { it.name == element.referenceName }
+        val resolved = resolveShallow()
         return (resolved as? ElmReferenceElement)?.reference?.resolve() ?: resolved
+    }
+
+    /**
+     * References of this type normally recursively resolve references to elements that are
+     * themselves references (e.g. usage of a name in a record destructuring pattern). This function
+     * will only resolve the first level of reference.
+     */
+    fun resolveShallow(): ElmNamedElement? {
+        return getCandidates().find { it.name == element.referenceName }
     }
 
     private fun getCandidates(): List<ElmNamedElement> {

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -46,6 +46,12 @@ foo e = ()
 main = foo { field = (), field2 = () }
 """)
 
+    fun `test record pattern parameter for record type literal`() = checkByText("""
+main : { field : () } -> Int
+main { field } = 
+  <error descr="Type mismatch.Required: IntFound: ()">field</error>
+""")
+
     fun `test let-in with mismatched type in annotated inner func`() = checkByText("""
 main : ()
 main =


### PR DESCRIPTION
Starting with PR #478, we always inferred references to record field pattern parameters of functions annotated with raw record types as `TyUnknown`. This PR fixes that regression. 