### PR TITLE
Use Elm 0.19.1 for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,10 @@ jobs:
       -   run:
               name: Installing Elm toolchain
               command: |
-                  wget "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz"
-                  tar zxvf binaries-for-linux.tar.gz
-                  sudo mv elm /usr/local/bin/
+                  wget "https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz"
+                  gunzip binary-for-linux-64-bit
+                  chmod +x binary-for-linux-64-bit
+                  sudo mv binary-for-linux-64-bit /usr/local/bin/elm
                   elm --version
 
       -   run:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
             vmImage: 'ubuntu-latest'
         steps:
             -   script: |
-                    wget -q https://github.com/elm/compiler/releases/download/0.19.0/binary-for-linux-64-bit.gz
+                    wget -q https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz
                     gunzip binary-for-linux-64-bit.gz
                     chmod +x binary-for-linux-64-bit
                     sudo mv binary-for-linux-64-bit /usr/local/bin/elm

--- a/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
+++ b/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
@@ -165,7 +165,7 @@ val elmJson = """
         "source-directories": [
             "src"
         ],
-        "elm-version": "0.19.0",
+        "elm-version": "0.19.1",
         "dependencies": {
             "direct": {
                 "elm/browser": "1.0.1",

--- a/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
@@ -80,7 +80,7 @@ object ElmSuggest {
     private fun suggestionsFromPath(): Sequence<Path> {
         return System.getenv("PATH").orEmpty()
                 .splitToSequence(File.pathSeparator)
-                .filter { !it.isEmpty() }
+                .filter { it.isNotEmpty() }
                 .map { Paths.get(it.trim()) }
                 .filter { it.isDirectory() }
     }
@@ -97,15 +97,14 @@ object ElmSuggest {
 
     private fun suggestionsForWindows(): Sequence<Path> {
         if (!SystemInfo.isWindows) return emptySequence()
-        return sequenceOf(
-                Paths.get("C:/Program Files (x86)/Elm Platform/0.19/bin"), // npm install -g elm
-                Paths.get("C:/Program Files/Elm Platform/0.19/bin"),
-                Paths.get("C:/Program Files (x86)/Elm/0.19/bin"), // choco install elm-platform
-                Paths.get("C:/Program Files/Elm/0.19/bin"),
-                Paths.get("C:/Program Files (x86)/Elm Platform/0.18/bin"), // TODO [drop 0.18]
-                Paths.get("C:/Program Files/Elm Platform/0.18/bin"),
-                Paths.get("C:/Program Files (x86)/Elm/0.18/bin"), // TODO [drop 0.18]
-                Paths.get("C:/Program Files/Elm/0.18/bin")
-        )
+        return sequenceOf("0.19.1", "0.19", "0.18") // TODO [drop 0.18]
+                .flatMap {
+                    sequenceOf(
+                            Paths.get("C:/Program Files (x86)/Elm Platform/$it/bin"), // npm install -g elm
+                            Paths.get("C:/Program Files/Elm Platform/$it/bin"),
+                            Paths.get("C:/Program Files (x86)/Elm/$it/bin"), // choco install elm-platform
+                            Paths.get("C:/Program Files/Elm/$it/bin")
+                    )
+                }
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmSuggest.kt
@@ -81,7 +81,7 @@ object ElmSuggest {
         return System.getenv("PATH").orEmpty()
                 .splitToSequence(File.pathSeparator)
                 .filter { !it.isEmpty() }
-                .map { Paths.get(it) }
+                .map { Paths.get(it.trim()) }
                 .filter { it.isDirectory() }
     }
 

--- a/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
@@ -58,7 +58,7 @@ class ElmCreateFileActionTest : ElmWorkspaceTestBase() {
                         "vendor/elm-foo",
                         "./foo1"
                     ],
-                    "elm-version": "0.19.0",
+                    "elm-version": "0.19.1",
                     "dependencies":      { "direct": {}, "indirect": {} },
                     "test-dependencies": { "direct": {}, "indirect": {} }
                 }

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -156,7 +156,7 @@ private val manifestElm19 = """
             "source-directories": [
                 "src"
             ],
