### PR TITLE
Fix stack overflow in type inference of some malformed programs

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1284,9 +1284,10 @@ private class InferenceScope(
                 } else if (!ty1.rigid && !ty2.rigid && tc1 == "comparable" && tc2 == "number") {
                     // `comparable` can be constrained to `number`
                     assign(ty1, ty2)
+                } else if (!ty1.rigid && ty2.rigid) {
+                    // Assigning a flex var to a rigid var makes the flex var rigid
+                    assign(ty1, ty2)
                 } else {
-                    // Normally, you have assignments like `Int => number` which constrains `number` to
-                    // be an `Int`.
                     assign(ty2, ty1)
                 }
             } else {

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -962,4 +962,27 @@ main foo =
 main x =
     { <error descr="Infinite self-referential type">x</error> | ff = x.ff "" }
 """)
+
+    fun `test flex arg to rigid param 1`() = checkByText("""
+type Foo a = Foo
+type Bar b = Bar { f2 : Foo ( (), b ) }
+type Baz c d = Baz { f4 : Foo d -> Foo d }
+
+main : Baz (e -> ()) e -> Bar e
+main (Baz baz) =
+    Bar <error descr="Type mismatch.Required: { f2 : Foo ((), b) }Found: { f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), b)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f2 = baz.f4 Foo }</error>
+""")
+
+    fun `test flex arg to rigid param 2`() = checkByText("""
+type Foo a = Foo
+type Bar b = Bar { f1 : b -> () , f2 : Foo ( (), b ) }
+type Baz c d = Baz { f3 : c , f4 : Foo d -> Foo d }
+
+main : Baz (e -> ()) e -> Bar e
+main (Baz baz) =
+    Bar
+        <error descr="Type mismatch.Required: { f1 : e → (), f2 : Foo ((), e) }Found: { f1 : e → (), f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), e)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
+        , f2 = baz.f4 Foo
+        }</error>
+""")
 }


### PR DESCRIPTION
In certain invalid programs, it was possible to assign a flex var to a rigid var in a way to would cause us to incorrectly store the replacement from rigid to flex rather than the other way around.

This commit contains two tests. Before this fix, the first test would incorrectly report a self-referential type, and the second would throw a StackOverflowException.

Fixes #536