### PR TITLE
Fix several cache invalidation bugs

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
@@ -58,7 +58,7 @@ class ElmPsiManager(val project: Project) : ProjectComponent {
                 modificationTracker.incModificationCount()
                 return
             }
-            
+
             if (file?.fileType != ElmFileType) return
             if (element is PsiComment || element is PsiWhiteSpace) return
 

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
@@ -52,11 +52,14 @@ class ElmPsiManager(val project: Project) : ProjectComponent {
         }
 
         private fun onPsiChange(event: PsiTreeChangeEvent, element: PsiElement) {
-            // There are some cases when PsiFile stored in the event as a child
-            // e.g. file removal by external VFS change
-            val file = event.file ?: event.child as? PsiFile
+            // If the file is null, then this is an event about VFS changes
+            val file = event.file
+            if (file == null && (element is ElmFile || element is PsiDirectory)) {
+                modificationTracker.incModificationCount()
+                return
+            }
+            
             if (file?.fileType != ElmFileType) return
-
             if (element is PsiComment || element is PsiWhiteSpace) return
 
             updateModificationCount(element)

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiManager.kt
@@ -7,15 +7,23 @@
 
 package org.elm.lang.core.psi
 
+import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.*
+import com.intellij.psi.PsiTreeChangeEvent.PROP_WRITABLE
 import com.intellij.psi.impl.PsiTreeChangeEventImpl
+import com.intellij.psi.util.PsiModificationTracker
 import org.elm.lang.core.ElmFileType
-import org.elm.lang.core.psi.elements.ElmValueDeclaration
 
 class ElmPsiManager(val project: Project) : ProjectComponent {
+    /**
+     * A modification tracker that is incremented on PSI changes that can affect non-local references or inference.
+     *
+     * It is incremented whenever a non-whitespace, non-comment change is made to the PSI of an Elm
+     * file outside of function bodies.
+     */
     val modificationTracker = SimpleModificationTracker()
 
     override fun projectOpened() {
@@ -23,18 +31,27 @@ class ElmPsiManager(val project: Project) : ProjectComponent {
     }
 
     inner class CacheInvalidator : PsiTreeChangeAdapter() {
-        override fun beforeChildRemoval(event: PsiTreeChangeEvent) = onPsiChange(event)
-        override fun childReplaced(event: PsiTreeChangeEvent) = onPsiChange(event)
-        override fun childAdded(event: PsiTreeChangeEvent) = onPsiChange(event)
-        override fun childrenChanged(event: PsiTreeChangeEvent) = onPsiChange(event)
-        override fun childMoved(event: PsiTreeChangeEvent) = onPsiChange(event)
-        override fun propertyChanged(event: PsiTreeChangeEvent) = onPsiChange(event)
-
-        private fun onPsiChange(event: PsiTreeChangeEvent) {
+        override fun beforeChildRemoval(event: PsiTreeChangeEvent) = onPsiChange(event, event.child)
+        override fun beforeChildReplacement(event: PsiTreeChangeEvent) = onPsiChange(event, event.oldChild)
+        override fun beforeChildMovement(event: PsiTreeChangeEvent) = onPsiChange(event, event.child)
+        override fun childReplaced(event: PsiTreeChangeEvent) = onPsiChange(event, event.newChild)
+        override fun childAdded(event: PsiTreeChangeEvent) = onPsiChange(event, event.child)
+        override fun childMoved(event: PsiTreeChangeEvent) = onPsiChange(event, event.child)
+        override fun childrenChanged(event: PsiTreeChangeEvent) {
             // `GenericChange` event means that "something changed in the file" and sends
             // after all events for concrete PSI changes in a file.
-            // We handle more concrete events and so should ignore generic event
-            if (event is PsiTreeChangeEventImpl && event.isGenericChange) return
+            // We handle more concrete events and so should ignore the generic event.
+            if (event !is PsiTreeChangeEventImpl || !event.isGenericChange) onPsiChange(event, event.parent)
+        }
+
+        override fun propertyChanged(event: PsiTreeChangeEvent) {
+            if (event.propertyName != PROP_WRITABLE && event.element != null) {
+                onPsiChange(event, event.element)
+            }
+        }
+
+        private fun onPsiChange(event: PsiTreeChangeEvent, element: PsiElement) {
+
 
             // There are some cases when PsiFile stored in the event as a child
             // e.g. file removal by external VFS change
@@ -48,9 +65,8 @@ class ElmPsiManager(val project: Project) : ProjectComponent {
         }
 
         private fun updateModificationCount(element: PsiElement) {
-            // If something is changed inside a function, we will only
-            // increment the function local modification counter. Otherwise, we will increment the
-            // global modification counter.
+            // If something is changed inside a function, we will only increment the function local
+            // modification counter. Otherwise, we will increment the global modification counter.
 
             val owner = element.outermostDeclaration(strict = true)
             if (owner == null) {
@@ -65,5 +81,23 @@ class ElmPsiManager(val project: Project) : ProjectComponent {
 private val Project.elmPsiManager: ElmPsiManager
     get() = getComponent(ElmPsiManager::class.java)
 
+/** @see ElmPsiManager.modificationTracker */
 val Project.modificationTracker: SimpleModificationTracker
     get() = elmPsiManager.modificationTracker
+
+/**
+ * Return [ElmPsiManager.modificationTracker], or [PsiModificationTracker.MODIFICATION_COUNT] if
+ * this element is in a language injection.
+ */
+val ElmPsiElement.globalModificationTracker: Any
+    get() = elmFile.globalModificationTracker
+
+val ElmFile.globalModificationTracker: Any
+    get() = when (virtualFile) {
+        // If the element is in a language injection (e.g. a Kotlin string literal with Elm
+        // injected, like we use in this project's tests), then we are never notified of PSI
+        // change events in the injected code; we have to invalidate the cache after any PSI
+        // change in the project.
+        is VirtualFileWindow -> PsiModificationTracker.MODIFICATION_COUNT
+        else -> project.modificationTracker
+    }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -8,6 +8,7 @@ import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
+import org.elm.lang.core.psi.globalModificationTracker
 import org.elm.lang.core.psi.modificationTracker
 
 private val DECLARED_VALUES_KEY: Key<CachedValue<List<ElmNamedElement>>> = Key.create("DECLARED_VALUES_KEY")
@@ -116,7 +117,7 @@ object ModuleScope {
             }
             val values = listOf(valueDecls, elmFile.getPortAnnotations(), elmFile.getInfixDeclarations())
                     .flatten()
-            Result.create(values, elmFile.project.modificationTracker)
+            Result.create(values, elmFile.globalModificationTracker)
         }
     }
 
@@ -134,7 +135,7 @@ object ModuleScope {
                     .map { it.element }
 
             val visibleValues = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
-            Result.create(visibleValues, elmFile.project.modificationTracker)
+            Result.create(visibleValues, elmFile.globalModificationTracker)
         }
     }
 
@@ -151,7 +152,7 @@ object ModuleScope {
                     .map { it.element }
 
             val visibleValues = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
-            Result.create(visibleValues, elmFile.project.modificationTracker)
+            Result.create(visibleValues, elmFile.globalModificationTracker)
         }
     }
 
@@ -168,7 +169,7 @@ object ModuleScope {
                     .map { it.element }
 
             val visibleValues = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
-            Result.create(visibleValues, elmFile.project.modificationTracker)
+            Result.create(visibleValues, elmFile.globalModificationTracker)
         }
     }
 
@@ -185,7 +186,7 @@ object ModuleScope {
                     .map { it.element }
 
             val visibleValues = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
-            Result.create(visibleValues, elmFile.project.modificationTracker)
+            Result.create(visibleValues, elmFile.globalModificationTracker)
         }
     }
 
@@ -242,7 +243,7 @@ object ModuleScope {
         return CachedValuesManager.getCachedValue(elmFile, DECLARED_TYPES_KEY) {
             val declaredTypes = (elmFile.getTypeDeclarations() as List<ElmNamedElement>) +
                     (elmFile.getTypeAliasDeclarations() as List<ElmNamedElement>)
-            Result.create(declaredTypes, elmFile.project.modificationTracker)
+            Result.create(declaredTypes, elmFile.globalModificationTracker)
         }
     }
 
@@ -254,7 +255,7 @@ object ModuleScope {
             val fromImports = elmFile.getImportClauses()
                     .flatMap { getVisibleImportTypes(it) }
             val names = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
-            Result.create(names, elmFile.project.modificationTracker)
+            Result.create(names, elmFile.globalModificationTracker)
         }
     }
 
@@ -285,7 +286,7 @@ object ModuleScope {
                     elmFile.getTypeDeclarations().flatMap { it.unionVariantList },
                     elmFile.getTypeAliasDeclarations().filter { it.isRecordAlias }
             ).flatten()
-            Result.create(declaredConstructors, elmFile.project.modificationTracker)
+            Result.create(declaredConstructors, elmFile.globalModificationTracker)
         }
     }
 
