### PR TITLE
Make the elm-test code match our Kotlin style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
         classpath "com.github.JetBrains:gradle-grammar-kit-plugin:2019.1"
     }
 }
@@ -29,7 +29,7 @@ repositories {
     maven { url 'http://dl.bintray.com/jetbrains/markdown' }
 }
 
-ext.kotlinVersion = '1.3.50'
+ext.kotlinVersion = '1.3.61'
 ext.junitVersion = '4.12'
 ext.jacksonVersion = '2.9.8'
 ext.markdownVersion = '0.1.31'

--- a/build.gradle
+++ b/build.gradle
@@ -59,16 +59,12 @@ def genRoot = file('gen')
 sourceSets {
     main {
         kotlin.srcDir 'src/main/kotlin'
-        java {
-            srcDirs 'src/main/java'
-            srcDirs genRoot
-        }
+        java.srcDir genRoot
         resources.srcDir 'src/main/resources'
     }
 
     test {
         kotlin.srcDir 'src/test/kotlin'
-        java.srcDir 'src/test/java'
         resources.srcDir 'src/test/resources'
     }
 }

--- a/src/main/kotlin/org/elm/ide/test/core/ElmProjectTestsHelper.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/ElmProjectTestsHelper.kt
@@ -56,6 +56,7 @@ class ElmProjectTestsHelper(project: Project) {
     companion object {
 
         fun elmFolderForTesting(elmProject: ElmProject): Path {
+            // TODO [drop 0.18] this function can be removed
             return if (elmProject.isElm18 && elmProject.presentableName == "tests")
                 elmProject.projectDirPath.parent
             else

--- a/src/main/kotlin/org/elm/ide/test/core/ElmProjectTestsHelper.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/ElmProjectTestsHelper.kt
@@ -1,28 +1,20 @@
 package org.elm.ide.test.core
 
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import org.elm.workspace.ElmProject
-import org.elm.workspace.ElmWorkspaceService
+import org.elm.workspace.elmWorkspace
 import java.nio.file.Files
 import java.nio.file.Path
 
 class ElmProjectTestsHelper(project: Project) {
 
-    private val workspaceService: ElmWorkspaceService
+    private val elmWorkspace = project.elmWorkspace
 
-    private val testableProjects: Sequence<ElmProject>
-        get() = workspaceService.allProjects.asSequence()
+    private val testableProjects: List<ElmProject>
+        get() = elmWorkspace.allProjects
                 .filter { Files.exists(it.projectDirPath.resolve("tests")) }
 
-    init {
-        workspaceService = ServiceManager.getService(project, ElmWorkspaceService::class.java)
-    }
-
-    fun allNames(): Sequence<String> {
-        return testableProjects
-                .map { it.presentableName }
-    }
+    fun allNames() = testableProjects.map { it.presentableName }
 
     fun nameByProjectDirPath(path: String): String? {
         return testableProjects
@@ -34,15 +26,13 @@ class ElmProjectTestsHelper(project: Project) {
     fun projectDirPathByName(name: String): String? {
         return testableProjects
                 .filter { it.presentableName == name }
-                .map { it.projectDirPath }
-                .map { it.toString() }
+                .map { it.projectDirPath.toString() }
                 .firstOrNull()
     }
 
     fun elmProjectByProjectDirPath(path: String): ElmProject? {
         return testableProjects
-                .filter { it.projectDirPath.toString() == path }
-                .firstOrNull()
+                .firstOrNull { it.projectDirPath.toString() == path }
     }
 
     fun adjustElmCompilerProjectDirPath(elmFolder: String, compilerPath: Path): Path {
@@ -55,7 +45,6 @@ class ElmProjectTestsHelper(project: Project) {
     }
 
     companion object {
-
         fun elmFolderForTesting(elmProject: ElmProject): Path {
             // TODO [drop 0.18] this function can be removed
             return if (elmProject.isElm18 && elmProject.presentableName == "tests")
@@ -64,5 +53,4 @@ class ElmProjectTestsHelper(project: Project) {
                 elmProject.projectDirPath
         }
     }
-
 }

--- a/src/main/kotlin/org/elm/ide/test/core/ElmProjectTestsHelper.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/ElmProjectTestsHelper.kt
@@ -46,6 +46,7 @@ class ElmProjectTestsHelper(project: Project) {
     }
 
     fun adjustElmCompilerProjectDirPath(elmFolder: String, compilerPath: Path): Path {
+        // TODO [drop 0.18] this function can be removed
         return if (elmProjectByProjectDirPath(elmFolder)?.isElm18 == true) {
             compilerPath.resolveSibling("elm-make")
         } else {

--- a/src/main/kotlin/org/elm/ide/test/core/ElmTestJsonProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/ElmTestJsonProcessor.kt
@@ -8,8 +8,7 @@ import com.intellij.execution.testframework.sm.runner.events.*
 import org.elm.ide.test.core.LabelUtils.commonParent
 import org.elm.ide.test.core.LabelUtils.getName
 import org.elm.ide.test.core.LabelUtils.subParents
-import org.elm.ide.test.core.LabelUtils.toSuiteLocationUrl
-import org.elm.ide.test.core.LabelUtils.toTestLocationUrl
+import org.elm.ide.test.core.LabelUtils.toLocationUrl
 import org.elm.ide.test.core.json.CompileErrors
 import org.elm.ide.test.core.json.Error
 import java.nio.file.Path
@@ -65,7 +64,7 @@ class ElmTestJsonProcessor {
     }
 
     private fun newTestSuiteStartedEvent(path: Path): TestSuiteStartedEvent {
-        return TestSuiteStartedEvent(getName(path), toSuiteLocationUrl(path))
+        return TestSuiteStartedEvent(getName(path), toLocationUrl(path, isSuite = true))
     }
 
     private fun newTestSuiteFinishedEvent(path: Path): TestSuiteFinishedEvent {
@@ -142,7 +141,7 @@ class ElmTestJsonProcessor {
         }
 
         private fun newTestStartedEvent(path: Path): TestStartedEvent {
-            return TestStartedEvent(getName(path), toTestLocationUrl(path))
+            return TestStartedEvent(getName(path), toLocationUrl(path))
         }
 
         private fun sureText(comment: String?): String {

--- a/src/main/kotlin/org/elm/ide/test/core/ElmTestJsonProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/ElmTestJsonProcessor.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.testframework.sm.runner.events.*
 import org.elm.ide.test.core.LabelUtils.commonParent
 import org.elm.ide.test.core.LabelUtils.getName
 import org.elm.ide.test.core.LabelUtils.subParents
-import org.elm.ide.test.core.LabelUtils.toErrorLocationUrl
 import org.elm.ide.test.core.LabelUtils.toSuiteLocationUrl
 import org.elm.ide.test.core.LabelUtils.toTestLocationUrl
 import org.elm.ide.test.core.json.CompileErrors
@@ -89,7 +88,11 @@ class ElmTestJsonProcessor {
                 ?.asSequence()
                 ?.flatMap { problem ->
                     sequenceOf(
-                            TestStartedEvent(problem.title!!, toErrorLocationUrl(error.path!!, problem.region?.start!!.line, problem.region?.start!!.column)),
+                            TestStartedEvent(problem.title!!, ErrorLabelLocation(
+                                    file = error.path!!,
+                                    line = problem.region?.start!!.line,
+                                    column = problem.region?.start!!.column
+                            ).toUrl()),
                             TestFailedEvent(problem.title!!, null, problem.textMessage, null, true, null, null, null, null, false, false, -1)
                     )
                 }

--- a/src/main/kotlin/org/elm/ide/test/core/ElmTestJsonProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/ElmTestJsonProcessor.kt
@@ -216,9 +216,10 @@ class ElmTestJsonProcessor {
 
         fun toPath(element: JsonObject): Path {
             return LabelUtils.toPath(
-                    element.get("labels").asJsonArray.iterator().asSequence()
+                    *element.get("labels").asJsonArray.iterator().asSequence()
                             .map { it.asString }
                             .toList()
+                            .toTypedArray()
             )
         }
 

--- a/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
@@ -47,16 +47,9 @@ object LabelUtils {
         return decodeLabel(path.fileName)
     }
 
-    fun toSuiteLocationUrl(path: Path): String {
-        return toLocationUrl(DESCRIBE_PROTOCOL, path)
-    }
-
-    fun toTestLocationUrl(path: Path): String {
-        return toLocationUrl(TEST_PROTOCOL, path)
-    }
-
-    private fun toLocationUrl(protocol: LabelProtocol, path: Path): String {
-        return String.format("%s://%s", protocol.protocol, pathString(path))
+    fun toLocationUrl(path: Path, isSuite: Boolean = false): String {
+        val p = if (isSuite) DESCRIBE_PROTOCOL else TEST_PROTOCOL
+        return String.format("%s://%s", p.protocol, pathString(path))
     }
 
     fun fromLocationUrlPath(path: String): Pair<String, String> {

--- a/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
@@ -1,19 +1,17 @@
 package org.elm.ide.test.core
 
 import com.intellij.openapi.util.io.FileUtil
-import org.elm.ide.test.core.LabelProtocol.*
+import org.elm.ide.test.core.LabelUtils.ERROR_PROTOCOL
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.file.Path
 import java.nio.file.Paths
 
-enum class LabelProtocol(val protocol: String) {
-    DESCRIBE_PROTOCOL("elmTestDescribe"),
-    TEST_PROTOCOL("elmTestTest"),
-    ERROR_PROTOCOL("elmTestError")
-}
-
 object LabelUtils {
+
+    val DESCRIBE_PROTOCOL = "elmTestDescribe"
+    val TEST_PROTOCOL = "elmTestTest"
+    val ERROR_PROTOCOL = "elmTestError"
 
     val EMPTY_PATH = Paths.get("")
 
@@ -48,8 +46,8 @@ object LabelUtils {
     }
 
     fun toLocationUrl(path: Path, isSuite: Boolean = false): String {
-        val p = if (isSuite) DESCRIBE_PROTOCOL else TEST_PROTOCOL
-        return String.format("%s://%s", p.protocol, pathString(path))
+        val protocol = if (isSuite) DESCRIBE_PROTOCOL else TEST_PROTOCOL
+        return String.format("%s://%s", protocol, pathString(path))
     }
 
     fun fromLocationUrlPath(path: String): Pair<String, String> {
@@ -105,7 +103,7 @@ data class ErrorLabelLocation(
         val column: Int
 ) {
     fun toUrl() =
-            String.format("%s://%s::%d::%d", ERROR_PROTOCOL.protocol, file, line, column)
+            String.format("%s://%s::%d::%d", ERROR_PROTOCOL, file, line, column)
 
     companion object {
         fun fromUrl(spec: String): ErrorLabelLocation {

--- a/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
@@ -33,7 +33,7 @@ object LabelUtils {
         return URLDecoder.decode(encoded, "utf8")
     }
 
-    fun toPath(labels: List<String>): Path {
+    fun toPath(vararg labels: String): Path {
         if (labels.isEmpty()) return EMPTY_PATH
         val encoded = labels.map { encodeLabel(it) }
         return Paths.get(encoded.first(), *encoded.drop(1).toList().toTypedArray())

--- a/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
@@ -1,17 +1,20 @@
 package org.elm.ide.test.core
 
-import com.intellij.openapi.util.Pair
 import com.intellij.openapi.util.io.FileUtil
+import org.elm.ide.test.core.LabelProtocol.*
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.file.Path
 import java.nio.file.Paths
 
+enum class LabelProtocol(val protocol: String) {
+    DESCRIBE_PROTOCOL("elmTestDescribe"),
+    TEST_PROTOCOL("elmTestTest"),
+    ERROR_PROTOCOL("elmTestError")
+}
+
 object LabelUtils {
-    val DESCRIBE_PROTOCOL = "elmTestDescribe"
-    val TEST_PROTOCOL = "elmTestTest"
-    val ERROR_PROTOCOL = "elmTestError"
 
     val EMPTY_PATH = Paths.get("")
 
@@ -70,8 +73,8 @@ object LabelUtils {
         return toLocationUrl(TEST_PROTOCOL, path)
     }
 
-    private fun toLocationUrl(protocol: String, path: Path): String {
-        return String.format("%s://%s", protocol, pathString(path))
+    private fun toLocationUrl(protocol: LabelProtocol, path: Path): String {
+        return String.format("%s://%s", protocol.protocol, pathString(path))
     }
 
     fun fromLocationUrlPath(path: String): Pair<String, String> {
@@ -132,7 +135,7 @@ data class ErrorLabelLocation(
         val column: Int
 ) {
     fun toUrl() =
-            String.format("%s://%s::%d::%d", LabelUtils.ERROR_PROTOCOL, file, line, column)
+            String.format("%s://%s::%d::%d", ERROR_PROTOCOL.protocol, file, line, column)
 
     companion object {
         fun fromUrl(spec: String): ErrorLabelLocation {

--- a/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
@@ -9,12 +9,10 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 object LabelUtils {
-    val ELM_TEST_PROTOCOL = "elmTest"
-    val DESCRIBE_PROTOCOL = ELM_TEST_PROTOCOL + "Describe"
-    private val TEST_PROTOCOL = ELM_TEST_PROTOCOL + "Test"
-    val ERROR_PROTOCOL = ELM_TEST_PROTOCOL + "Error"
+    val DESCRIBE_PROTOCOL = "elmTestDescribe"
+    val TEST_PROTOCOL = "elmTestTest"
+    val ERROR_PROTOCOL = "elmTestError"
 
-    //internal
     val EMPTY_PATH = Paths.get("")
 
     private fun getModuleName(path: Path): String {
@@ -30,12 +28,10 @@ object LabelUtils {
 
     }
 
-    //internal
     fun decodeLabel(encoded: Path): String {
         return decodeLabel(pathString(encoded))
     }
 
-    //internal
     fun decodeLabel(encoded: String): String {
         try {
             return URLDecoder.decode(encoded, "utf8")
@@ -44,7 +40,6 @@ object LabelUtils {
         }
     }
 
-    //internal
     fun toPath(labels: List<String>): Path {
         val encoded = labels
                 .asSequence()
@@ -59,7 +54,6 @@ object LabelUtils {
         }
     }
 
-    //internal
     fun pathString(path: Path): String {
         return FileUtil.toSystemIndependentName(path.toString())
     }
@@ -68,12 +62,10 @@ object LabelUtils {
         return decodeLabel(path.fileName)
     }
 
-    //internal
     fun toSuiteLocationUrl(path: Path): String {
         return toLocationUrl(DESCRIBE_PROTOCOL, path)
     }
 
-    //internal
     fun toTestLocationUrl(path: Path): String {
         return toLocationUrl(TEST_PROTOCOL, path)
     }
@@ -90,7 +82,6 @@ object LabelUtils {
         return Pair(moduleFile, label)
     }
 
-    //internal
     fun commonParent(path1: Path?, path2: Path): Path {
         if (path1 == null) {
             return EMPTY_PATH
@@ -105,7 +96,6 @@ object LabelUtils {
         }
     }
 
-    //internal
     fun subParents(path: Path, excludeParent: Path): Sequence<Path> {
         if (excludeParent === EMPTY_PATH) {
             var current: Path? = path
@@ -134,17 +124,24 @@ object LabelUtils {
         }
     }
 
-    //internal
-    fun toErrorLocationUrl(path: String, line: Int, column: Int): String {
-        return String.format("%s://%s::%d::%d", ERROR_PROTOCOL, path, line, column)
-    }
+}
 
-    fun fromErrorLocationUrlPath(spec: String): Pair<String, Pair<Int, Int>> {
-        val parts = spec.split("::".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        val file = parts[0]
-        val line = if (parts.size > 1) Integer.parseInt(parts[1]) else 1
-        val column = if (parts.size > 2) Integer.parseInt(parts[2]) else 1
-        return Pair(file, Pair(line, column))
-    }
+data class ErrorLabelLocation(
+        val file: String,
+        val line: Int,
+        val column: Int
+) {
+    fun toUrl() =
+            String.format("%s://%s::%d::%d", LabelUtils.ERROR_PROTOCOL, file, line, column)
 
+    companion object {
+        fun fromUrl(spec: String): ErrorLabelLocation {
+            val parts = spec.split("::").dropLastWhile { it.isEmpty() }
+            return ErrorLabelLocation(
+                    file = parts[0],
+                    line = if (parts.size > 1) Integer.parseInt(parts[1]) else 1,
+                    column = if (parts.size > 2) Integer.parseInt(parts[2]) else 1
+            )
+        }
+    }
 }

--- a/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
+++ b/src/main/kotlin/org/elm/ide/test/core/LabelUtils.kt
@@ -2,7 +2,6 @@ package org.elm.ide.test.core
 
 import com.intellij.openapi.util.io.FileUtil
 import org.elm.ide.test.core.LabelProtocol.*
-import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.file.Path
@@ -23,12 +22,7 @@ object LabelUtils {
     }
 
     private fun encodeLabel(label: String): String {
-        try {
-            return URLEncoder.encode(label, "utf8")
-        } catch (e: UnsupportedEncodingException) {
-            throw RuntimeException(e)
-        }
-
+        return URLEncoder.encode(label, "utf8")
     }
 
     fun decodeLabel(encoded: Path): String {
@@ -36,25 +30,13 @@ object LabelUtils {
     }
 
     fun decodeLabel(encoded: String): String {
-        try {
-            return URLDecoder.decode(encoded, "utf8")
-        } catch (e: UnsupportedEncodingException) {
-            throw RuntimeException(e)
-        }
+        return URLDecoder.decode(encoded, "utf8")
     }
 
     fun toPath(labels: List<String>): Path {
-        val encoded = labels
-                .asSequence()
-                .map { encodeLabel(it) }
-
-        return if (encoded.count() < 1) {
-            EMPTY_PATH
-        } else {
-            Paths.get(
-                    encoded.first(),
-                    *encoded.drop(1).toList().toTypedArray())
-        }
+        if (labels.isEmpty()) return EMPTY_PATH
+        val encoded = labels.map { encodeLabel(it) }
+        return Paths.get(encoded.first(), *encoded.drop(1).toList().toTypedArray())
     }
 
     fun pathString(path: Path): String {
@@ -86,16 +68,11 @@ object LabelUtils {
     }
 
     fun commonParent(path1: Path?, path2: Path): Path {
-        if (path1 == null) {
-            return EMPTY_PATH
-        }
-        if (path1.nameCount > path2.nameCount) {
-            return commonParent(path2, path1)
-        }
-        return if (path2.startsWith(path1)) {
-            path1
-        } else {
-            commonParent(path1.parent, path2)
+        return when {
+            path1 == null -> EMPTY_PATH
+            path1.nameCount > path2.nameCount -> commonParent(path2, path1)
+            path2.startsWith(path1) -> path1
+            else -> commonParent(path1.parent, path2)
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestAutoTestManager.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestAutoTestManager.kt
@@ -1,32 +1,30 @@
 package org.elm.ide.test.run
 
 import com.intellij.execution.testframework.autotest.AbstractAutoTestManager
-import com.intellij.execution.testframework.autotest.AutoTestWatcher
 import com.intellij.execution.testframework.autotest.DelayedDocumentWatcher
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.StoragePathMacros
+import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import org.elm.lang.core.ElmFileType
 
-@State(name = "ElmTestAutoTestManager", storages = [Storage(StoragePathMacros.WORKSPACE_FILE)])
-class ElmTestAutoTestManager internal constructor(project: Project) : AbstractAutoTestManager(project) {
+@State(
+        name = "ElmTestAutoTestManager",
+        storages = [Storage(StoragePathMacros.WORKSPACE_FILE)]
+)
+class ElmTestAutoTestManager internal constructor(
+        project: Project
+) : AbstractAutoTestManager(project) {
 
-    override fun createWatcher(project: Project): AutoTestWatcher {
-        return DelayedDocumentWatcher(project,
-                myDelayMillis,
-                { this.restartAllAutoTests(it) },
-                { file -> FileEditorManager.getInstance(project).isFileOpen(file) && ElmFileType == file.fileType }
-        )
-    }
-
-    companion object {
-
-        internal fun getInstance(project: Project): ElmTestAutoTestManager {
-            return ServiceManager.getService(project, ElmTestAutoTestManager::class.java)
-        }
-    }
-
+    override fun createWatcher(project: Project) =
+            DelayedDocumentWatcher(project,
+                    myDelayMillis,
+                    { restartAllAutoTests(it) },
+                    { it.fileType == ElmFileType && FileEditorManager.getInstance(project).isFileOpen(it) }
+            )
 }
+
+val Project.elmAutoTestManager
+    get() = service<ElmTestAutoTestManager>()

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestConfigurationFactory.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestConfigurationFactory.kt
@@ -2,31 +2,19 @@ package org.elm.ide.test.run
 
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
-import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.project.Project
 import org.elm.ide.icons.ElmIcons
-import javax.swing.Icon
 
 class ElmTestConfigurationFactory internal constructor(type: ConfigurationType) : ConfigurationFactory(type) {
 
-    override fun createTemplateConfiguration(project: Project): RunConfiguration {
-        return ElmTestRunConfiguration(project, this, "Elm Test")
-    }
+    override fun createTemplateConfiguration(project: Project) =
+            ElmTestRunConfiguration(project, this, "Elm Test")
 
-    override fun getName(): String {
-        return FACTORY_NAME
-    }
+    override fun getName() = "Elm Test configuration factory"
 
-    override fun getIcon(): Icon? {
-        return RUN_ICON
-    }
+    override fun getIcon() = RUN_ICON
 
     companion object {
-
-        private val FACTORY_NAME = "Elm Test configuration factory"
-
-//        internal
         val RUN_ICON = ElmIcons.COLORFUL
     }
-
 }

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestLocator.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestLocator.kt
@@ -17,7 +17,7 @@ import org.elm.ide.test.core.LabelProtocol.*
 import org.elm.ide.test.core.LabelUtils
 
 
-class ElmTestLocator private constructor() : FileUrlProvider() {
+object ElmTestLocator : FileUrlProvider() {
 
     override fun getLocation(protocol: String, path: String, metainfo: String?, project: Project, scope: GlobalSearchScope): List<Location<*>> {
         when (val p = LabelProtocol.valueOf(protocol)) {
@@ -62,9 +62,5 @@ class ElmTestLocator private constructor() : FileUrlProvider() {
         val element = psiFile.findElementAt(offset) ?: return PsiLocation.fromPsiElement(project, psiFile)
 
         return PsiLocation.fromPsiElement(project, element)
-    }
-
-    companion object {
-        val INSTANCE = ElmTestLocator()
     }
 }

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestLocator.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestLocator.kt
@@ -11,47 +11,48 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
 import org.elm.ide.test.core.ElmPluginHelper
+import org.elm.ide.test.core.ErrorLabelLocation
 import org.elm.ide.test.core.LabelUtils
 
 
 class ElmTestLocator private constructor() : FileUrlProvider() {
 
     override fun getLocation(protocol: String, path: String, metainfo: String?, project: Project, scope: GlobalSearchScope): List<Location<*>> {
-        if (!protocol.startsWith(LabelUtils.ELM_TEST_PROTOCOL)) {
-            return super.getLocation(protocol, path, metainfo, project, scope)
+        when (protocol) {
+            LabelUtils.ERROR_PROTOCOL -> {
+                val label = ErrorLabelLocation.fromUrl(path)
+                val systemIndependentPath = FileUtil.toSystemIndependentName(label.file)
+                val virtualFiles = TestsLocationProviderUtil.findSuitableFilesFor(systemIndependentPath, project)
+                return if (virtualFiles.isEmpty()) {
+                    emptyList()
+                } else virtualFiles
+                        .mapNotNull { getErrorLocation(label.line, label.column, project, it) }
+                        .map { it!! }
+            }
+
+            LabelUtils.DESCRIBE_PROTOCOL, LabelUtils.TEST_PROTOCOL -> {
+                val pair = LabelUtils.fromLocationUrlPath(path)
+                val filePath = pair.first
+                val labels = pair.second
+
+                val systemIndependentPath = FileUtil.toSystemIndependentName(filePath)
+                val virtualFiles = TestsLocationProviderUtil.findSuitableFilesFor(systemIndependentPath, project)
+                if (virtualFiles.isEmpty()) {
+                    return emptyList()
+                }
+
+                val isDescribe = LabelUtils.DESCRIBE_PROTOCOL == protocol
+
+                return virtualFiles
+                        .map { getLocation(isDescribe, labels, project, it) }
+                        .filter { it != null }
+                        .map { it!! }
+            }
+
+            else -> {
+                return super.getLocation(protocol, path, metainfo, project, scope)
+            }
         }
-
-        if (protocol.startsWith(LabelUtils.ERROR_PROTOCOL)) {
-            val pair = LabelUtils.fromErrorLocationUrlPath(path)
-            val filePath = pair.first
-            val line = pair.second.first
-            val column = pair.second.second
-
-            val systemIndependentPath = FileUtil.toSystemIndependentName(filePath)
-            val virtualFiles = TestsLocationProviderUtil.findSuitableFilesFor(systemIndependentPath, project)
-            return if (virtualFiles.isEmpty()) {
-                emptyList()
-            } else virtualFiles
-                    .mapNotNull { getErrorLocation(line, column, project, it) }
-                    .map { it!! }
-        }
-
-        val pair = LabelUtils.fromLocationUrlPath(path)
-        val filePath = pair.first
-        val labels = pair.second
-
-        val systemIndependentPath = FileUtil.toSystemIndependentName(filePath)
-        val virtualFiles = TestsLocationProviderUtil.findSuitableFilesFor(systemIndependentPath, project)
-        if (virtualFiles.isEmpty()) {
-            return emptyList()
-        }
-
-        val isDescribe = LabelUtils.DESCRIBE_PROTOCOL == protocol
-
-        return virtualFiles
-                .map { getLocation(isDescribe, labels, project, it) }
-                .filter { it != null }
-                .map { it!! }
     }
 
     private fun getLocation(isDescribe: Boolean, labels: String, project: Project, virtualFile: VirtualFile): Location<*>? {
@@ -74,6 +75,6 @@ class ElmTestLocator private constructor() : FileUrlProvider() {
     }
 
     companion object {
-        internal val INSTANCE = ElmTestLocator()
+        val INSTANCE = ElmTestLocator()
     }
 }

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestProgramRunner.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestProgramRunner.kt
@@ -16,28 +16,20 @@ class ElmTestProgramRunner : GenericProgramRunner<Settings>() {
 
     @Throws(ExecutionException::class)
     override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor? {
-        val result = state.execute(environment.executor, this)
-        val descriptor = RunContentBuilder(result!!, environment).showRunContent(environment.contentToReuse)
-        return withReusePolicy(descriptor)
+        val result = state.execute(environment.executor, this) ?: return null
+        return RunContentBuilder(result, environment)
+                .showRunContent(environment.contentToReuse)
+                .apply {
+                    reusePolicy = object : RunContentDescriptorReusePolicy() {
+                        override fun canBeReusedBy(newDescriptor: RunContentDescriptor) = true
+                    }
+                }
     }
 
+    override fun getRunnerId() = "ELM_TEST_PROGRAM_RUNNER"
 
-    private fun withReusePolicy(descriptor: RunContentDescriptor): RunContentDescriptor {
-        descriptor.reusePolicy = object : RunContentDescriptorReusePolicy() {
-            override fun canBeReusedBy(newDescriptor: RunContentDescriptor): Boolean {
-                return true
-            }
-        }
-        return descriptor
-    }
-
-    override fun getRunnerId(): String {
-        return "ELM_TEST_PROGRAM_RUNNER"
-    }
-
-    override fun canRun(executorId: String, profile: RunProfile): Boolean {
-        return DefaultRunExecutor.EXECUTOR_ID == executorId && profile is ElmTestRunConfiguration
-    }
+    override fun canRun(executorId: String, profile: RunProfile) =
+            DefaultRunExecutor.EXECUTOR_ID == executorId && profile is ElmTestRunConfiguration
 }
 
 class Settings : RunnerSettings {

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestRunConfiguration.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestRunConfiguration.kt
@@ -12,56 +12,45 @@ import com.intellij.openapi.util.WriteExternalException
 import org.elm.ide.test.run.ElmTestConfigurationFactory.Companion.RUN_ICON
 import org.jdom.Element
 import java.nio.file.Paths
-import javax.swing.Icon
 
 
 class ElmTestRunConfiguration internal constructor(project: Project, factory: ConfigurationFactory, name: String) : LocatableConfigurationBase<ElmTestRunProfileState>(project, factory, name) {
 
-    internal var options = Options()
+    var options = Options()
 
-    override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
-        return ElmTestSettingsEditor(project)
-    }
+    override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =
+            ElmTestSettingsEditor(project)
 
     override fun checkConfiguration() {}
 
-    override fun getState(executor: Executor, executionEnvironment: ExecutionEnvironment): ElmTestRunProfileState? {
-        return ElmTestRunProfileState(executionEnvironment, this)
-    }
+    override fun getState(executor: Executor, executionEnvironment: ExecutionEnvironment) =
+            ElmTestRunProfileState(executionEnvironment, this)
 
-    //internal
     class Options {
         var elmFolder: String? = null
     }
 
-    override fun getIcon(): Icon? {
-        return RUN_ICON
-    }
+    override fun getIcon() = RUN_ICON
 
     @Throws(InvalidDataException::class)
     override fun readExternal(element: Element) {
-        this.options = readOptions(element)
+        options = readOptions(element)
     }
 
     @Throws(WriteExternalException::class)
     override fun writeExternal(element: Element) {
-        writeOptions(this.options, element)
+        writeOptions(options, element)
     }
 
     override fun suggestedName(): String? {
-        if (options.elmFolder == null) {
-            return null
-        }
-        val elmProjectName = Paths.get(options.elmFolder).fileName
-        return "Tests in $elmProjectName"
+        val elmFolder = options.elmFolder ?: return null
+        return "Tests in ${Paths.get(elmFolder).fileName}"
     }
 
     companion object {
 
+        // <ElmTestRunConfiguration elm-folder="" />
 
-        // <ElmTestRunConfiguration elm-folder="" elm-test-binary=""/>
-
-        //internal
         fun writeOptions(options: Options, element: Element) {
             val e = Element(ElmTestRunConfiguration::class.java.simpleName)
             if (options.elmFolder != null) {
@@ -70,21 +59,11 @@ class ElmTestRunConfiguration internal constructor(project: Project, factory: Co
             element.addContent(e)
         }
 
-        //internal
         fun readOptions(element: Element): Options {
-            val result = Options()
-
-            val name = ElmTestRunConfiguration::class.java.simpleName
-            val optionsElement = element.getChild(name)
-
-            if (optionsElement != null) {
-                val elmFolderAttr = optionsElement.getAttribute("elm-folder")
-                result.elmFolder = null
-                if (elmFolderAttr != null) {
-                    result.elmFolder = elmFolderAttr.value
-                }
+            return Options().apply {
+                val name = ElmTestRunConfiguration::class.java.simpleName
+                elmFolder = element.getChild(name)?.getAttribute("elm-folder")?.value
             }
-            return result
         }
     }
 }

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestRunConfigurationProducer.kt
@@ -2,49 +2,31 @@ package org.elm.ide.test.run
 
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.LazyRunConfigurationProducer
-import com.intellij.execution.actions.RunConfigurationProducer
-import com.intellij.execution.configurations.ConfigurationFactory
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.elm.ide.test.core.ElmProjectTestsHelper
-import org.elm.workspace.ElmWorkspaceService
+import org.elm.workspace.elmWorkspace
 
 class ElmTestRunConfigurationProducer : LazyRunConfigurationProducer<ElmTestRunConfiguration>() {
 
-    override fun getConfigurationFactory(): ConfigurationFactory {
-        return ElmTestConfigurationFactory(ElmTestRunConfigurationType())
-    }
+    override fun getConfigurationFactory() =
+            ElmTestConfigurationFactory(ElmTestRunConfigurationType())
 
     override fun setupConfigurationFromContext(configuration: ElmTestRunConfiguration, context: ConfigurationContext, sourceElement: Ref<PsiElement>): Boolean {
-        return getCandidateElmFolder(context)
-                ?.let {
-                    configuration.options.elmFolder = it
-                    configuration.setGeneratedName()
-                    true
-                }
-                ?: false
+        val elmFolder = getCandidateElmFolder(context) ?: return false
+        configuration.options.elmFolder = elmFolder
+        configuration.setGeneratedName()
+        return true
     }
 
     override fun isConfigurationFromContext(configuration: ElmTestRunConfiguration, context: ConfigurationContext): Boolean {
-        return getCandidateElmFolder(context)
-                ?.let { it == configuration.options.elmFolder }
-                ?: false
+        val elmFolder = getCandidateElmFolder(context) ?: return false
+        return elmFolder == configuration.options.elmFolder
     }
 
-    private fun getCandidateElmFolder(context: ConfigurationContext?): String? {
-        if (context == null) {
-            return null
-        }
-
-        val elmWorkspace = ServiceManager.getService(
-                context.project, ElmWorkspaceService::class.java)
-
-        return context.location?.virtualFile
-                ?.let {
-                    elmWorkspace.findProjectForFile(it)
-                }?.let {
-                    ElmProjectTestsHelper.elmFolderForTesting(it).toString()
-                }
+    private fun getCandidateElmFolder(context: ConfigurationContext): String? {
+        val vfile = context.location?.virtualFile ?: return null
+        val elmProject = context.project.elmWorkspace.findProjectForFile(vfile) ?: return null
+        return ElmProjectTestsHelper.elmFolderForTesting(elmProject).toString()
     }
 }

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestRunConfigurationType.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestRunConfigurationType.kt
@@ -1,31 +1,18 @@
 package org.elm.ide.test.run
 
-import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
 import org.elm.ide.test.run.ElmTestConfigurationFactory.Companion.RUN_ICON
-import javax.swing.Icon
 
 class ElmTestRunConfigurationType : ConfigurationType {
-    override fun getDisplayName(): String {
-        return "Elm Test"
-    }
 
-    override fun getConfigurationTypeDescription(): String {
-        return "Elm Test Runner"
-    }
+    override fun getDisplayName() = "Elm Test"
 
-    override fun getIcon(): Icon {
-        return RUN_ICON
-    }
+    override fun getConfigurationTypeDescription() = "Elm Test Runner"
 
-    override fun getId(): String {
-        return "ELM_TEST_RUN_CONFIGURATION"
-    }
+    override fun getIcon() = RUN_ICON
 
-    override fun getConfigurationFactories(): Array<ConfigurationFactory> {
-        return arrayOf(ElmTestConfigurationFactory(this))
-    }
+    override fun getId() = "ELM_TEST_RUN_CONFIGURATION"
 
+    override fun getConfigurationFactories() = arrayOf(ElmTestConfigurationFactory(this))
 
 }
-

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestRunProfileState.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestRunProfileState.kt
@@ -10,7 +10,6 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.execution.testframework.TestConsoleProperties
-import com.intellij.execution.testframework.autotest.AbstractAutoTestManager
 import com.intellij.execution.testframework.autotest.ToggleAutoTestAction
 import com.intellij.execution.testframework.sm.SMCustomMessagesParsing
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
@@ -75,9 +74,7 @@ class ElmTestRunProfileState internal constructor(environment: ExecutionEnvironm
         val result = super.execute(executor, runner)
         if (result is DefaultExecutionResult) {
             result.setRestartActions(object : ToggleAutoTestAction() {
-                override fun getAutoTestManager(project: Project): AbstractAutoTestManager {
-                    return ElmTestAutoTestManager.getInstance(project)
-                }
+                override fun getAutoTestManager(project: Project) = project.elmAutoTestManager
             })
         }
         return result

--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestSettingsEditor.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestSettingsEditor.kt
@@ -26,9 +26,7 @@ class ElmTestSettingsEditor internal constructor(project: Project) : SettingsEdi
     private var projectChooser: ComboBox<String>? = null
 
     override fun createEditor(): JComponent {
-        helper
-                .allNames()
-                .forEach { projectChooser!!.addItem(it) }
+        helper.allNames().forEach { projectChooser!!.addItem(it) }
         return this.myPanel!!
     }
 

--- a/src/test/kotlin/org/elm/ide/test/core/ElmPluginHelperTest.kt
+++ b/src/test/kotlin/org/elm/ide/test/core/ElmPluginHelperTest.kt
@@ -5,7 +5,6 @@ import com.intellij.testFramework.ParsingTestCase
 import org.elm.ide.test.core.ElmPluginHelper.getPsiElement
 import org.elm.ide.test.core.LabelUtils.toPath
 import org.elm.lang.core.parser.ElmParserDefinition
-import java.util.*
 
 class ElmPluginHelperTest : ParsingTestCase("elmPluginHelper", "elm", ElmParserDefinition()) {
 
@@ -66,7 +65,7 @@ class ElmPluginHelperTest : ParsingTestCase("elmPluginHelper", "elm", ElmParserD
     }
 
     private fun assertSuite(offset: Int, vararg labels: String) {
-        val path = toPath(Arrays.asList(*labels))
+        val path = toPath(*labels)
         val element = getPsiElement(true, path.toString(), myFile)
 
         val expected = String.format("describe \"%s\"", labels[labels.size - 1])
@@ -75,7 +74,7 @@ class ElmPluginHelperTest : ParsingTestCase("elmPluginHelper", "elm", ElmParserD
     }
 
     private fun assertTest(offset: Int, vararg labels: String) {
-        val path = toPath(Arrays.asList(*labels))
+        val path = toPath(*labels)
         val element = getPsiElement(false, path.toString(), myFile)
 
         val expected = String.format("test \"%s\"", labels[labels.size - 1])
@@ -84,7 +83,7 @@ class ElmPluginHelperTest : ParsingTestCase("elmPluginHelper", "elm", ElmParserD
     }
 
     private fun assertFuzz(offset: Int, vararg labels: String) {
-        val path = toPath(Arrays.asList(*labels))
+        val path = toPath(*labels)
         val element = getPsiElement(false, path.toString(), myFile)
 
         val expected = String.format("fuzz fuzzer \"%s\"", labels[labels.size - 1])
@@ -93,13 +92,13 @@ class ElmPluginHelperTest : ParsingTestCase("elmPluginHelper", "elm", ElmParserD
     }
 
     private fun assertMissing(vararg labels: String) {
-        val path = toPath(Arrays.asList(*labels))
+        val path = toPath(*labels)
         val element = getPsiElement(false, path.toString(), myFile)
         assertSame(myFile, element)
     }
 
     private fun assertFallback(fallback: String, vararg labels: String) {
-        val path = toPath(Arrays.asList(*labels))
+        val path = toPath(*labels)
         val element = getPsiElement(true, path.toString(), myFile)
 
         val expected = String.format("describe \"%s\"", fallback)

--- a/src/test/kotlin/org/elm/ide/test/core/ElmTestJsonProcessorTest.kt
+++ b/src/test/kotlin/org/elm/ide/test/core/ElmTestJsonProcessorTest.kt
@@ -90,8 +90,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun closeNoSuites() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite", "test2")
         val paths = closeSuitePaths(from, to)
                 .toList()
         assertEquals(emptyList<String>(), paths)
@@ -99,8 +99,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun closeOneSuite() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite2", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite2", "test2")
         val paths = closeSuitePaths(from, to)
                 .map { pathString(it) }
                 .toList()
@@ -109,8 +109,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun closeTwoSuites() {
-        val from = toPath(listOf("Module", "suite", "deep", "test"))
-        val to = toPath(listOf("Module", "suite2", "test2"))
+        val from = toPath("Module", "suite", "deep", "test")
+        val to = toPath("Module", "suite2", "test2")
         val paths = closeSuitePaths(from, to)
                 .map { pathString(it) }
                 .toList()
@@ -119,7 +119,7 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun closeInitialSuite() {
-        val to = toPath(listOf("Module", "suite", "test"))
+        val to = toPath("Module", "suite", "test")
         val paths = closeSuitePaths(LabelUtils.EMPTY_PATH, to)
                 .map { pathString(it) }
                 .toList()
@@ -128,8 +128,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun openNoSuites() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite", "test2")
         val paths = openSuitePaths(from, to)
                 .map { pathString(it) }
                 .toList()
@@ -138,8 +138,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun openOneSuite() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite2", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite2", "test2")
         val paths = openSuitePaths(from, to)
                 .map { pathString(it) }
                 .toList()
@@ -148,8 +148,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun openTwoSuites() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite2", "deep2", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite2", "deep2", "test2")
         val paths = openSuitePaths(from, to)
                 .map { pathString(it) }
                 .toList()
@@ -158,7 +158,7 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun openInitialSuites() {
-        val to = toPath(listOf("Module", "suite", "test"))
+        val to = toPath("Module", "suite", "test")
         val paths = openSuitePaths(LabelUtils.EMPTY_PATH, to)
                 .map { pathString(it) }
                 .toList()
@@ -167,8 +167,8 @@ class ElmTestJsonProcessorTest {
 
     @Test
     fun openSuiteWithSlash() {
-        val from = toPath(listOf("Module"))
-        val to = toPath(listOf("Module", "suite / stuff", "test"))
+        val from = toPath("Module")
+        val to = toPath("Module", "suite / stuff", "test")
         val paths = openSuitePaths(from, to)
                 .map { pathString(it) }
                 .toList()

--- a/src/test/kotlin/org/elm/ide/test/core/LabelUtilsTest.kt
+++ b/src/test/kotlin/org/elm/ide/test/core/LabelUtilsTest.kt
@@ -5,36 +5,34 @@ import org.elm.ide.test.core.LabelUtils.commonParent
 import org.elm.ide.test.core.LabelUtils.fromLocationUrlPath
 import org.elm.ide.test.core.LabelUtils.pathString
 import org.elm.ide.test.core.LabelUtils.subParents
+import org.elm.ide.test.core.LabelUtils.toLocationUrl
 import org.elm.ide.test.core.LabelUtils.toPath
-import org.elm.ide.test.core.LabelUtils.toSuiteLocationUrl
-import org.elm.ide.test.core.LabelUtils.toTestLocationUrl
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.util.*
 
 class LabelUtilsTest {
 
     @Test
     fun locationUrl() {
-        val url = toTestLocationUrl(toPath(Arrays.asList("Module", "test")))
+        val url = toLocationUrl(toPath(listOf("Module", "test")))
         assertEquals("elmTestTest://Module/test", url)
     }
 
     @Test
     fun suiteLocationUrl() {
-        val url = toSuiteLocationUrl(toPath(Arrays.asList("Module", "suite")))
-        assertEquals("elmTestDescribe://Module/suite", url)
+        val url = toLocationUrl(toPath(listOf("Module", "test")), isSuite = true)
+        assertEquals("elmTestDescribe://Module/test", url)
     }
 
     @Test
     fun locationUrlWithSlash() {
-        val url = toTestLocationUrl(toPath(Arrays.asList("Nested.Module", "test / stuff")))
+        val url = toLocationUrl(toPath(listOf("Nested.Module", "test / stuff")))
         assertEquals("elmTestTest://Nested.Module/test+%2F+stuff", url)
     }
 
     @Test
     fun useLocationUrl() {
-        val url = toTestLocationUrl(toPath(Arrays.asList("Nested.Module", "test")))
+        val url = toLocationUrl(toPath(listOf("Nested.Module", "test")))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -44,7 +42,7 @@ class LabelUtilsTest {
 
     @Test
     fun useNestedLocationUrl() {
-        val url = toTestLocationUrl(toPath(Arrays.asList("Nested.Module", "suite", "test")))
+        val url = toLocationUrl(toPath(listOf("Nested.Module", "suite", "test")))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -54,7 +52,7 @@ class LabelUtilsTest {
 
     @Test
     fun useLocationUrlWithSlash() {
-        val url = toTestLocationUrl(toPath(Arrays.asList("Module", "test / stuff")))
+        val url = toLocationUrl(toPath(listOf("Module", "test / stuff")))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -64,7 +62,7 @@ class LabelUtilsTest {
 
     @Test
     fun useLocationModuleOnly() {
-        val url = toTestLocationUrl(toPath(listOf("Module")))
+        val url = toLocationUrl(toPath(listOf("Module")))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -74,8 +72,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentSameSuite() {
-        val from = toPath(Arrays.asList("Module", "suite", "test"))
-        val to = toPath(Arrays.asList("Module", "suite", "test2"))
+        val from = toPath(listOf("Module", "suite", "test"))
+        val to = toPath(listOf("Module", "suite", "test2"))
 
         val parent = commonParent(from, to)
         assertEquals("Module/suite", pathString(parent))
@@ -83,8 +81,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentDifferentSuite() {
-        val from = toPath(Arrays.asList("Module", "suite", "test"))
-        val to = toPath(Arrays.asList("Module", "suite2", "test2"))
+        val from = toPath(listOf("Module", "suite", "test"))
+        val to = toPath(listOf("Module", "suite2", "test2"))
 
         val parent = commonParent(from, to)
         assertEquals("Module", pathString(parent))
@@ -95,8 +93,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentDifferentSuite2() {
-        val from = toPath(Arrays.asList("Module", "suite", "deep", "test"))
-        val to = toPath(Arrays.asList("Module", "suite2", "test2"))
+        val from = toPath(listOf("Module", "suite", "deep", "test"))
+        val to = toPath(listOf("Module", "suite2", "test2"))
 
         val parent = commonParent(from, to)
         assertEquals("Module", pathString(parent))
@@ -107,8 +105,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentNoParent() {
-        val from = toPath(Arrays.asList("Module", "suite", "test"))
-        val to = toPath(Arrays.asList("Module2", "suite2", "test2"))
+        val from = toPath(listOf("Module", "suite", "test"))
+        val to = toPath(listOf("Module2", "suite2", "test2"))
 
         val parent = commonParent(from, to)
         assertEquals("", pathString(parent))
@@ -116,13 +114,10 @@ class LabelUtilsTest {
 
     @Test
     fun parentPaths() {
-        val path = toPath(Arrays.asList("Module", "suite", "test"))
+        val path = toPath(listOf("Module", "suite", "test"))
         val parent = toPath(listOf("Module"))
 
-        val parents = subParents(path, parent)
-                .asSequence()
-                .map { pathString(it) }
-                .toList()
+        val parents = subParents(path, parent).toList().map { pathString(it) }
 
         assertEquals(listOf("Module/suite"), parents)
     }

--- a/src/test/kotlin/org/elm/ide/test/core/LabelUtilsTest.kt
+++ b/src/test/kotlin/org/elm/ide/test/core/LabelUtilsTest.kt
@@ -14,25 +14,25 @@ class LabelUtilsTest {
 
     @Test
     fun locationUrl() {
-        val url = toLocationUrl(toPath(listOf("Module", "test")))
+        val url = toLocationUrl(toPath("Module", "test"))
         assertEquals("elmTestTest://Module/test", url)
     }
 
     @Test
     fun suiteLocationUrl() {
-        val url = toLocationUrl(toPath(listOf("Module", "test")), isSuite = true)
+        val url = toLocationUrl(toPath("Module", "test"), isSuite = true)
         assertEquals("elmTestDescribe://Module/test", url)
     }
 
     @Test
     fun locationUrlWithSlash() {
-        val url = toLocationUrl(toPath(listOf("Nested.Module", "test / stuff")))
+        val url = toLocationUrl(toPath("Nested.Module", "test / stuff"))
         assertEquals("elmTestTest://Nested.Module/test+%2F+stuff", url)
     }
 
     @Test
     fun useLocationUrl() {
-        val url = toLocationUrl(toPath(listOf("Nested.Module", "test")))
+        val url = toLocationUrl(toPath("Nested.Module", "test"))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -42,7 +42,7 @@ class LabelUtilsTest {
 
     @Test
     fun useNestedLocationUrl() {
-        val url = toLocationUrl(toPath(listOf("Nested.Module", "suite", "test")))
+        val url = toLocationUrl(toPath("Nested.Module", "suite", "test"))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -52,7 +52,7 @@ class LabelUtilsTest {
 
     @Test
     fun useLocationUrlWithSlash() {
-        val url = toLocationUrl(toPath(listOf("Module", "test / stuff")))
+        val url = toLocationUrl(toPath("Module", "test / stuff"))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -62,7 +62,7 @@ class LabelUtilsTest {
 
     @Test
     fun useLocationModuleOnly() {
-        val url = toLocationUrl(toPath(listOf("Module")))
+        val url = toLocationUrl(toPath("Module"))
         val urlPath = url.substring(url.indexOf("://") + 3)
 
         val pair = fromLocationUrlPath(urlPath)
@@ -72,8 +72,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentSameSuite() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite", "test2")
 
         val parent = commonParent(from, to)
         assertEquals("Module/suite", pathString(parent))
@@ -81,8 +81,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentDifferentSuite() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module", "suite2", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module", "suite2", "test2")
 
         val parent = commonParent(from, to)
         assertEquals("Module", pathString(parent))
@@ -93,8 +93,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentDifferentSuite2() {
-        val from = toPath(listOf("Module", "suite", "deep", "test"))
-        val to = toPath(listOf("Module", "suite2", "test2"))
+        val from = toPath("Module", "suite", "deep", "test")
+        val to = toPath("Module", "suite2", "test2")
 
         val parent = commonParent(from, to)
         assertEquals("Module", pathString(parent))
@@ -105,8 +105,8 @@ class LabelUtilsTest {
 
     @Test
     fun commonParentNoParent() {
-        val from = toPath(listOf("Module", "suite", "test"))
-        val to = toPath(listOf("Module2", "suite2", "test2"))
+        val from = toPath("Module", "suite", "test")
+        val to = toPath("Module2", "suite2", "test2")
 
         val parent = commonParent(from, to)
         assertEquals("", pathString(parent))
@@ -114,8 +114,8 @@ class LabelUtilsTest {
 
     @Test
     fun parentPaths() {
-        val path = toPath(listOf("Module", "suite", "test"))
-        val parent = toPath(listOf("Module"))
+        val path = toPath("Module", "suite", "test")
+        val parent = toPath("Module")
 
         val parents = subParents(path, parent).toList().map { pathString(it) }
 

--- a/src/test/kotlin/org/elm/ide/test/core/LabelUtilsTest.kt
+++ b/src/test/kotlin/org/elm/ide/test/core/LabelUtilsTest.kt
@@ -2,11 +2,9 @@ package org.elm.ide.test.core
 
 import com.intellij.openapi.vfs.VirtualFileManager.extractPath
 import org.elm.ide.test.core.LabelUtils.commonParent
-import org.elm.ide.test.core.LabelUtils.fromErrorLocationUrlPath
 import org.elm.ide.test.core.LabelUtils.fromLocationUrlPath
 import org.elm.ide.test.core.LabelUtils.pathString
 import org.elm.ide.test.core.LabelUtils.subParents
-import org.elm.ide.test.core.LabelUtils.toErrorLocationUrl
 import org.elm.ide.test.core.LabelUtils.toPath
 import org.elm.ide.test.core.LabelUtils.toSuiteLocationUrl
 import org.elm.ide.test.core.LabelUtils.toTestLocationUrl
@@ -131,19 +129,15 @@ class LabelUtilsTest {
 
     @Test
     fun errorLocationUrl() {
-        val url = toErrorLocationUrl("my/path/file", 1313, 13)
+        val url = ErrorLabelLocation("my/path/file", 1313, 13).toUrl()
         assertEquals("elmTestError://my/path/file::1313::13", url)
 
         val path = extractPath(url)
-        val pair = fromErrorLocationUrlPath(path)
+        val location = ErrorLabelLocation.fromUrl(path)
 
-        val file = pair.first
-        val line = pair.second.first
-        val column = pair.second.second
-
-        assertEquals("my/path/file", file)
-        assertEquals(1313, line.toLong())
-        assertEquals(13, column.toLong())
+        assertEquals("my/path/file", location.file)
+        assertEquals(1313, location.line)
+        assertEquals(13, location.column)
     }
 
 }

--- a/src/test/kotlin/org/elm/workspace/ElmProjectHelperTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmProjectHelperTest.kt
@@ -5,7 +5,6 @@ import org.elm.fileTree
 import org.elm.ide.test.core.ElmProjectTestsHelper
 import org.elm.ide.test.core.ElmProjectTestsHelper.Companion.elmFolderForTesting
 import org.elm.openapiext.pathAsPath
-import java.util.*
 
 class ElmProjectHelperTest : ElmWorkspaceTestBase() {
 
@@ -13,7 +12,7 @@ class ElmProjectHelperTest : ElmWorkspaceTestBase() {
         testProject()
 
         val helper = ElmProjectTestsHelper(project)
-        checkEquals(Arrays.asList("a", "b"), helper.allNames().toList())
+        checkEquals(listOf("a", "b"), helper.allNames())
     }
 
     fun `test by name`() {


### PR DESCRIPTION
There were some places where the Kotlin code was showing its roots from Java (or didn't match the way that most of our Kotlin code is written).