### PR TITLE
Support destructuring and nested declarations in structure view

### DIFF
--- a/src/main/kotlin/org/elm/ide/presentation/PresentationUtils.kt
+++ b/src/main/kotlin/org/elm/ide/presentation/PresentationUtils.kt
@@ -29,7 +29,7 @@ private fun presentableName(element: PsiElement): String? =
                 element.name
 
             is ElmValueDeclaration ->
-                element.declaredNames(includeParameters = false).firstOrNull()?.name
+                element.declaredNames(includeParameters = false).joinToString { it.name }.takeIf { it.isNotEmpty() }
 
             else ->
                 null

--- a/src/main/kotlin/org/elm/ide/structure/ElmPresentableTreeElement.kt
+++ b/src/main/kotlin/org/elm/ide/structure/ElmPresentableTreeElement.kt
@@ -4,8 +4,12 @@ import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.ide.util.treeView.smartTree.TreeElement
 import com.intellij.pom.Navigatable
 import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
 import org.elm.ide.presentation.getPresentationForStructure
 import org.elm.lang.core.psi.ElmPsiElement
+import org.elm.lang.core.psi.descendants
+import org.elm.lang.core.psi.directChildren
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
 
 
 class ElmPresentableTreeElement(val element: ElmPsiElement)
@@ -14,7 +18,14 @@ class ElmPresentableTreeElement(val element: ElmPsiElement)
 
 
     override fun getChildren(): Array<TreeElement> =
-            emptyArray()
+            when (element) {
+                is ElmValueDeclaration -> {
+                    element.directChildDecls
+                            .map { ElmPresentableTreeElement(it) }
+                            .toList().toTypedArray()
+                }
+                else -> emptyArray()
+            }
 
     override fun getValue() =
             element
@@ -23,3 +34,12 @@ class ElmPresentableTreeElement(val element: ElmPsiElement)
             getPresentationForStructure(element)
 
 }
+
+/** Like [PsiElement.descendants], but stops at any [ElmValueDeclaration]s */
+private val PsiElement.directChildDecls: Sequence<ElmValueDeclaration>
+    get() = directChildren.flatMap {
+        when (it) {
+            is ElmValueDeclaration -> sequenceOf(it)
+            else -> sequenceOf(it) + it.directChildDecls
+        }
+    }.filterIsInstance<ElmValueDeclaration>()

--- a/src/main/kotlin/org/elm/ide/structure/ElmStructureViewModel.kt
+++ b/src/main/kotlin/org/elm/ide/structure/ElmStructureViewModel.kt
@@ -5,6 +5,7 @@ import com.intellij.ide.structureView.StructureViewModelBase
 import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.ide.util.treeView.smartTree.Sorter
 import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
 
 class ElmStructureViewModel(elmFile: ElmFile) :
         StructureViewModelBase(elmFile, ElmFileTreeElement(elmFile)),
@@ -15,5 +16,11 @@ class ElmStructureViewModel(elmFile: ElmFile) :
 
     override fun isAlwaysShowsPlus(element: StructureViewTreeElement?) = false
 
-    override fun isAlwaysLeaf(element: StructureViewTreeElement?) = false
+    override fun isAlwaysLeaf(element: StructureViewTreeElement?): Boolean {
+        // Only value declarations can have children. This is just an optimization, so return false
+        // if we're not sure.
+        return (element as? ElmPresentableTreeElement)?.element
+                ?.let { it !is ElmValueDeclaration }
+                ?: false
+    }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -12,15 +12,16 @@ import org.elm.lang.core.stubs.ElmPlaceholderStub
 
 
 /**
- * A top-level value/function declaration.
+ * A value/function declaration.
  *
  * Most of the time this is a simple value or function declaration
  * e.g. `x = 42` or `f x = 2 * x`
- * That case is covered by [ElmFunctionDeclarationLeft].
+ * That case is covered by [functionDeclarationLeft].
  *
- * The other case, and it's quite rare, is when you are binding a value
- * to a pattern, possibly introducing multiple top-level names.
+ * The other case is when you are binding a value to a pattern,
+ * possibly introducing multiple names.
  * e.g. `(x,y) = (0,0)`
+ * This case is covered by [pattern].
  */
 class ElmValueDeclaration : ElmStubbedElement<ElmPlaceholderStub>, ElmDocTarget {
 

--- a/src/test/kotlin/org/elm/ide/structure/ElmStructureViewTest.kt
+++ b/src/test/kotlin/org/elm/ide/structure/ElmStructureViewTest.kt
@@ -1,0 +1,80 @@
+package org.elm.ide.structure
+
+import com.intellij.testFramework.PlatformTestUtil
+import org.elm.lang.ElmTestBase
+import org.intellij.lang.annotations.Language
+
+internal class ElmStructureViewTest : ElmTestBase() {
+    fun `test top-level declarations`() = doTest("""
+type alias Alias = ()
+type Foo = Bar
+main = 1
+""", """
+-Main.elm
+ Alias
+ Foo
+ main
+""")
+
+    fun `test destructuring declaration`() = doTest("""
+(foo, bar) = (1, 2)
+""", """
+-Main.elm
+ foo, bar
+""")
+
+    fun `test nested value declaration`() = doTest("""
+main =
+  let foo = 1 in foo
+""", """
+-Main.elm
+ -main
+  foo
+""")
+
+    fun `test nested value declarations in tuple`() = doTest("""
+main =
+  (
+  let foo = 1 in foo,
+  let bar = 2 in bar
+  )
+""", """
+-Main.elm
+ -main
+  foo
+  bar
+""")
+
+    fun `test deeply nested value declarations`() = doTest("""
+main =
+  let
+    level1 =
+      let
+        level2a = 1
+        level2b =
+          let
+            level3a = 1
+            level3b = 2
+          in
+          level3b
+      in
+      level2b
+  in
+  level1
+""", """
+-Main.elm
+ -main
+  -level1
+   level2a
+   -level2b
+    level3a
+    level3b
+""")
+    private fun doTest(@Language("Elm") code: String, expected: String) {
+        myFixture.configureByText("Main.elm", code)
+        myFixture.testStructureView {
+            PlatformTestUtil.expandAll(it.tree)
+            PlatformTestUtil.assertTreeEqual(it.tree, expected)
+        }
+    }
+}


### PR DESCRIPTION
Previously, only top level declarations were shown, and destructuring declarations only showed the name of the first declared value.