@@ -297,7 +298,7 @@ object ModuleScope {
             val fromImports = elmFile.getImportClauses()
                     .flatMap { getVisibleImportConstructors(it) }
             val names = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
-            Result.create(names, elmFile.project.modificationTracker)
+            Result.create(names, elmFile.globalModificationTracker)
         }
 
     }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -27,7 +27,7 @@ private val TY_VARIANT_CACHE_KEY: Key<CachedValue<ParameterizedInferenceResult<V
 fun ElmTypeDeclaration.typeExpressionInference(): ParameterizedInferenceResult<TyUnion> {
     val cachedValue = CachedValuesManager.getCachedValue(this, TY_UNION_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = false).beginTypeDeclarationInference(this)
-        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+        CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     }
     return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true) as TyUnion)
 }
@@ -37,7 +37,7 @@ fun ElmTypeAliasDeclaration.typeExpressionInference(): ParameterizedInferenceRes
 private fun ElmTypeAliasDeclaration.typeExpressionInference(activeAliases: MutableSet<ElmTypeAliasDeclaration>): ParameterizedInferenceResult<Ty> {
     val cachedValue = CachedValuesManager.getManager(project).getParameterizedCachedValue(this, TY_ALIAS_CACHE_KEY, { useActiveAliases ->
         val inferenceResult = TypeExpression(this, rigidVars = false, activeAliases = useActiveAliases).beginTypeAliasDeclarationInference(this)
-        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+        CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     },  /*trackValue*/ false, /*parameter*/ activeAliases)
     return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true))
 }
