### PR TITLE
Added "nvm" section on workspace settings screen with link to docs

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
+++ b/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
@@ -75,8 +75,9 @@ class ElmWorkspaceConfigurable(
                 row("Version:", elmTestVersionLabel)
             }
             block("nvm") {
-                val url = "https://github.com/klazuka/intellij-elm/blob/master/docs/nvm.md"
-                noteRow("""If your Node installation is managed by nvm please see <a href="$url">here</a> for some related information""")
+                val nvmUrl = "https://github.com/nvm-sh/nvm"
+                val docsUrl = "https://github.com/klazuka/intellij-elm/blob/master/docs/nvm.md"
+                noteRow("""Using <a href="$nvmUrl">nvm</a>? Please read <a href="$docsUrl">our troubleshooting tips</a>.""")
             }
         }
 

--- a/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
+++ b/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
@@ -74,6 +74,10 @@ class ElmWorkspaceConfigurable(
                 row("Location:", pathFieldPlusAutoDiscoverButton(elmTestPathField, "elm-test"))
                 row("Version:", elmTestVersionLabel)
             }
+            block("nvm") {
+                val url = "https://github.com/klazuka/intellij-elm/blob/master/docs/nvm.md"
+                noteRow("""If your Node installation is managed by nvm please see <a href="$url">here</a> for some related information""")
+            }
         }
 
         // Whenever this panel appears, refresh just in case the user made changes on the Keymap settings screen.


### PR DESCRIPTION
Added "nvm" section on workspace settings screen with hyperlink to page describing some issues related to using the plugin when Node managed by nvm.

The UI now looks as shown below:

![intellij-elm-nvm](https://user-images.githubusercontent.com/39593145/71519764-c3a5ce80-28b0-11ea-9ba7-4070aa2718ab.png)

The link is currently broken, as the URL it targets is where the information will exist if/when #571 is merged. If, as part of that PR, the file name/location changes, then I'll update the URL in the code in this PR.

I haven't added any tests here as I couldn't see anywhere else where just the layout of the UI is tested, and because there's no real logic to test: it's just a couple of new controls on the UI (let me know if I'm mistaken and tests need to be added).