### PR TITLE
Ignore nested functions named 'main' when finding entry point

### DIFF
--- a/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
@@ -18,7 +18,9 @@ import org.elm.lang.core.lookup.ClientLocation
 import org.elm.lang.core.lookup.ElmLookup
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
-import org.elm.lang.core.types.*
+import org.elm.lang.core.types.TyUnion
+import org.elm.lang.core.types.TyUnknown
+import org.elm.lang.core.types.findTy
 import org.elm.openapiext.isUnitTestMode
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.saveAllDocuments
@@ -88,7 +90,7 @@ class ElmBuildAction : AnAction() {
                             is TyUnknown -> ty.alias?.let { it.module to it.name }
                             else -> null
                         }
-                        key != null && key in elmMainTypes
+                        key != null && key in elmMainTypes && decl.isTopLevel
                     }
 
     private fun findActiveFile(e: AnActionEvent, project: Project): VirtualFile? =

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -1,13 +1,9 @@
 package org.elm.ide.actions
 
-import com.intellij.notification.Notification
-import com.intellij.notification.Notifications
-import com.intellij.notification.NotificationsAdapter
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.command.undo.UndoManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.util.Ref
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.TestActionEvent
@@ -148,16 +144,6 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
         val event = TestActionEvent(dataContext, action)
         action.beforeActionPerformedUpdate(event)
         return Pair(action, event)
-    }
-
-    private fun connectToBusAndGetNotificationRef(): Ref<Notification> {
-        val notificationRef = Ref<Notification>()
-        project.messageBus.connect(testRootDisposable).subscribe(Notifications.TOPIC,
-                object : NotificationsAdapter() {
-                    override fun notify(notification: Notification) =
-                            notificationRef.set(notification)
-                })
-        return notificationRef
     }
 
 }


### PR DESCRIPTION
@dprophete reported on Slack that the Elm compiler panel was producing inconsistent/confusing results. The root cause was that he had a function with a `let/in` where it declared a nested function named `main` of type `Html`. Our code thought this nested function was `main`, sometimes.