@@ -46,7 +46,7 @@ private fun ElmTypeAliasDeclaration.typeExpressionInference(activeAliases: Mutab
 fun ElmPortAnnotation.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
     val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = false).beginPortAnnotationInference(this)
-        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+        CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     }
     return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true))
 }
@@ -54,7 +54,7 @@ fun ElmPortAnnotation.typeExpressionInference(): ParameterizedInferenceResult<Ty
 fun ElmUnionVariant.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
     val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = false).beginUnionConstructorInference(this)
-        CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+        CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     }
     return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true))
 }
@@ -77,8 +77,8 @@ fun ElmTypeAnnotation.typeExpressionInference(rigid: Boolean = true): InferenceR
         val frozenResult =  inferenceResult.copy(ty = TypeReplacement.freeze(inferenceResult.ty))
 
         val trackers = when (parentModificationTracker) {
-            null -> arrayOf(project.modificationTracker)
-            else -> arrayOf(project.modificationTracker, parentModificationTracker)
+            null -> arrayOf(globalModificationTracker)
+            else -> arrayOf(globalModificationTracker, parentModificationTracker)
         }
 
         CachedValueProvider.Result.create(frozenResult, *trackers)
@@ -97,7 +97,7 @@ fun ElmTypeAnnotation.typeExpressionInference(rigid: Boolean = true): InferenceR
 fun ElmTypeDeclaration.variantInference(): ParameterizedInferenceResult<VariantParameters> =
         CachedValuesManager.getCachedValue(this, TY_VARIANT_CACHE_KEY) {
             val inferenceResult = TypeExpression(this, rigidVars = false).beginUnionVariantsInference(this)
-            CachedValueProvider.Result.create(inferenceResult, project.modificationTracker)
+            CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
         }
 
 /**

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -235,14 +235,13 @@ private fun Map<String, Constraint>.constraintDepsToPackages(repo: ElmPackageRep
         map { (name, constraint) ->
             val version = repo.availableVersionsForPackage(name)
                     .filter { constraint.contains(it) }
-                    .sorted()
-                    .firstOrNull()
+                    .min()
                     ?: throw ProjectLoadException("Could not load $name ($constraint). Is it installed?")
 
             loadDependency(repo, name, version)
         }
 
-fun loadDependency(repo: ElmPackageRepository, name: String, version: Version): ElmPackageProject {
+private fun loadDependency(repo: ElmPackageRepository, name: String, version: Version): ElmPackageProject {
     val manifestPath = repo.findPackageManifest(name, version)
             ?: throw ProjectLoadException("Could not load $name ($version): manifest not found")
     // TODO [kl] guard against circular dependencies
@@ -257,7 +256,7 @@ fun loadDependency(repo: ElmPackageRepository, name: String, version: Version): 
 
 
 // TODO [drop 0.18] remove me
-fun loadPackageLegacy(elmStuffPath: Path, name: String, version: Version): ElmPackageProject {
+private fun loadPackageLegacy(elmStuffPath: Path, name: String, version: Version): ElmPackageProject {
     val manifestPath =
             elmStuffPath.resolve("packages")
                     .resolve(name)

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -1,6 +1,5 @@
 package org.elm.workspace
 
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
@@ -12,9 +11,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-
-private val log = Logger.getInstance(ElmToolchain::class.java)
-
 
 data class ElmToolchain(
         val elmCompilerPath: Path?,

--- a/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
@@ -1,0 +1,151 @@
+package org.elm.lang.core.psi
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+import org.elm.fileTreeFromText
+import org.elm.lang.ElmTestBase
+import org.elm.lang.core.psi.ElmGlobalModificationTrackerTest.TestAction.INC
+import org.intellij.lang.annotations.Language
+
+internal class ElmGlobalModificationTrackerTest : ElmTestBase() {
+    fun `test comment`() = doTest(TestAction.NOT_INC, """
+-- {-caret-}
+""")
+
+    fun `test function`() = doTest(INC, """
+{-caret-}
+""", "main = ()")
+
+    fun `test unannotated function name`() = doTest(INC, """
+main{-caret-} = ()
+""")
+
+    fun `test unannotated function params`() = doTest(INC, """
+main a {-caret-} = ()
+""")
+
+    fun `test unannotated function body`() = doTest(INC, """
+main = {-caret-}
+""", "()")
+
+    fun `test annotation`() = doTest(INC, """
+main : () -> {-caret-}
+main a = a
+""", "()")
+
+    fun `test annotated function name`() = doTest(INC, """
+main : ()
+main{-caret-} = ()
+""")
+
+    fun `test annotated function params`() = doTest(TestAction.NOT_INC, """
+main : () -> ()
+main a {-caret-} = ()
+""")
+
+    fun `test annotated function body`() = doTest(TestAction.NOT_INC, """
+main : ()
+main = {-caret-}
+""", "()")
+
+    fun `test nested function name in annotated parent`() = doTest(TestAction.NOT_INC, """
+main : ()
+main = 
+    let
+        foo{-caret-} = ()
+    in
+    foo
+""", "()")
+
+    fun `test nested function body in annotated parent`() = doTest(TestAction.NOT_INC, """
+main : ()
+main = 
+    let
+        foo = {-caret-}
+    in
+    foo
+""", "()")
+
+    fun `test type`() = doTest(INC, """
+type T = T {-caret-}
+""")
+
+    fun `test type alias`() = doTest(INC, """
+type alias R = { {-caret-} }
+""")
+
+    fun `test replace function with comment`() = doTest(INC, """
+main : ()
+{-caret-}main = ()
+""", "-- ")
+
+
+    fun `test vfs file change`() = doVfsTest(INC, """
+--@ Main.elm
+import Foo exposing (..)
+--^
+--@ Foo.elm
+module Foo exposing (..)
+-- foo = ()
+""") { file ->
+        VfsUtil.saveText(file, VfsUtil.loadText(file).replace("--", ""))
+    }
+
+    fun `test vfs file removal`() = doVfsTest(INC, """
+--@ Main.elm
+import Foo exposing (..)
+--^
+--@ Foo.elm
+module Foo exposing (..)
+foo = ()
+""") { file ->
+        file.delete(null)
+    }
+
+    fun `test vfs file rename`() = doVfsTest(INC, """
+--@ Main.elm
+import Foo exposing (..)
+--^
+--@ Foo.elm
+module Foo exposing (..)
+foo = ()
+""") { file ->
+        file.rename(null, "Bar.elm")
+    }
+
+    private enum class TestAction(val function: (Long, Long) -> Boolean, val comment: String) {
+        INC({ a, b -> a > b }, "Modification counter expected to be incremented, but it remained the same"),
+        NOT_INC({ a, b -> a == b }, "Modification counter expected to remain the same, but it was incremented")
+    }
+
+    private fun checkModCount(op: TestAction, action: () -> Unit) {
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        val modTracker = project.modificationTracker
+        val oldCount = modTracker.modificationCount
+        action()
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        check(op.function(modTracker.modificationCount, oldCount)) { op.comment }
+    }
+
+    private fun checkModCount(op: TestAction, @Language("Elm") code: String, text: String) {
+        InlineFile(code).withCaret()
+        checkModCount(op) { myFixture.type(text) }
+    }
+
+    private fun doTest(op: TestAction, @Language("Elm") code: String, text: String = "a") {
+        checkModCount(op, code, text)
+    }
+
+    private fun doVfsTest(op: TestAction, @Language("Elm") code: String, filename: String = "Foo.elm", action: (VirtualFile) -> Unit) {
+        val p = fileTreeFromText(code).createAndOpenFileWithCaretMarker()
+        val file = p.psiFile(filename).virtualFile!!
+        checkModCount(op) {
+            runWriteAction {
+                file.delete(null)
+            }
+        }
+    }
+}
+

--- a/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
@@ -52,7 +52,7 @@ main = {-caret-}
 
     fun `test nested function name in annotated parent`() = doTest(TestAction.NOT_INC, """
 main : ()
-main = 
+main =
     let
         foo{-caret-} = ()
     in
@@ -61,7 +61,7 @@ main =
 
     fun `test nested function body in annotated parent`() = doTest(TestAction.NOT_INC, """
 main : ()
-main = 
+main =
     let
         foo = {-caret-}
     in

--- a/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
@@ -115,6 +115,17 @@ foo = ()
         file.rename(null, "Bar.elm")
     }
 
+    fun `test vfs directory removal`() = doVfsTest(INC, """
+--@ Main.elm
+import Foo.Bar exposing (..)
+--^
+--@ Foo/Bar.elm
+module Bar exposing (..)
+foo = ()
+""", "Foo") { file ->
+        file.delete(null)
+    }
+
     private enum class TestAction(val function: (Long, Long) -> Boolean, val comment: String) {
         INC({ a, b -> a > b }, "Modification counter expected to be incremented, but it remained the same"),
         NOT_INC({ a, b -> a == b }, "Modification counter expected to remain the same, but it was incremented")

--- a/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerWorkspaceTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerWorkspaceTest.kt
@@ -1,0 +1,38 @@
+package org.elm.lang.core.psi
+
+import org.elm.fileTree
+import org.elm.workspace.ElmWorkspaceTestBase
+import org.elm.workspace.elmWorkspace
+
+internal class ElmGlobalModificationTrackerWorkspaceTest : ElmWorkspaceTestBase() {
+    fun `test mod count incremented on workspace refresh`() {
+        fileTree {
+            dir("a") {
+                project("elm.json", """
+                    {
+                      "type": "application",
+                      "source-directories": [ "src" ],
+                      "elm-version": "0.19.0",
+                      "dependencies": {
+                        "direct": {},
+                        "indirect": {}
+                      },
+                      "test-dependencies": {
+                        "direct": {},
+                        "indirect": {}
+                      }
+                    }
+                    """)
+                dir("src") {
+                    elm("Main.elm", "")
+                }
+            }
+        }.create(project, elmWorkspaceDirectory)
+
+        val modTracker = project.modificationTracker
+        val oldCount = modTracker.modificationCount
+        project.elmWorkspace.asyncRefreshAllProjects().get()
+        check(modTracker.modificationCount > oldCount)
+    }
+}
+


### PR DESCRIPTION
- Language injections don't have an event system, so we need to invalidate their contents on any PSI change
- Invalidate globally when the body of an unannotated top-level function changes, since that can change the return type or parameters
- Invalidate globally when a VFS directory is deleted