### PR TITLE
Add performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ build/
 out/
 gen/
 dist/
+testData/
 

--- a/src/main/kotlin/org/elm/utils/Timings.kt
+++ b/src/main/kotlin/org/elm/utils/Timings.kt
@@ -1,0 +1,88 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elm.utils
+
+import kotlin.system.measureTimeMillis
+
+class Timings(
+        private val valuesTotal: LinkedHashMap<String, Long> = LinkedHashMap(),
+        private val invokes: MutableMap<String, Long> = mutableMapOf()
+) {
+    fun <T> measure(name: String, f: () -> T): T {
+        check(name !in valuesTotal)
+        return measureInternal(name, f)
+    }
+
+    fun <T> measureAverage(name: String, f: () -> T): T = measureInternal(name, f)
+
+    fun merge(other: Timings): Timings {
+        val values = values()
+        val otherValues = other.values()
+        check(values.isEmpty() || otherValues.isEmpty() || values.size == otherValues.size)
+        val result = Timings()
+        for (k in values.keys.union(otherValues.keys)) {
+            result.valuesTotal[k] =
+                    // https://www.youtube.com/watch?v=vrfYLlR8X8k&feature=youtu.be&t=25m17s
+                    minOf(values.getOrDefault(k, Long.MAX_VALUE), otherValues.getOrDefault(k, Long.MAX_VALUE))
+            result.invokes[k] = 1
+        }
+        return result
+    }
+
+    fun report() {
+        val values = values()
+        if (values.isEmpty()) {
+            println("No metrics recorder")
+            return
+        }
+
+        val width = values.keys.map { it.length }.max()!!
+        for ((k, v) in values) {
+            println("${k.padEnd(width)}: $v ms")
+        }
+        val total = values.values.sum()
+        println("$total ms total.")
+        println()
+    }
+
+    private fun <T> measureInternal(name: String, f: () -> T): T {
+        var result: T? = null
+        val time = measureTimeMillis { result = f() }
+        valuesTotal.merge(name, time, Long::plus)
+        invokes.merge(name, 1, Long::plus)
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    private fun values(): Map<String, Long> {
+        val result = LinkedHashMap<String, Long>()
+        for ((k, sum) in valuesTotal) {
+            result[k] = (sum.toDouble() / invokes[k]!!).toLong()
+        }
+        return result
+    }
+}

--- a/src/test/kotlin/org/elmPerformanceTests/ElmHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmHighlightingPerformanceTest.kt
@@ -43,19 +43,13 @@ class ElmHighlightingPerformanceTest : ElmRealProjectTestBase() {
             repeatTest { highlightProjectFile(SPA, "src/Page/Article/Editor.elm") }
 
     fun `test highlighting elm-css`() =
-            repeatTest { highlightProjectFile(ELM_CSS, "src/Css.elm") }
-
-    fun `test highlighting elm-css 2`() =
             repeatTest { highlightProjectFile(ELM_CSS, "src/Css/Transitions.elm") }
 
     fun `test highlighting elm-list-extra`() =
             repeatTest { highlightProjectFile(LIST_EXTRA, "src/List/Extra.elm") }
 
     fun `test highlighting elm-dev-tools`() =
-            repeatTest { highlightProjectFile(DEV_TOOLS, "src/DevTools.elm") }
-
-    fun `test highlighting platformer`() =
-            repeatTest { highlightProjectFile(PLATFORMER, "src/Tiled/Util.elm") }
+            repeatTest { highlightProjectFile(DEV_TOOLS, "src/Browser/DevTools/Main.elm") }
 
     private fun repeatTest(f: () -> Timings) {
         var result = Timings()

--- a/src/test/kotlin/org/elmPerformanceTests/ElmHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmHighlightingPerformanceTest.kt
@@ -1,0 +1,103 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elmPerformanceTests
+
+import com.intellij.psi.util.PsiModificationTracker
+import org.elm.lang.core.psi.descendantsOfType
+import org.elm.lang.core.resolve.ElmReferenceElement
+import org.elm.utils.Timings
+
+class ElmHighlightingPerformanceTest : ElmRealProjectTestBase() {
+
+    // It is a performance test, but we will measure performance ourselves
+    override fun isPerformanceTest(): Boolean = false
+
+    fun `test highlighting elm-json-tree-view`() =
+            repeatTest { highlightProjectFile(JSON_TREE_VIEW, "src/JsonTree.elm") }
+
+    fun `test highlighting elm-spa-example`() =
+            repeatTest { highlightProjectFile(SPA, "src/Page/Article/Editor.elm") }
+
+    fun `test highlighting elm-css`() =
+            repeatTest { highlightProjectFile(ELM_CSS, "src/Css.elm") }
+
+    fun `test highlighting elm-css 2`() =
+            repeatTest { highlightProjectFile(ELM_CSS, "src/Css/Transitions.elm") }
+
+    fun `test highlighting elm-list-extra`() =
+            repeatTest { highlightProjectFile(LIST_EXTRA, "src/List/Extra.elm") }
+
+    fun `test highlighting elm-dev-tools`() =
+            repeatTest { highlightProjectFile(DEV_TOOLS, "src/DevTools.elm") }
+
+    fun `test highlighting platformer`() =
+            repeatTest { highlightProjectFile(PLATFORMER, "src/Tiled/Util.elm") }
+
+    private fun repeatTest(f: () -> Timings) {
+        var result = Timings()
+        println("${name.substring("test ".length)}:")
+        repeat(10) {
+            result = result.merge(f())
+            tearDown()
+            setUp()
+        }
+        result.report()
+    }
+
+    private fun highlightProjectFile(info: RealProjectInfo, filePath: String): Timings {
+        val timings = Timings()
+        val base = openRealProject(info) ?: return timings
+
+        myFixture.configureFromTempProjectFile(filePath)
+
+        val modificationCount = currentPsiModificationCount()
+
+        val refs = timings.measure("collecting") {
+            myFixture.file.descendantsOfType<ElmReferenceElement>()
+        }
+
+        timings.measure("resolve") {
+            refs.forEach { it.reference.resolve() }
+        }
+        timings.measure("highlighting") {
+            myFixture.doHighlighting()
+        }
+
+        check(modificationCount == currentPsiModificationCount()) {
+            "PSI changed during resolve and highlighting, resolve might be double counted"
+        }
+
+        timings.measure("resolve_cached") {
+            refs.forEach { it.reference.resolve() }
+        }
+
+        return timings
+    }
+
+    private fun currentPsiModificationCount() =
+            PsiModificationTracker.SERVICE.getInstance(project).modificationCount
+}

--- a/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectAnalysisTest.kt
@@ -1,0 +1,117 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elmPerformanceTests
+
+import com.intellij.codeInspection.ex.InspectionToolRegistrar
+import org.elm.ide.inspections.ElmLocalInspection
+import org.elm.lang.core.ElmFileType
+import org.elm.lang.core.psi.ElmFile
+import org.elm.openapiext.toPsiFile
+import org.junit.ComparisonFailure
+import java.lang.reflect.Field
+
+class ElmRealProjectAnalysisTest : ElmRealProjectTestBase() {
+
+    fun `test analyze elm-json-tree-view`() = doTest(JSON_TREE_VIEW)
+    fun `test analyze elm-spa-example`() = doTest(SPA)
+    fun `test analyze elm-css`() = doTest(ELM_CSS)
+    fun `test analyze elm-dev-tools`() = doTest(DEV_TOOLS)
+    fun `test analyze list-extra`() = doTest(LIST_EXTRA)
+
+    /*
+        The 'platformer' project is disabled because it has false-positive
+        type errors. It appears that the code depends on bugs in the
+        Elm compiler's type inference, and AJ concluded that it wasn't
+        worth the trouble to copy the bug behavior.
+
+    fun `test analyze platformer`() = doTest(PLATFORMER)
+    */
+
+    private fun doTest(info: RealProjectInfo, failOnFirstFileWithErrors: Boolean = false) {
+        val inspections = InspectionToolRegistrar.getInstance().createTools()
+                .map { it.tool }
+                .filterIsInstance<ElmLocalInspection>()
+        myFixture.enableInspections(*inspections.toTypedArray())
+
+        println("Opening the project")
+        val base = openRealProject(info) ?: return
+
+        println("Collecting files to analyze")
+        val filesToCheck = base.findDescendants {
+            it.fileType == ElmFileType && run {
+                val file = it.toPsiFile(project)
+                file is ElmFile && file.elmProject != null
+            }
+        }
+
+        if (failOnFirstFileWithErrors) {
+            println("Analyzing...")
+            myFixture.testHighlightingAllFiles(
+                    /* checkWarnings = */ false,
+                    /* checkInfos = */ false,
+                    /* checkWeakWarnings = */ false,
+                    *filesToCheck.toTypedArray()
+            )
+        } else {
+            val exceptions = filesToCheck.mapNotNull { file ->
+                val path = file.path.substring(base.path.length + 1)
+                println("Analyzing $path")
+                try {
+                    myFixture.testHighlighting(
+                            /* checkWarnings = */ false,
+                            /* checkInfos = */ false,
+                            /* checkWeakWarnings = */ false,
+                            file
+                    )
+                    null
+                } catch (e: ComparisonFailure) {
+                    e to path
+                }
+            }
+
+            if (exceptions.isNotEmpty()) {
+                error("Error annotations found:\n\n" + exceptions.joinToString("\n\n") { (e, path) ->
+                    "$path:\n${e.detailMessage}"
+                })
+            }
+        }
+    }
+}
+
+private val THROWABLE_DETAILED_MESSAGE_FIELD: Field = run {
+    val field = Throwable::class.java.getDeclaredField("detailMessage")
+    field.isAccessible = true
+    field
+}
+
+/**
+ * Retrieves original value of detailMessage field of [Throwable] class.
+ * It is needed because [ComparisonFailure] overrides [Throwable.message]
+ * method so we can't get the original value without reflection
+ */
+private val Throwable.detailMessage: CharSequence
+    get() = THROWABLE_DETAILED_MESSAGE_FIELD.get(this) as CharSequence

--- a/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectAnalysisTest.kt
@@ -34,22 +34,23 @@ import org.elm.openapiext.toPsiFile
 import org.junit.ComparisonFailure
 import java.lang.reflect.Field
 
+/**
+ * Smoke-test the plugin by evaluating it against a variety of real-world Elm projects.
+ * Assuming that the projects you are testing are well-formed, these tests will detect
+ * any false-positive errors caused by bugs in:
+ *
+ * - the parser
+ * - the unresolved reference inspector
+ * - the type checker
+ */
 class ElmRealProjectAnalysisTest : ElmRealProjectTestBase() {
 
-    fun `test analyze elm-json-tree-view`() = doTest(JSON_TREE_VIEW)
-    fun `test analyze elm-spa-example`() = doTest(SPA)
     fun `test analyze elm-css`() = doTest(ELM_CSS)
     fun `test analyze elm-dev-tools`() = doTest(DEV_TOOLS)
-    fun `test analyze list-extra`() = doTest(LIST_EXTRA)
-
-    /*
-        The 'platformer' project is disabled because it has false-positive
-        type errors. It appears that the code depends on bugs in the
-        Elm compiler's type inference, and AJ concluded that it wasn't
-        worth the trouble to copy the bug behavior.
-
-    fun `test analyze platformer`() = doTest(PLATFORMER)
-    */
+    fun `test analyze elm-json-tree-view`() = doTest(JSON_TREE_VIEW)
+    fun `test analyze elm-list-extra`() = doTest(LIST_EXTRA)
+    fun `test analyze elm-physics`() = doTest(ELM_PHYSICS)
+    fun `test analyze elm-spa-example`() = doTest(SPA)
 
     private fun doTest(info: RealProjectInfo, failOnFirstFileWithErrors: Boolean = false) {
         val inspections = InspectionToolRegistrar.getInstance().createTools()

--- a/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectTestBase.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectTestBase.kt
@@ -1,0 +1,109 @@
+/*
+The MIT License (MIT)
+
+Derived from intellij-rust
+Copyright (c) 2015 Aleksey Kladov, Evgeny Kurbatsky, Alexey Kudinkin and contributors
+Copyright (c) 2016 JetBrains
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+package org.elmPerformanceTests
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.vfs.*
+import com.intellij.util.ui.UIUtil
+import org.elm.openapiext.fullyRefreshDirectory
+import org.elm.workspace.ElmToolchain
+import org.elm.workspace.ElmWorkspaceTestBase
+import org.elm.workspace.elmWorkspace
+
+abstract class ElmRealProjectTestBase : ElmWorkspaceTestBase() {
+
+    protected fun openRealProject(info: RealProjectInfo): VirtualFile? {
+        val base = openRealProject("testData/${info.path}", info.exclude)
+        if (base == null) {
+            val name = info.name
+            println("SKIP $name: git clone ${info.gitUrl} testData/$name")
+            return null
+        }
+        return base
+    }
+
+    private fun openRealProject(path: String, exclude: List<String> = emptyList()): VirtualFile? {
+        val projectDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(path)
+                ?: return null
+
+        fun isAppropriate(file: VirtualFile): Boolean {
+            val relativePath = file.path.substring(projectDir.path.length + 1)
+            // 1. Ignore excluded files
+            if (exclude.any { relativePath.startsWith(it) }) return false
+            // 2. Ignore hidden files
+            if (file.name.startsWith(".")) return false
+
+            // Otherwise, analyse it
+            return true
+        }
+
+        runWriteAction {
+            fullyRefreshDirectoryInUnitTests(projectDir)
+            VfsUtil.copyDirectory(this, projectDir, elmWorkspaceDirectory, ::isAppropriate)
+            fullyRefreshDirectoryInUnitTests(elmWorkspaceDirectory)
+        }
+
+        project.elmWorkspace.asyncDiscoverAndRefresh()
+        UIUtil.dispatchAllInvocationEvents()
+        return elmWorkspaceDirectory
+    }
+
+    class RealProjectInfo(
+            val name: String,
+            val path: String,
+            val gitUrl: String,
+            val exclude: List<String> = emptyList()
+    )
+
+    companion object {
+        val SPA = RealProjectInfo("elm-spa-example", "elm-spa-example", "https://github.com/rtfeldman/elm-spa-example")
+        val PLATFORMER = RealProjectInfo("platformer", "platformer", "https://github.com/justgook/platformer")
+        val ELM_CSS = RealProjectInfo("elm-css", "elm-css", "https://github.com/rtfeldman/elm-css")
+        val LIST_EXTRA = RealProjectInfo("elm-list-extra", "elm-list-extra", "https://github.com/elm-community/list-extra")
+        val JSON_TREE_VIEW = RealProjectInfo("elm-json-tree-view", "elm-json-tree-view", "https://github.com/klazuka/elm-json-tree-view")
+        val DEV_TOOLS = RealProjectInfo("elm-dev-tools", "elm-dev-tools", "https://github.com/opvasger/elm-dev-tools")
+    }
+}
+
+fun VirtualFile.findDescendants(filter: (VirtualFile) -> Boolean): ArrayList<VirtualFile> {
+    val result = ArrayList<VirtualFile>()
+    VfsUtilCore.visitChildrenRecursively(this,
+            object : VirtualFileVisitor<ArrayList<VirtualFile>>() {
+                override fun visitFile(file: VirtualFile): Boolean {
+                    if (!file.isDirectory && filter(file)) result.add(file)
+                    return true
+                }
+            })
+    return result
+}
+
+fun fullyRefreshDirectoryInUnitTests(directory: VirtualFile) {
+    // It's very weird, but real refresh occurs only if
+    // we touch file names. At least in the test environment
+    VfsUtilCore.iterateChildrenRecursively(directory, null) { it.name; true }
+    fullyRefreshDirectory(directory)
+}

--- a/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectTestBase.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmRealProjectTestBase.kt
@@ -30,7 +30,6 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.vfs.*
 import com.intellij.util.ui.UIUtil
 import org.elm.openapiext.fullyRefreshDirectory
-import org.elm.workspace.ElmToolchain
 import org.elm.workspace.ElmWorkspaceTestBase
 import org.elm.workspace.elmWorkspace
 
@@ -81,8 +80,8 @@ abstract class ElmRealProjectTestBase : ElmWorkspaceTestBase() {
 
     companion object {
         val SPA = RealProjectInfo("elm-spa-example", "elm-spa-example", "https://github.com/rtfeldman/elm-spa-example")
-        val PLATFORMER = RealProjectInfo("platformer", "platformer", "https://github.com/justgook/platformer")
-        val ELM_CSS = RealProjectInfo("elm-css", "elm-css", "https://github.com/rtfeldman/elm-css")
+        val ELM_CSS = RealProjectInfo("elm-css", "elm-css", "https://github.com/rtfeldman/elm-css", exclude = listOf("src/DEPRECATED", "tests"))
+        val ELM_PHYSICS = RealProjectInfo("elm-physics", "elm-physics", "https://github.com/w0rm/elm-physics")
         val LIST_EXTRA = RealProjectInfo("elm-list-extra", "elm-list-extra", "https://github.com/elm-community/list-extra")
         val JSON_TREE_VIEW = RealProjectInfo("elm-json-tree-view", "elm-json-tree-view", "https://github.com/klazuka/elm-json-tree-view")
         val DEV_TOOLS = RealProjectInfo("elm-dev-tools", "elm-dev-tools", "https://github.com/opvasger/elm-dev-tools")


### PR DESCRIPTION
These tests are optional as they depend on having some projects checked-out
in the `testData` directory. But if there are Elm projects there, it will kick-the-tires
and make sure that there are no false positives in:
- parser
- unresolved reference inspection
- type checker inspection

We probably should arrange things on the CI server so that it downloads the example projects automatically.

It also provides some code for measuring how long it takes to parse a file,
syntax highlight it, and resolve all references. The perf numbers are just emitted
to the console—we don't actually do any baseline/regression testing yet.