### PR TITLE
Improve placeholder for parameters of Maybe type

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -119,16 +119,18 @@ fun Ty.renderParam(): String {
     }
 }
 
-fun TyUnion.renderParam(): String =
-        when {
-            this.isTyList ->
-                when (val p = parameters.singleOrNull()) {
-                    is TyUnion -> StringUtil.pluralize(p.name)
-                    is TyRecord, is MutableTyRecord -> p.alias?.name?.let { StringUtil.pluralize(it) } ?: "list"
-                    else -> "list"
-                }
-            else -> name
-        }.toElmLowerId()
+fun TyUnion.renderParam(): String {
+    val singleParam = when (val p = parameters.singleOrNull()) {
+        is TyUnion -> p.name
+        is TyRecord, is MutableTyRecord -> p.alias?.name
+        else -> null
+    }
+    return when {
+        isTyList -> singleParam?.let { StringUtil.pluralize(it) } ?: "list"
+        module == "Maybe" && name == "Maybe" -> singleParam?.let { "maybe$it" } ?: "maybe"
+        else -> name
+    }.toElmLowerId()
+}
 
 fun TyTuple.renderParam(): String =
         types.joinToString(", ", prefix = "(", postfix = ")") { it.renderParam() }

--- a/src/test/kotlin/org/elm/ide/inspections/import/MakeDeclarationFixTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/import/MakeDeclarationFixTest.kt
@@ -99,4 +99,18 @@ f : List User -> List Color -> Int
 f users colors =
     {-caret-}
 """)
+
+    fun `test maybe parameters`() = checkFixByText("Create",
+            """
+type Color = Red | Green | Blue
+type alias User = { name : String }
+f : Maybe User -> Maybe Color -> Int{-caret-}
+"""
+            , """
+type Color = Red | Green | Blue
+type alias User = { name : String }
+f : Maybe User -> Maybe Color -> Int
+f maybeUser maybeColor =
+    {-caret-}
+""")
 }


### PR DESCRIPTION
Following on #528, I think it would also be useful to add a case for `Maybe`.