### PR TITLE
Support scroll-from-source in structure view

### DIFF
--- a/src/main/kotlin/org/elm/ide/structure/ElmStructureViewFactory.kt
+++ b/src/main/kotlin/org/elm/ide/structure/ElmStructureViewFactory.kt
@@ -14,7 +14,7 @@ class ElmStructureViewFactory : PsiStructureViewFactory {
         val elmFile = psiFile as ElmFile
         return object : TreeBasedStructureViewBuilder() {
             override fun createStructureViewModel(editor: Editor?) =
-                    ElmStructureViewModel(elmFile)
+                    ElmStructureViewModel(editor, elmFile)
         }
     }
 }

--- a/src/main/kotlin/org/elm/ide/structure/ElmStructureViewModel.kt
+++ b/src/main/kotlin/org/elm/ide/structure/ElmStructureViewModel.kt
@@ -4,12 +4,25 @@ import com.intellij.ide.structureView.StructureViewModel
 import com.intellij.ide.structureView.StructureViewModelBase
 import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.ide.util.treeView.smartTree.Sorter
+import com.intellij.openapi.editor.Editor
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.psi.ElmNamedElement
+import org.elm.lang.core.psi.elements.*
 
-class ElmStructureViewModel(elmFile: ElmFile) :
-        StructureViewModelBase(elmFile, ElmFileTreeElement(elmFile)),
+class ElmStructureViewModel(editor: Editor?, elmFile: ElmFile) :
+        StructureViewModelBase(elmFile, editor, ElmFileTreeElement(elmFile)),
         StructureViewModel.ElementInfoProvider {
+
+    init {
+        // This list is used by the scroll-to-source functionality: the nearest ancestor of the
+        // element at the caret that is one of these classes will be scrolled to.
+        withSuitableClasses(
+                ElmValueDeclaration::class.java,
+                ElmTypeAliasDeclaration::class.java,
+                ElmTypeDeclaration::class.java,
+                ElmPortAnnotation::class.java
+        )
+    }
 
     override fun getSorters() =
             arrayOf(Sorter.ALPHA_SORTER)

--- a/src/test/kotlin/org/elm/ide/structure/ElmStructureViewTest.kt
+++ b/src/test/kotlin/org/elm/ide/structure/ElmStructureViewTest.kt
@@ -8,11 +8,13 @@ internal class ElmStructureViewTest : ElmTestBase() {
     fun `test top-level declarations`() = doTest("""
 type alias Alias = ()
 type Foo = Bar
+port somePort : ()
 main = 1
 """, """
 -Main.elm
  Alias
  Foo
+ somePort
  main
 """)
 


### PR DESCRIPTION
The relevant code from IntelliJ:

`StructureViewComponent.scrolltoSelectedElementInner`, calls  `TextEditorBasedStructureViewModel.getCurrentEditorElement`, which eventually uses `isSuitable` to pick the psi element corresponding to the structure element to scroll to by finding the nearest psi ancestor that's in the list of `suitableClasses`.

Fixes #538 