### PR TITLE
Add filtered live template contexts

### DIFF
--- a/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateContext.kt
+++ b/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateContext.kt
@@ -1,10 +1,73 @@
 package org.elm.ide.livetemplates
 
+import com.intellij.codeInsight.template.EverywhereContextType
 import com.intellij.codeInsight.template.TemplateContextType
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiUtilCore
+import org.elm.lang.core.ElmLanguage
+import org.elm.lang.core.psi.ElmExpressionTag
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ancestors
+import org.elm.lang.core.psi.elements.ElmLetInExpr
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+import org.elm.lang.core.psi.elements.ElmTypeExpression
+import kotlin.reflect.KClass
 
-class ElmLiveTemplateContext : TemplateContextType("ELM", "Elm") {
+sealed class ElmLiveTemplateContext(
+        id: String,
+        presentableName: String,
+        baseContextType: KClass<out TemplateContextType>
+) : TemplateContextType(id, presentableName, baseContextType.java) {
+    override fun isInContext(file: PsiFile, offset: Int): Boolean {
+        if (!PsiUtilCore.getLanguageAtOffset(file, offset).isKindOf(ElmLanguage)) {
+            return false
+        }
 
-    override fun isInContext(file: PsiFile, offset: Int) =
-            file.name.endsWith(".elm")
+        val element = file.findElementAt(offset)
+        if (element == null ||
+                element is PsiComment ||
+                element is ElmStringConstantExpr ||
+                element.parent is ElmStringConstantExpr) {
+            return false
+        }
+
+        return isInContext(element)
+    }
+
+    protected abstract fun isInContext(element: PsiElement): Boolean
+
+    class Generic : ElmLiveTemplateContext("ELM", "Elm", EverywhereContextType::class) {
+        override fun isInContext(element: PsiElement): Boolean = true
+    }
+
+    class TopLevel : ElmLiveTemplateContext("ELM_TOP_LEVEL", "Top level statement", Generic::class) {
+        override fun isInContext(element: PsiElement): Boolean {
+            return isTopLevel(element)
+        }
+    }
+
+    class ValueDecl : ElmLiveTemplateContext("ELM_VALUE_DECL", "Function declaration", Generic::class) {
+        override fun isInContext(element: PsiElement): Boolean {
+            return isTopLevel(element)
+                    || element.parent is ElmLetInExpr
+        }
+    }
+
+    class Expression : ElmLiveTemplateContext("ELM_EXPRESSION", "Expression", Generic::class) {
+        override fun isInContext(element: PsiElement): Boolean {
+            if (element.parent is ElmLetInExpr) return false
+
+            return element.ancestors
+                    .takeWhile { it !is ElmTypeExpression && it !is ElmFile }
+                    .any { it is ElmExpressionTag }
+        }
+    }
+}
+
+private fun isTopLevel(element: PsiElement): Boolean {
+    return element.parent is ElmFile ||
+            element.parent is PsiErrorElement && element.parent?.parent is ElmFile
 }

--- a/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateProvider.kt
+++ b/src/main/kotlin/org/elm/ide/livetemplates/ElmLiveTemplateProvider.kt
@@ -3,7 +3,7 @@ package org.elm.ide.livetemplates
 import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider
 
 class ElmLiveTemplateProvider : DefaultLiveTemplatesProvider {
-    override fun getDefaultLiveTemplateFiles() = arrayOf("liveTemplates/Elm")
+    override fun getDefaultLiveTemplateFiles(): Array<out String>? = arrayOf("liveTemplates/Elm")
 
-    override fun getHiddenLiveTemplateFiles() = arrayOf<String>()
+    override fun getHiddenLiveTemplateFiles(): Array<out String>? = null
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -359,7 +359,10 @@
 
         <multiHostInjector implementation="org.elm.ide.injection.ElmGlslInjector"/>
 
-        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext"/>
+        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext$Generic"/>
+        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext$TopLevel"/>
+        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext$Expression"/>
+        <liveTemplateContext implementation="org.elm.ide.livetemplates.ElmLiveTemplateContext$ValueDecl"/>
         <defaultLiveTemplatesProvider implementation="org.elm.ide.livetemplates.ElmLiveTemplateProvider"/>
 
         <configurationType implementation="org.frawa.elmtest.run.ElmTestRunConfigurationType"/>

--- a/src/main/resources/liveTemplates/Elm.xml
+++ b/src/main/resources/liveTemplates/Elm.xml
@@ -3,14 +3,14 @@
     <variable name="NAME" expression="fileNameWithoutExtension()" defaultValue="" alwaysStopAt="true" />
     <variable name="EXPOSED" expression="&quot;..&quot;" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_TOP_LEVEL" value="true" />
     </context>
   </template>
   <template name="fn0" value="$NAME$ : $RETURNTYPE$&#10;$NAME$ =&#10;    $END$ " description="Function with no arguments" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="camelCase(String)" defaultValue="" alwaysStopAt="true" />
     <variable name="RETURNTYPE" expression="capitalize(String)" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_VALUE_DECL" value="true" />
     </context>
   </template>
   <template name="fn1" value="$NAME$ : $FIRSTTYPE$ -&gt; $RETURNTYPE$&#10;$NAME$ $FIRSTVAR$ =&#10;    $END$" description="Function with one argument" toReformat="false" toShortenFQNames="true">
@@ -19,7 +19,7 @@
     <variable name="RETURNTYPE" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="FIRSTVAR" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_VALUE_DECL" value="true" />
     </context>
   </template>
   <template name="fn2" value="$NAME$ : $FIRSTTYPE$ -&gt; $SECONDTYPE$ -&gt; $RETURNTYPE$&#10;$NAME$ $FIRSTVAR$ $SECONDVAR$ =&#10;    $END$" description="Function with two arguments" toReformat="false" toShortenFQNames="true">
@@ -30,7 +30,7 @@
     <variable name="FIRSTVAR" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="SECONDVAR" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_VALUE_DECL" value="true" />
     </context>
   </template>
   <template name="fn3" value="$NAME$ : $FIRSTTYPE$ -&gt; $SECONDTYPE$ -&gt; $THIRDTYPE$ -&gt; $RETURNTYPE$&#10;$NAME$ $FIRSTVAR$ $SECONDVAR$ $THIRDVAR$ =&#10;    $END$" description="Function with three arguments" toReformat="false" toShortenFQNames="true">
@@ -43,26 +43,26 @@
     <variable name="SECONDVAR" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="THIRDVAR" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_VALUE_DECL" value="true" />
     </context>
   </template>
   <template name="ty" value="type $NAME$&#10;    = $END$" description="Type Declaration" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_TOP_LEVEL" value="true" />
     </context>
   </template>
   <template name="tya" value="type alias $NAME$ =&#10;   $END$" description="Typealias Declaration" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_TOP_LEVEL" value="true" />
     </context>
   </template>
   <template name="let1" value="let&#10;    $FIRSTNAME$ =&#10;        $FIRSTEXP$&#10;in&#10;    $END$" description="Let expression with a single binding" toReformat="false" toShortenFQNames="true">
     <variable name="FIRSTNAME" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="FIRSTEXP" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_EXPRESSION" value="true" />
     </context>
   </template>
   <template name="let2" value="let&#10;    $FIRSTNAME$ =&#10;        $FIRSTEXP$&#10;    $SECONDNAME$ =&#10;        $SECONDEXP$&#10;in&#10;    $END$" description="Let expression with two bindings" toReformat="false" toShortenFQNames="true">
@@ -71,7 +71,7 @@
     <variable name="SECONDNAME" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="SECONDEXP" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_EXPRESSION" value="true" />
     </context>
   </template>
   <template name="let3" value="let&#10;    $FIRSTNAME$ =&#10;        $FIRSTEXP$&#10;    $SECONDNAME$ =&#10;        $SECONDEXP$&#10;    $THIRDNAME$ =&#10;        $THIRDEXP$&#10;in&#10;    $END$" description="Let expression with three bindings" toReformat="false" toShortenFQNames="true">
@@ -82,7 +82,7 @@
     <variable name="THIRDNAME" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="THIRDEXP" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_EXPRESSION" value="true" />
     </context>
   </template>
   <template name="case1" value="case $VAR$ of&#10;    $FIRSTCOND$ -&gt; &#10;        $FIRSTBRANCH$" description="Case Expression with one Branch" toReformat="false" toShortenFQNames="true">
@@ -90,7 +90,7 @@
     <variable name="FIRSTCOND" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="FIRSTBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_EXPRESSION" value="true" />
     </context>
   </template>
   <template name="case2" value="case $VAR$ of&#10;    $FIRSTCOND$ -&gt; &#10;        $FIRSTBRANCH$&#10;        &#10;    $SECONDCOND$ -&gt; &#10;        $SECONDBRANCH$&#10;" description="Case Expression with two Branches" toReformat="false" toShortenFQNames="true">
@@ -100,7 +100,7 @@
     <variable name="SECONDCOND" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="SECONDBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_EXPRESSION" value="true" />
     </context>
   </template>
   <template name="case3" value="case $VAR$ of&#10;    $FIRSTCOND$ -&gt; &#10;        $FIRSTBRANCH$&#10;        &#10;    $SECONDCOND$ -&gt; &#10;        $SECONDBRANCH$&#10;        &#10;    $THIRDCOND$ -&gt; &#10;        $THIRDBRANCH$" description="Case Expression with three Branches" toReformat="false" toShortenFQNames="true">
@@ -112,7 +112,7 @@
     <variable name="THIRDCOND" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="THIRDBRANCH" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="ELM" value="true" />
+      <option name="ELM_EXPRESSION" value="true" />
     </context>
   </template>
 </templateSet>

--- a/src/test/kotlin/org/elm/ide/template/ElmLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/elm/ide/template/ElmLiveTemplatesTest.kt
@@ -1,0 +1,212 @@
+package org.elm.ide.template
+
+import com.intellij.openapi.actionSystem.IdeActions
+import org.elm.lang.ElmTestBase
+import org.intellij.lang.annotations.Language
+
+class ElmLiveTemplatesTest : ElmTestBase() {
+    fun `test module`() = expandSnippet(
+            """
+mod{-caret-}
+""",
+            """
+module main exposing (..)
+
+
+""")
+
+    fun `test module in expression`() = noSnippet(
+            """
+main =
+  mod{-caret-}
+""")
+
+    fun `test module in comment`() = noSnippet(
+            """
+{-
+mod{-caret-}
+-}
+""")
+
+    fun `test fn1`() = expandSnippet(
+            """
+fn1{-caret-}
+""", """
+ :  -> 
+  =
+    
+""")
+
+    fun `test fn1 in let`() = expandSnippet(
+            """
+main =
+  let
+    fn1{-caret-}
+  in
+  ()
+""", """
+main =
+  let
+     :  -> 
+      =
+        
+  in
+  ()
+""")
+
+    fun `test fn2`() = expandSnippet(
+            """
+fn2{-caret-}
+""", """
+ :  ->  -> 
+   =
+    
+""")
+
+    fun `test fn3`() = expandSnippet(
+            """
+fn3{-caret-}
+""", """
+ :  ->  ->  -> 
+    =
+    
+""")
+
+    fun `test ty`() = expandSnippet(
+            """
+ty{-caret-}
+""", """
+type 
+    = 
+""")
+
+    fun `test tya`() = expandSnippet(
+            """
+tya{-caret-}
+""", """
+type alias  =
+   
+""")
+
+    fun `test let1`() = expandSnippet(
+            """
+main =
+  let1{-caret-}
+""", """
+main =
+  let
+       =
+          
+  in
+      
+""")
+
+    fun `test let1 in binary expression`() = expandSnippet(
+            """
+main =
+  1 + let1{-caret-}
+""", """
+main =
+  1 + let
+       =
+          
+  in
+      
+""")
+
+    fun `test let1 in comment`() = noSnippet(
+            """
+main =
+  --let1{-caret-}
+""")
+
+    fun `test let1 in string`() = noSnippet(
+            """
+main = ${"\"\"\""}
+    let1{-caret-}
+    ${"\"\"\""}
+""")
+
+    fun `test let1 in params`() = noSnippet(
+            """
+main let1{-caret-} = ()
+""")
+
+    fun `test let1 in type expr`() = noSnippet(
+            """
+main : let1{-caret-}
+main = ()
+""")
+
+    fun `test let1 at top level`() = noSnippet(
+            """
+let1{-caret-}
+""")
+
+    fun `test let1 at in nested statement`() = noSnippet(
+            """
+main =
+  let
+    let1{-caret-}
+  in
+  ()
+""")
+
+    fun `test let1 in let-in expr`() = expandSnippet(
+            """
+main =
+  let
+    f=()
+  in
+  let1{-caret-}
+""","""
+main =
+  let
+    f=()
+  in
+  let
+       =
+          
+  in
+      
+""")
+
+    fun `test let1 in nested expression`() = expandSnippet(
+            """
+main =
+  let
+    f = 
+      let1{-caret-}
+  in
+  ()
+""","""
+main =
+  let
+    f = 
+      let
+           =
+              
+      in
+          
+  in
+  ()
+""")
+
+    fun `test case1`() = expandSnippet(
+            """
+main =
+  case1{-caret-}
+""", """
+main =
+  case  of
+       -> 
+          
+""")
+
+    private fun expandSnippet(@Language("Elm") before: String, @Language("Elm") after: String) =
+            checkByText(before, after) {
+                myFixture.performEditorAction(IdeActions.ACTION_EXPAND_LIVE_TEMPLATE_BY_TAB)
+            }
+
+    private fun noSnippet(@Language("Elm") code: String) = expandSnippet(code, code)
+}


### PR DESCRIPTION
This allows us to only expand live contexts when they're syntactically valid.

Templates like `ty` and `mod` will now only expand at the top level in files.
Templates like `fn1` will now expand at top level or in a let declaration.
Templates like `case1` and `let1` will now only expand in an expression.

No templates will expand in a string or comment.

Fixes #543