### PR TITLE
Fix replacement when freezing records with no other changes

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
@@ -36,4 +36,8 @@ data class RecordFieldReferenceTable(
                 frozen
         )
     }
+
+    override fun toString(): String {
+        return "<RecordFieldReferenceTable frozen=$frozen, refs=${refsByField.keys}>"
+    }
 }

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -60,7 +60,7 @@ data class TyTuple(val types: List<Ty>, override val alias: AliasInfo? = null) :
  *   accessors, record with base identifiers etc. that match a subset of record fields
  * @property alias The alias for this record, if there is one. Used for rendering and tracking record constructors
  * @property fieldReferences A map of field name to the psi element that defines them; used for
- *   reference resolve, does not affect equality
+ *   reference resolve, only the frozen status affects equality
  */
 data class TyRecord(
         val fields: Map<String, Ty>,
@@ -87,6 +87,7 @@ data class TyRecord(
         if (fields != other.fields) return false
         if (baseTy != other.baseTy) return false
         if (alias != other.alias) return false
+        if (fieldReferences.frozen != other.fieldReferences.frozen) return false
         return true
     }
 
@@ -94,6 +95,7 @@ data class TyRecord(
         var result = fields.hashCode()
         result = 31 * result + (baseTy?.hashCode() ?: 0)
         result = 31 * result + (alias?.hashCode() ?: 0)
+        result = 31 * result + fieldReferences.frozen.hashCode()
         return result
     }
 }
@@ -119,12 +121,14 @@ data class MutableTyRecord(
         if (fields != other.fields) return false
         if (baseTy != other.baseTy) return false
         if (alias != other.alias) return false
+        if (fieldReferences.frozen != other.fieldReferences.frozen) return false
         return true
     }
     override fun hashCode(): Int {
         var result = fields.hashCode()
         result = 31 * result + (baseTy?.hashCode() ?: 0)
         result = 31 * result + (alias?.hashCode() ?: 0)
+        result = 31 * result + fieldReferences.frozen.hashCode()
         return result
     }
     override fun toString() = "{~${toRecord().toString().drop(1)}"

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -250,12 +250,12 @@ private class InferenceScope(
     private fun toTopLevelResult(ty: Ty, replaceExpressionTypes: Boolean = true): InferenceResult {
         val exprs = when {
             replaceExpressionTypes -> {
-                expressionTypes.mapValues { (_, t) -> TypeReplacement.replace(t, replacements) }
+                expressionTypes.mapValues { (_, t) -> TypeReplacement.replace(t, replacements, freeze = replaceExpressionTypes) }
             }
             else -> expressionTypes
         }
         val outerVars = ancestors.drop(1).flatMap { it.annotationVars.asSequence() }.toList()
-        val ret = TypeReplacement.replace(ty, replacements, outerVars)
+        val ret = TypeReplacement.replace(ty, replacements, outerVars, freeze = replaceExpressionTypes)
         return InferenceResult(exprs, diagnostics, ret)
     }
 


### PR DESCRIPTION
A record's field reference table wasn't participating in equality. This is correct with respect to the fields themselves, but since the frozen status was not part of equality, the replacement code would return the unfrozen record when no other replacement were made. This caused unfrozen tables to be cached, leading to ConcurrentModificationExceptions.