-            "elm-version": "0.19.0",
+            "elm-version": "0.19.1",
             "dependencies": {
                 "direct": {},
                 "indirect": {}

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -179,7 +179,7 @@ private val manifestElm19 = """
             "source-directories": [
                 "src"
             ],
-            "elm-version": "0.19.0",
+            "elm-version": "0.19.1",
             "dependencies": {
                 "direct": {},
                 "indirect": {}

--- a/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
@@ -20,7 +20,7 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -70,7 +70,7 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
                         "elm/parser": "1.0.0"

--- a/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerWorkspaceTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerWorkspaceTest.kt
@@ -12,7 +12,7 @@ internal class ElmGlobalModificationTrackerWorkspaceTest : ElmWorkspaceTestBase(
                     {
                       "type": "application",
                       "source-directories": [ "src" ],
-                      "elm-version": "0.19.0",
+                      "elm-version": "0.19.1",
                       "dependencies": {
                         "direct": {},
                         "indirect": {}

--- a/src/test/kotlin/org/elm/workspace/ElmProjectHelperTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmProjectHelperTest.kt
@@ -171,7 +171,7 @@ class ElmProjectHelperTest : ElmWorkspaceTestBase() {
     val elmJson = """{
         "type": "application",
         "source-directories": [ "src" ],
-        "elm-version": "0.19.0",
+        "elm-version": "0.19.1",
         "dependencies": {
             "direct": {
             },

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -17,7 +17,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -53,7 +53,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                             "src",
                             "../src"
                         ],
-                        "elm-version": "0.19.0",
+                        "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {},
                             "indirect": {}
@@ -78,7 +78,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "source-directories": [
                         "src"
                     ],
-                    "elm-version": "0.19.0",
+                    "elm-version": "0.19.1",
                     "dependencies": {
                         "direct": {},
                         "indirect": {}
@@ -134,7 +134,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -172,7 +172,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
                         "elm/time": "1.0.0"
@@ -206,7 +206,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
                         "elm/parser": "1.0.0"
@@ -243,7 +243,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                         "source-directories": [
                             "src"
                         ],
-                        "elm-version": "0.19.0",
+                        "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
                                 "elm/parser": "1.0.0"
@@ -270,7 +270,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                         "source-directories": [
                             "src"
                         ],
-                        "elm-version": "0.19.0",
+                        "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
                                 "elm/parser": "1.1.0"
@@ -332,7 +332,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -366,7 +366,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -401,7 +401,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "source-directories": [
                     "src"
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -436,7 +436,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 //                "source-directories": [
 //                    "src"
 //                ],
-//                "elm-version": "0.19.0",
+//                "elm-version": "0.19.1",
 //                "dependencies": {
 //                    "direct": {},
 //                    "indirect": {

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -17,7 +17,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                     {
                       "type": "application",
                       "source-directories": [ "src" ],
-                      "elm-version": "0.19.0",
+                      "elm-version": "0.19.1",
                       "dependencies": {
                         "direct": {},
                         "indirect": {}
@@ -61,7 +61,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                     {
                         "type": "application",
                         "source-directories": [ "src", "vendor" ],
-                        "elm-version": "0.19.0",
+                        "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
                                 "elm/core": "1.0.0",
@@ -106,7 +106,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             return
         }
 
-        checkEquals(Version(0, 19, 0), elmProject.elmVersion)
+        checkEquals(Version(0, 19, 1), elmProject.elmVersion)
         checkEquals(setOf(Paths.get("src"), Paths.get("vendor")), elmProject.sourceDirectories.toSet())
 
         checkEquals(setOf(
@@ -188,7 +188,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                     {
                       "type": "application",
                       "source-directories": [ "src" ],
-                      "elm-version": "0.19.0",
+                      "elm-version": "0.19.1",
                       "dependencies": {
                         "direct": {},
                         "indirect": {}
@@ -208,7 +208,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                     {
                       "type": "application",
                       "source-directories": [ "src" ],
-                      "elm-version": "0.19.0",
+                      "elm-version": "0.19.1",
                       "dependencies": {
                         "direct": {},
                         "indirect": {}
@@ -461,7 +461,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                 {
                   "type": "application",
                   "source-directories": [ "src" ],
-                  "elm-version": "0.19.0",
+                  "elm-version": "0.19.1",
                   "dependencies": {
                     "direct": {},
                     "indirect": {}
@@ -503,7 +503,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                     {
                       "type": "application",
                       "source-directories": [ "src" ],
-                      "elm-version": "0.19.0",
+                      "elm-version": "0.19.1",
                       "dependencies": {
                         "direct": {},
                         "indirect": {}

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -73,7 +73,7 @@ object MinimalElmStdlibVariant : ElmStdlibVariant {
                 "source-directories": [
                     "."
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
                         "elm/core": "1.0.0",
@@ -107,7 +107,7 @@ class CustomElmStdlibVariant(val extraDependencies: Map<String, Version>) : ElmS
                         "source-directories": [
                             "."
                         ],
-                        "elm-version": "0.19.0",
+                        "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
                                 "elm/core": "1.0.0",
@@ -139,7 +139,7 @@ object FullElmStdlibVariant : ElmStdlibVariant {
                 "source-directories": [
                     "."
                 ],
-                "elm-version": "0.19.0",
+                "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
                         "elm/core": "1.0.0",
@@ -168,6 +168,7 @@ object FullElmStdlibVariant : ElmStdlibVariant {
  * A dummy Elm Main module necessary to get Elm to install the packages we want.
  */
 private val elmHeadlessWorkerCode = """
+        module Main exposing (..)
         main =
             Platform.worker { init = init , update = update , subscriptions = always Sub.none }
 

--- a/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
@@ -20,6 +20,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
 
     fun `test build Elm application project`() {
         val source = """
+                    module Main exposing (..)
                     import Html
                     main = Html.text "hi"$caret
                 """.trimIndent()
@@ -38,6 +39,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
 
     fun `test build Elm application project with an error`() {
         val source = """
+                    module Main exposing (..)
                     import Html
                     foo = bogus$caret
                     main = Html.text "hi"
@@ -56,6 +58,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
 
     fun `test build Elm project ignores nested function named 'main'`() {
         val source = """
+                    module Main exposing (..)
                     import Html
                     foo =
                         let
@@ -138,7 +141,7 @@ private val manifestElm19 = """
             "source-directories": [
                 "src"
             ],
-            "elm-version": "0.19.0",
+            "elm-version": "0.19.1",
             "dependencies": {
                 "direct": {
                     "elm/core": "1.0.0",


### PR DESCRIPTION
In 0.19.1, it's now an error to compile a file without a module declaration. This change is not documented in the release notes or migration guide.