### PR TITLE
Add color swatch line markers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
         classpath "com.github.JetBrains:gradle-grammar-kit-plugin:2019.1"
     }
 }
@@ -29,7 +29,7 @@ repositories {
     maven { url 'http://dl.bintray.com/jetbrains/markdown' }
 }
 
-ext.kotlinVersion = '1.3.50'
+ext.kotlinVersion = '1.3.61'
 ext.junitVersion = '4.12'
 ext.jacksonVersion = '2.9.8'
 ext.markdownVersion = '0.1.31'
@@ -137,6 +137,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     compileOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    compile 'com.github.ajalt:colormath:1.4.0'
     compile("org.jetbrains:markdown:$markdownVersion") {
         exclude module: "kotlin-runtime"
         exclude module: "kotlin-stdlib"

--- a/src/main/kotlin/org/elm/ide/color/ElmColorProvider.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorProvider.kt
@@ -1,0 +1,203 @@
+package org.elm.ide.color
+
+import com.github.ajalt.colormath.*
+import com.intellij.ide.IdeBundle
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.editor.ElementColorProvider
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
+import org.elm.lang.core.psi.ElmTypes.REGULAR_STRING_PART
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.*
+import java.awt.Color
+import kotlin.math.roundToInt
+
+private val colorRegex = Regex("""#[0-9a-fA-F]{3,8}\b|\b(?:rgb|hsl)a?\([^)]+\)""")
+
+/** Adds color blocks to the gutter when hex colors exist in a string */
+class ElmColorProvider : ElementColorProvider {
+    override fun getColorFrom(element: PsiElement): Color? {
+        // Like all line markers, we should only provide colors on leaf elements
+        if (element.firstChild != null) return null
+        return getCssColorFromString(element)
+                ?: getColorFromFuncCall(element)
+    }
+
+    // Parse a CSS color from any string that contains one, since "1px solid #1a2b3c" probably
+    // contains a color. We don't parse color keywords, since "The red fire truck" is probably not
+    // supposed to contain a color.
+    private fun getCssColorFromString(element: PsiElement): Color? {
+        if (element.elementType != REGULAR_STRING_PART) return null
+        return colorRegex.find(element.text)
+                ?.let { runCatching { ConvertibleColor.fromCss(it.value) }.getOrNull() }
+                ?.toAwtColor()
+    }
+
+    private fun getColorFromFuncCall(element: PsiElement): Color? {
+        val call = getFuncCall(element) ?: return null
+        val color = runCatching {
+            // color constructors will throw if the args are out of bounds
+            when (call.name) {
+                "rgb", "rgba" -> {
+                    if (call.a == null && call.name == "rgba") return null
+                    if (call.useFloat) RGB(call.c1, call.c2, call.c3, call.a ?: 1f)
+                    else RGB(call.c1.toInt(), call.c2.toInt(), call.c3.toInt(), call.a ?: 1f)
+                }
+                "rgb255" -> RGB(call.c1.toInt(), call.c2.toInt(), call.c3.toInt())
+                "rgba255" -> RGB(call.c1.toInt(), call.c2.toInt(), call.c3.toInt(), call.a ?: return null)
+                "hsl" -> HSL(call.c1, call.c2, call.c3)
+                "hsla" -> HSL(call.c1, call.c2, call.c3, call.a ?: return null)
+                else -> return null
+            }
+        }.getOrNull()
+        return color?.toAwtColor()
+    }
+
+    private fun getFuncCall(element: PsiElement): FuncCall? {
+        if (element.elementType != LOWER_CASE_IDENTIFIER) return null
+        if (element.parent !is ElmValueQID) return null
+
+        val valueExpr = element.parent.parent as? ElmValueExpr ?: return null
+        val callExpr = valueExpr.parent as? ElmFunctionCallExpr ?: return null
+        if (callExpr.target != valueExpr) return null
+        if (valueExpr.referenceName !in listOf("rgb", "rgba", "hsl", "hsla", "rgb255", "rgba255")) return null
+
+        val args = callExpr.arguments.toList()
+        if ((args.size != 3 && args.size != 4) || args.any { it !is ElmNumberConstantExpr }) return null
+
+        @Suppress("UNCHECKED_CAST")
+        args as List<ElmNumberConstantExpr>
+
+        return FuncCall(
+                c1 = args[0].text.toFloatOrNull() ?: return null,
+                c2 = args[1].text.toFloatOrNull() ?: return null,
+                c3 = args[2].text.toFloatOrNull() ?: return null,
+                // the alpha channel is optional
+                a = args.getOrNull(3)?.text?.let { it.toFloatOrNull() ?: return null },
+                name = valueExpr.referenceName,
+                containsFloats = args.take(3).any { it.isFloat },
+                target = valueExpr,
+                args = args
+        )
+    }
+
+    override fun setColorTo(element: PsiElement, color: Color) {
+        if (element.firstChild != null) return
+        val command = stringColorSettingRunnable(element, color)
+                ?: functionColorSettingRunnable(element, color)
+                ?: return
+
+        val document = PsiDocumentManager.getInstance(element.project).getDocument(element.containingFile)
+        CommandProcessor.getInstance().executeCommand(
+                element.project,
+                command,
+                // This is the message that the JavaColorProvider uses
+                IdeBundle.message("change.color.command.text"),
+                null, // groupId
+                document
+        )
+    }
+
+    private fun functionColorSettingRunnable(element: PsiElement, color: Color): Runnable? {
+        val funcCall = getFuncCall(element)
+        val call = funcCall ?: return null
+        return Runnable { setColorInFunctionCall(element, color, call) }
+    }
+
+    private fun setColorInFunctionCall(element: PsiElement, color: Color, call: FuncCall) {
+        val factory = ElmPsiFactory(element.project)
+
+        fun ElmNumberConstantExpr.replace(c: Int, float: Boolean) {
+            val rendered = if (float) (c / 255f).render() else c.toString()
+            replace(factory.createNumberConstant(rendered))
+        }
+
+        if (call.name.startsWith("hsl")) {
+            val hsl = color.toRGB().toHSL()
+            call.args[0].replace(factory.createNumberConstant(hsl.h.toFloat().render()))
+            call.args[1].replace(factory.createNumberConstant((hsl.s / 100f).render()))
+            call.args[2].replace(factory.createNumberConstant((hsl.l / 100f).render()))
+        } else {
+            call.args[0].replace(color.red, call.useFloat)
+            call.args[1].replace(color.green, call.useFloat)
+            call.args[2].replace(color.blue, call.useFloat)
+        }
+
+        call.args.getOrNull(3)?.replace(color.alpha, true)
+    }
+
+    private fun stringColorSettingRunnable(element: PsiElement, color: Color): Runnable? {
+        if (element.elementType != REGULAR_STRING_PART) return null
+        return Runnable { setCssColorInString(element, color) }
+    }
+
+    private fun setCssColorInString(element: PsiElement, color: Color) {
+        val parent = element.parent as? ElmStringConstantExpr ?: return
+        val match = colorRegex.find(element.text)?.value ?: return
+
+        val rgb = color.toRGB()
+        val percentCount = match.count { it == '%' }
+        val commas = ',' in match
+
+        val newColor = when {
+            match.startsWith("#") -> rgb.toHex()
+            match.startsWith("rgb") -> rgb.toCssRgb(
+                    commas = commas,
+                    namedRgba = match.startsWith("rgba"),
+                    rgbPercent = percentCount > 1,
+                    alphaPercent = percentCount == 1 || percentCount == 4
+            )
+            match.startsWith("hsl") -> rgb.toCssHsl(
+                    commas = commas,
+                    namedHsla = match.startsWith("hsla"),
+                    hueUnit = when {
+                        "deg" in match -> AngleUnit.DEGREES
+                        "grad" in match -> AngleUnit.GRADIANS
+                        "rad" in match -> AngleUnit.RADIANS
+                        "turn" in match -> AngleUnit.TURNS
+                        else -> AngleUnit.AUTO
+                    },
+                    alphaPercent = percentCount == 1 || percentCount == 3
+            )
+            else -> return
+        }
+
+        val factory = ElmPsiFactory(element.project)
+        val newText = colorRegex.replaceFirst(parent.text, newColor)
+        val newElement = factory.createStringConstant(newText)
+        parent.replace(newElement)
+    }
+}
+
+private data class FuncCall(
+        val c1: Float,
+        val c2: Float,
+        val c3: Float,
+        val a: Float?,
+        val name: String,
+        private val containsFloats: Boolean,
+        val target: ElmValueExpr,
+        val args: List<ElmNumberConstantExpr>
+) {
+    val colors = listOf(c1, c2, c3)
+    val useFloat = when {
+            containsFloats -> true
+            colors.all { it == 0f } -> false // literal `0` can be used for both
+            colors.any { it > 1 } -> false
+            else -> true // Args are a mix of `0` and `1`. Assume a float, but we could be wrong.
+        }
+}
+
+fun ConvertibleColor.toAwtColor(): Color = toRGB().let {
+    Color(it.r, it.g, it.b, (it.a * 255).roundToInt())
+}
+
+private fun Color.toRGB() = RGB(red, green, blue, alpha / 255f)
+
+private fun Float.render(): String = when (this) {
+    0f -> "0"
+    1f -> "1"
+    else -> String.format("%.4f", this).trimEnd('0').trimEnd('.')
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -114,6 +114,14 @@ class ElmPsiFactory(private val project: Project) {
             createFromText("f = $text")
                     ?: error("Invalid value QID: `$text`")
 
+    fun createStringConstant(text: String): ElmStringConstantExpr =
+            createFromText("f = $text")
+                    ?: error("Invalid string: `$text`")
+
+    fun createNumberConstant(num: String): ElmNumberConstantExpr =
+            createFromText("f = $num")
+                    ?: error("Invalid number: `$num`")
+
     fun createAnythingPattern(): ElmAnythingPattern =
             createFromText("f _ = 1")
                     ?: error("Invalid anything pattern")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -281,6 +281,7 @@
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
         <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.refactoring.ElmImportOptimizer"/>
+        <colorProvider language="Elm" implementation="org.elm.ide.color.ElmColorProvider" />
 
         <!-- Inspections -->
 

--- a/src/test/kotlin/org/elm/ide/color/ElmColorProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/color/ElmColorProviderTest.kt
@@ -1,0 +1,239 @@
+package org.elm.ide.color
+
+import com.github.ajalt.colormath.ConvertibleColor
+import com.github.ajalt.colormath.HSL
+import com.github.ajalt.colormath.RGB
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.util.ui.ColorIcon
+import org.elm.lang.ElmTestBase
+import org.intellij.lang.annotations.Language
+
+
+internal class ElmColorProviderTest : ElmTestBase() {
+    //<editor-fold desc="css">
+    fun `test value with other string content`() = doGutterTest(1, """
+main = ("border", "1px solid #aabbcc")
+""")
+
+    // format test cases from https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+
+    fun `test #f09`() = doFormatTest("#f09")
+    fun `test #F09`() = doFormatTest("#F09")
+    fun `test #ff0099`() = doFormatTest("#ff0099")
+    fun `test #FF0099`() = doFormatTest("#FF0099")
+    fun `test rgb(255,0,153)`() = doFormatTest("rgb(255,0,153)")
+    fun `test rgb(255, 0, 153)`() = doFormatTest("rgb(255, 0, 153)")
+    fun `test rgb(255, 0, 153_0)`() = doFormatTest("rgb(255, 0, 153.0)")
+    fun `test rgb(100%,0%,60%)`() = doFormatTest("rgb(100%,0%,60%)")
+    fun `test rgb(100%, 0%, 60%)`() = doFormatTest("rgb(100%, 0%, 60%)")
+    fun `test rgb(255 0 153)`() = doFormatTest("rgb(255 0 153)")
+    fun `test #f09f`() = doFormatTest("#f09f")
+    fun `test #F09F`() = doFormatTest("#F09F")
+    fun `test #ff0099ff`() = doFormatTest("#ff0099ff")
+    fun `test #FF0099FF`() = doFormatTest("#FF0099FF")
+    fun `test rgb(255, 0, 153, 1)`() = doFormatTest("rgb(255, 0, 153, 1)")
+    fun `test rgb(255, 0, 153, 100%)`() = doFormatTest("rgb(255, 0, 153, 100%)")
+    fun `test rgb(255 0 153 _ 1)`() = doFormatTest("rgb(255 0 153 / 1)")
+    fun `test rgb(255 0 153 _ 100%)`() = doFormatTest("rgb(255 0 153 / 100%)")
+    fun `test rgb(255, 0, 153_6, 1)`() = doFormatTest("rgb(255, 0, 153.6, 1)")
+    fun `test rgb(1e2, _5e1, _5e0, +_25e2%)`() = doFormatTest("rgb(1e2, .5e1, .5e0, +.25e2%)")
+    fun `test hsl(270,60%,70%)`() = doFormatTest("hsl(270,60%,70%)")
+    fun `test hsl(270, 60%, 70%)`() = doFormatTest("hsl(270, 60%, 70%)")
+    fun `test hsl(270 60% 70%)`() = doFormatTest("hsl(270 60% 70%)")
+    fun `test hsl(270deg, 60%, 70%)`() = doFormatTest("hsl(270deg, 60%, 70%)")
+    fun `test hsl(4_71239rad, 60%, 70%)`() = doFormatTest("hsl(4.71239rad, 60%, 70%)")
+    fun `test hsl(_75turn, 60%, 70%)`() = doFormatTest("hsl(.75turn, 60%, 70%)")
+    fun `test hsl(270, 60%, 50%, _15)`() = doFormatTest("hsl(270, 60%, 50%, .15)")
+    fun `test hsl(270, 60%, 50%, 15%)`() = doFormatTest("hsl(270, 60%, 50%, 15%)")
+    fun `test hsl(270 60% 50% _ _15)`() = doFormatTest("hsl(270 60% 50% / .15)")
+    fun `test hsl(270 60% 50% _ 15%)`() = doFormatTest("hsl(270 60% 50% / 15%)")
+
+    fun `test write #f09`() = doCssWriteTest("#f09", "#7b2d43")
+    fun `test write #ff0099`() = doCssWriteTest("#ff0099", "#7b2d43")
+    fun `test write rgb(255,0,153)`() = doCssWriteTest("rgb(255,0,153)", "rgb(123, 45, 67)")
+    fun `test write rgb(255, 0, 153)`() = doCssWriteTest("rgb(255, 0, 153)", "rgb(123, 45, 67)")
+    fun `test write rgb(255, 0, 153_0)`() = doCssWriteTest("rgb(255, 0, 153.0)", "rgb(123, 45, 67)")
+    fun `test write rgb(100%,0%,60%)`() = doCssWriteTest("rgb(100%,0%,60%)", "rgb(48%, 18%, 26%)")
+    fun `test write rgb(100%, 0%, 60%)`() = doCssWriteTest("rgb(100%, 0%, 60%)", "rgb(48%, 18%, 26%)")
+    fun `test write rgb(255 0 153)`() = doCssWriteTest("rgb(255 0 153)", "rgb(123 45 67)")
+    fun `test write #f090`() = doCssWriteTest("#f090", "#7b2d4300", RGB(123, 45, 67, 0f))
+    fun `test write #ff009900`() = doCssWriteTest("#ff00990", "#7b2d4300", RGB(123, 45, 67, 0f))
+    fun `test write rgba(255, 0, 153, 1)`() = doCssWriteTest("rgba(255, 0, 153, 1)", "rgba(123, 45, 67)")
+    fun `test write rgb(255, 0, 153, 100%)`() = doCssWriteTest("rgb(255, 0, 153, 100%)", "rgb(123, 45, 67, 50%)", RGB(123, 45, 67, .5f))
+    fun `test write rgb(255 0 153 _ 1)`() = doCssWriteTest("rgb(255 0 153 / 1)", "rgb(123 45 67 / .2)", RGB(123, 45, 67, .2f))
+    fun `test write rgb(255 0 153 _ 100%)`() = doCssWriteTest("rgb(255 0 153 / 100%)", "rgb(123 45 67 / 50%)", RGB(123, 45, 67, .5f))
+    fun `test write hsl(270,60%,70%)`() = doCssWriteTest("hsl(270,60%,70%)", "hsl(123, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270, 60%, 70%)`() = doCssWriteTest("hsl(270, 60%, 70%)", "hsl(123, 45%, 67%)", HSL(123, 45, 67))
+    fun `test write hsl(270 60% 70%)`() = doCssWriteTest("hsl(270 60% 70%)", "hsl(123 45% 67%)", HSL(123, 45, 67))
+    fun `test write hsl(270, 60%, 50%, _15)`() = doCssWriteTest("hsl(270, 60%, 50%, .15)", "hsl(123, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270, 60%, 50%, 15%)`() = doCssWriteTest("hsl(270, 60%, 50%, 15%)", "hsl(123, 45%, 67%, 20%)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270 60% 50% _ _15)`() = doCssWriteTest("hsl(270 60% 50% / .15)", "hsl(123 45% 67% / .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270 60% 50% _ 15%)`() = doCssWriteTest("hsl(270 60% 50% / 15%)", "hsl(123 45% 67% / 20%)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270grad,60%,70%)`() = doCssWriteTest("hsl(270grad,60%,70%)", "hsl(136.6667grad, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270rad,60%,70%)`() = doCssWriteTest("hsl(270rad,60%,70%)", "hsl(2.1468rad, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270turn,60%,70%)`() = doCssWriteTest("hsl(270turn,60%,70%)", "hsl(.3417turn, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    //</editor-fold>
+
+    //<editor-fold desc="functions">
+
+    fun `test rgb int read`() = doGutterTest(2, """
+type Color = Color
+rgb : Int -> Int -> Int -> Color
+rgb r g b = Color
+
+main =
+    [ rgb 0 0 0
+    , rgb 255 255 255
+    , rgb 0 0 -- partial
+    , rgb 0 0 300 -- out of bounds
+    , rgb 0 0 -2 -- out of bounds
+    ]
+""")
+
+    fun `test rgba int read`() = doGutterTest(3, """
+type Color = Color
+rgba : Int -> Int -> Int -> Float -> Color
+rgba r g b a = Color
+
+main =
+    [ rgba 0 0 0 0
+    , rgba 255 255 255 1
+    , rgba 0 0 0 0.5
+    , rgba 0 0 0 -- partial
+    ]
+""")
+
+    fun `test rgb255 int read`() = doGutterTest(2, """
+type Color = Color
+rgb255 : Int -> Int -> Int -> Color
+rgb255 r g b = Color
+
+main =
+    [ rgb255 0 0 0
+    , rgb255 255 255 255
+    ]
+""")
+
+    fun `test rgb float read`() = doGutterTest(3, """
+type Color = Color
+rgb : Float -> Float -> Float -> Color
+rgb r g b = Color
+
+main =
+    [ rgb 0 0 0
+    , rgb 1 1 1
+    , rgb 0 0.5 1
+    , rgb 0 0 -- partial
+    ]
+""")
+
+    fun `test rgba float read`() = doGutterTest(3, """
+type Color = Color
+rgba : Float -> Float -> Float -> Float -> Color
+rgba r g b a = Color
+
+main =
+    [ rgba 0 0 0 0
+    , rgba 1 1 1 1
+    , rgba 0.5 0.5 0.5 0.5
+    , rgba 0 0 -- partial
+    ]
+""")
+
+    fun `test hsl read`() = doGutterTest(3, """
+type Color = Color
+hsl : Float -> Float -> Float -> Color
+rgb h s l = Color
+
+main =
+    [ hsl 0 0 0
+    , hsl 1 1 1
+    , hsl 0 0.5 1
+    , hsl 0 0 2 -- out of bounds
+    , hsl 0 0 -- partial
+    ]
+""")
+
+    fun `test hsla read`() = doGutterTest(3, """
+type Color = Color
+hsla : Float -> Float -> Float -> Float -> Color
+hsla h s l a = Color
+
+main =
+    [ hsla 0 0 0 0
+    , hsla 1 1 1 1
+    , hsla 0 0.5 1 0.5
+    , hsla 0 0 0 -- partial
+    ]
+""")
+
+    fun `test write rgb 0 0 0`() = doFuncWriteTest("rgb", "0 0 0", "123 45 67")
+
+    fun `test write rgb 255 255 255`() = doFuncWriteTest("rgb", "255 255 255", "123 45 67")
+    fun `test write rgb 0 0 0 with alpha`() = doFuncWriteTest("rgb", "0 0 0", "123 45 67", RGB(123, 45, 67, .5f))
+
+    fun `test write rgb255 0 0 0`() = doFuncWriteTest("rgb255", "0 0 0", "123 45 67")
+
+    fun `test write rgba 0 0 0 0`() = doFuncWriteTest("rgba", "0 0 0 0", "123 45 67 1")
+    fun `test write rgba 255 255 255 1`() = doFuncWriteTest("rgba", "255 255 255 1", "123 45 67 0.2", RGB(123, 45, 67, .2f))
+
+    fun `test write rgb float 1 1 1`() = doFuncWriteTest("rgb", "1 1 1", "0.4824 0.1765 0.2627")
+    fun `test write rgb float 0_5 0_5 0_5`() = doFuncWriteTest("rgb", "0.5 0.5 05", "0.4824 0.1765 0.2627")
+
+    fun `test write rgba 1 1 1 1`() = doFuncWriteTest("rgba", "1 1 1 1", "0.4824 0.1765 0.2627 1")
+    fun `test write rgba float`() = doFuncWriteTest("rgba", "0.5 0.5 05 0.5", "0.4824 0.1765 0.2627 1")
+
+    fun `test write hsl 0 0 0`() = doFuncWriteTest("hsl", "0 0 0", "0 0 0", HSL(0, 0, 0))
+    fun `test write hsl 360 1 1`() = doFuncWriteTest("hsl", "360 1 1", "180 0.5 0.5", HSL(180, 50, 50))
+
+    fun `test write hsla 0 0 0 0`() = doFuncWriteTest("hsla", "0 0 0 0", "0 0 0 1", HSL(0, 0, 0))
+    fun `test write hsla 360 1 1 1`() = doFuncWriteTest("hsla", "360 1 1 1", "180 0.5 0.5 0.2", HSL(180, 50, 50, .2f))
+
+    fun `test write rgb with linebreaks and comments`() = doWriteTest(RGB(123, 45, 67), """
+main = rgb{-caret-}
+    -- red
+    2 --
+     3 {--}
+      {--}4
+""", """
+main = rgb
+    -- red
+    123 --
+     45 {--}
+      {--}67
+""")
+
+    //</editor-fold>
+
+    private fun doFormatTest(color: String) {
+        doGutterTest(1, """
+        import Html.Attributes exposing (style)
+        main = style "color" "$color"
+        """.trimIndent())
+    }
+
+    private fun doGutterTest(expected: Int, @Language("Elm") code: String) {
+        InlineFile(code)
+        val actual = myFixture.findAllGutters().count { it.icon is ColorIcon }
+        assertEquals(expected, actual)
+    }
+
+    private fun doCssWriteTest(before: String, after: String, color: ConvertibleColor = RGB(123, 45, 67)) {
+        doWriteTest(color, "main = \". $before {-caret-}.\"", "main = \". $after .\"")
+    }
+
+    private fun doFuncWriteTest(func: String, before: String, after: String, color: ConvertibleColor = RGB(123, 45, 67)) {
+        doWriteTest(color, "main = $func{-caret-} $before", "main = $func $after")
+    }
+
+    private fun doWriteTest(color: ConvertibleColor, @Language("Elm") before: String, @Language("Elm") after: String) {
+        InlineFile(before)
+        val element = myFixture.file.findElementAt(myFixture.caretOffset - 1)
+        requireNotNull(element)
+        val awtColor = color.toAwtColor()
+        runWriteAction {
+            ElmColorProvider().setColorTo(element, awtColor)
+        }
+        myFixture.checkResult(after)
+    }
+}

--- a/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/psi/ElmGlobalModificationTrackerTest.kt
@@ -154,7 +154,7 @@ foo = ()
         val file = p.psiFile(filename).virtualFile!!
         checkModCount(op) {
             runWriteAction {
-                file.delete(null)
+                action(file)
             }
         }
     }

--- a/src/test/kotlin/org/elmPerformanceTests/ElmHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/elmPerformanceTests/ElmHighlightingPerformanceTest.kt
@@ -64,7 +64,7 @@ class ElmHighlightingPerformanceTest : ElmRealProjectTestBase() {
 
     private fun highlightProjectFile(info: RealProjectInfo, filePath: String): Timings {
         val timings = Timings()
-        val base = openRealProject(info) ?: return timings
+        openRealProject(info) ?: return timings
 
         myFixture.configureFromTempProjectFile(filePath)
 


### PR DESCRIPTION
Add color swatch line markers

This PR adds a marker to lines containing expressions with colors. Clicking the marker will open a color picker, and choosing a color from that picker will update the expression, keeping whatever format and units currently exists.

![Capture](https://user-images.githubusercontent.com/1109214/71383310-9f847d80-2590-11ea-8b3c-7d138bf12229.PNG)

I added support for colors in two formats:

## String literals

And string that contains a CSS hex, hsl(a), or rgb(a) color will work. The string can contain other characters. I chose not to limit this to arguments to know functions, since these formats are fairly unique, so it seems that the risk of false positives are low. On the other hand, because I didn't limit which strings can contain a color, I chose not to support CSS color keywords such as `"red"` or `"rebeccapurple"`, since I think it would lead to noticeable false-positives. Like all decisions, this is open for discussion.

## Function calls

I support a specific set of functions when called with number literals. I do not attempt to resolve references if the arguments to these functions are in a variable or other expression. I support most of the color functions from [elm-css](https://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Css#rgb) and [elm-ui](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/Element#rgb).

The following functions are supported:

- `rgb`, with either `Int` arguments (like in elm-css) or `Float` arguments (like elm-ui)
- `rgba`
- `rgb255`
- `rgba255`
- `hsl`
- `hsla`

The marker provider only looks at the function name and arguments. This mean we don't need to resolve any references in the marker provider, and allows us to support identical functions in other libraries (there are a number of Elm packages that copy these functions).

## Limitations

### Multiple colors in a string

Even though IntelliJ supports multiple color markers per line, due to the way `ElementColorProvider` is designed, each PsiElement can only have one color. This prevents us from showing more than one marker for each string literal, even if the colors are on separate lines.

A possible workaround would be to add a color to the `OPEN_QUOTE` and `CLOSE_QUOTE` elements in addition to the existing `REGULAR_STRING_PART` element. This would allow us to have at least three colors per string literal.

### Rounding

When a user chooses a color from the picker, floating point number might not match the chosen color exactly. `ElementColorProvider` gives us the user's choice as a `java.awt.Color`, which only has 8-bit color channels (including alpha) rather than floating point numbers. 

For example, if the user chooses an alpha of `0.5`, `java.awt.Color` rounds this to 127, which is `0.498 * 255`, so we have no way of knowing that the user actually selected 0.5 instead. I'm open to suggestions on how to improve this situation.