### PR TITLE
Fix some cached inference results not being frozen

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -88,7 +88,7 @@ class TypeReplacement(
          */
         fun freeze(ty: Ty): Ty {
             if (ty.traverse(true).none { it.isUnfrozenRecord() }) return ty
-            return TypeReplacement(emptyMap(), freshen = false, varsToRemainRigid = emptyList(), freeze = false, keepRecordsMutable = false).replace(ty)
+            return TypeReplacement(emptyMap(), freshen = false, varsToRemainRigid = emptyList(), freeze = true, keepRecordsMutable = false).replace(ty)
         }
 
         private fun tyWouldChange(ty: Ty, freeze: Boolean): Boolean {


### PR DESCRIPTION
This would cause intermittent ConcurrentModificationExceptions.

Fixes #489
Fixes #508
Fixes #535
Fixes #558