### PR TITLE
Optimize reference resolve

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -41,8 +41,8 @@ class ElmDocumentationProvider : AbstractDocumentationProvider() {
         val lastDot = link.indexOfLast { it == '.' }
         return if (lastDot <= 0) {
             with(ModuleScope) {
-                getVisibleTypes(context.elmFile).all.find { it.name == link }
-                        ?: getDeclaredValues(context.elmFile).find { it.name == link }
+                getVisibleTypes(context.elmFile)[link]
+                        ?: getDeclaredValues(context.elmFile)[link]
             }
         } else {
             val qualifierPrefix = link.substring(0, lastDot)
@@ -190,8 +190,7 @@ private fun documentationFor(decl: ElmModuleDeclaration): String? = buildString 
         html.replace(Regex("<p>@docs (.+?)</p>", RegexOption.DOT_MATCHES_ALL)) { match ->
             val names = match.groupValues[1].split(Regex(",\\s+"))
             names.joinToString(", ") { name ->
-                val target = declarations.find { it.name == name }
-                target?.let { buildString { renderLink(name, name) } } ?: name
+                declarations[name]?.let { buildString { renderLink(name, name) } } ?: name
             }
         }
     }

--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -8,8 +8,8 @@ import com.intellij.psi.PsiManager
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.BLOCK_COMMENT
 import org.elm.lang.core.psi.elements.*
-import org.elm.lang.core.resolve.scope.ImportScope
 import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.resolve.scope.QualifiedImportScope
 import org.elm.lang.core.types.*
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
@@ -47,9 +47,7 @@ class ElmDocumentationProvider : AbstractDocumentationProvider() {
         } else {
             val qualifierPrefix = link.substring(0, lastDot)
             val name = link.substring(lastDot + 1)
-            ImportScope.fromQualifierPrefixInModule(qualifierPrefix, context.elmFile)
-                    .flatMap { it.getExposedTypes() }
-                    .find { it.name == name }
+            QualifiedImportScope(qualifierPrefix, context.elmFile).getExposedType(name)
         }
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnresolvedReferenceInspection.kt
@@ -112,7 +112,7 @@ class ElmUnresolvedReferenceInspection : ElmLocalInspection() {
             else -> error("Unexpected qualified ref type: $ref")
         }
 
-        if (exposedNames.none { it.name == ref.nameWithoutQualifier })
+        if (exposedNames.elements.none { it.name == ref.nameWithoutQualifier })
             return false
 
         // Success! The reference would have succeeded were it not for the alias.

--- a/src/main/kotlin/org/elm/ide/structure/ElmFileTreeElement.kt
+++ b/src/main/kotlin/org/elm/ide/structure/ElmFileTreeElement.kt
@@ -3,6 +3,12 @@ package org.elm.ide.structure
 import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.ide.structureView.impl.common.PsiTreeElementBase
 import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.ElmPsiElement
+import org.elm.lang.core.psi.elements.ElmPortAnnotation
+import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
+import org.elm.lang.core.psi.elements.ElmTypeDeclaration
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.psi.stubDirectChildrenOfType
 
 
 class ElmFileTreeElement(element: ElmFile) : PsiTreeElementBase<ElmFile>(element) {
@@ -13,14 +19,13 @@ class ElmFileTreeElement(element: ElmFile) : PsiTreeElementBase<ElmFile>(element
 
     override fun getChildrenBase(): Collection<StructureViewTreeElement> {
         val file = element ?: return emptyList()
-
-        return listOf(
-                file.getValueDeclarations(),
-                file.getTypeAliasDeclarations(),
-                file.getTypeDeclarations(),
-                file.getPortAnnotations()
-        )
-                .flatten()
+        return file.stubDirectChildrenOfType<ElmPsiElement>()
+                .filter {
+                    it is ElmValueDeclaration ||
+                            it is ElmTypeAliasDeclaration ||
+                            it is ElmTypeDeclaration ||
+                            it is ElmPortAnnotation
+                }
                 .map { ElmPresentableTreeElement(it) }
                 .sortedBy { it.element.textOffset }
     }

--- a/src/main/kotlin/org/elm/ide/typing/ElmOnEnterSmartIndentHandler.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmOnEnterSmartIndentHandler.kt
@@ -97,7 +97,7 @@ class ElmOnEnterSmartIndentHandler : EnterHandlerDelegateAdapter() {
         }
 
         if (elementAtCaretType == ElmTypes.EQ
-                && elementAtCaret.parentOfType(ElmRecordExpr::class, ElmTypeDeclaration::class) != null) {
+                && elementAtCaret.parentOfType(ElmRecordExpr::class.java, ElmTypeDeclaration::class.java) != null) {
             return Result.Continue
         }
 

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -6,10 +6,7 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.PsiReference
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
-import org.elm.lang.core.resolve.scope.ExpressionScope
-import org.elm.lang.core.resolve.scope.GlobalScope
-import org.elm.lang.core.resolve.scope.ImportScope
-import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.resolve.scope.*
 import org.elm.lang.core.stubs.index.ElmModulesIndex
 
 
@@ -48,9 +45,9 @@ object ElmQualifiableRefSuggestor : Suggestor {
                                 and those that are not. When selecting a completion that is not yet imported,
                                 the import declaration should be automatically added.
                         */
-                        val importScopes = ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
-                        importScopes.flatMap { it.getExposedValues() }.forEach { result.add(it) }
-                        importScopes.flatMap { it.getExposedConstructors() }.forEach { result.add(it) }
+                        val importScopes = QualifiedImportScope(qualifierPrefix, file, importsOnly = false)
+                        importScopes.getExposedValues().forEach { result.add(it) }
+                        importScopes.getExposedConstructors().forEach { result.add(it) }
                     }
                 }
                 is ElmUnionPattern -> {
@@ -59,8 +56,8 @@ object ElmQualifiableRefSuggestor : Suggestor {
                                 .filterIsInstance<ElmUnionVariant>()
                                 .forEach { result.add(it) }
                     } else {
-                        ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
-                                .flatMap { it.getExposedConstructors() }
+                        QualifiedImportScope(qualifierPrefix, file, importsOnly = false)
+                                .getExposedConstructors()
                                 .filterIsInstance<ElmUnionVariant>()
                                 .forEach { result.add(it) }
                     }
@@ -70,8 +67,8 @@ object ElmQualifiableRefSuggestor : Suggestor {
                         ModuleScope.getVisibleTypes(file).all.forEach { result.add(it) }
                         GlobalScope.builtInTypes.forEach { result.add(it) }
                     } else {
-                        ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
-                                .flatMap { it.getExposedTypes() }
+                        QualifiedImportScope(qualifierPrefix, file, importsOnly = false)
+                                .getExposedTypes()
                                 .forEach { result.add(it) }
                     }
                 }

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmQualifiableRefSuggestor.kt
@@ -3,6 +3,7 @@ package org.elm.lang.core.completion
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.PsiReference
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
 import org.elm.lang.core.resolve.scope.ExpressionScope
@@ -55,12 +56,12 @@ object ElmQualifiableRefSuggestor : Suggestor {
                 is ElmUnionPattern -> {
                     if (qualifierPrefix.isEmpty()) {
                         ModuleScope.getVisibleConstructors(file).all
-                                .filter { it is ElmUnionVariant }
+                                .filterIsInstance<ElmUnionVariant>()
                                 .forEach { result.add(it) }
                     } else {
                         ImportScope.fromQualifierPrefixInModule(qualifierPrefix, file, importsOnly = false)
                                 .flatMap { it.getExposedConstructors() }
-                                .filter { it is ElmUnionVariant }
+                                .filterIsInstance<ElmUnionVariant>()
                                 .forEach { result.add(it) }
                     }
                 }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -76,25 +76,6 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
                 .toList()
     }
 
-    fun getValueDeclarations() =
-            stubDirectChildrenOfType<ElmValueDeclaration>()
-
-    fun getTypeDeclarations() =
-            stubDirectChildrenOfType<ElmTypeDeclaration>()
-
-    fun getTypeAliasDeclarations() =
-            stubDirectChildrenOfType<ElmTypeAliasDeclaration>()
-
-    fun getTypeAnnotations() =
-            stubDirectChildrenOfType<ElmTypeAnnotation>()
-
-    fun getPortAnnotations() =
-            stubDirectChildrenOfType<ElmPortAnnotation>()
-
-    fun getInfixDeclarations() =
-            stubDirectChildrenOfType<ElmInfixDeclaration>()
-
-
     companion object {
         fun fromVirtualFile(file: VirtualFile, project: Project): ElmFile? =
                 file.toPsiFile(project) as? ElmFile

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -33,11 +33,7 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
     override fun getStub(): ElmFileStub? =
             super.getStub() as ElmFileStub?
 
-    fun isCore(): Boolean {
-        val pkgName = (elmProject as? ElmPackageProject)?.name
-                ?: return false
-        return (pkgName == "elm/core" || pkgName == "elm-lang/core") // TODO [drop 0.18] remove "elm-core/lang" clause
-    }
+    fun isCore(): Boolean = elmProject?.isCore() ?: false
 
     override fun setName(name: String): PsiElement {
         val nameWithExtension = if (name.endsWith(".elm")) name else "$name.elm"

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -66,8 +66,8 @@ inline fun <reified T : PsiElement> PsiElement.parentOfType(strict: Boolean = tr
 inline fun <reified T : PsiElement> PsiElement.parentOfType(strict: Boolean = true, stopAt: Class<out PsiElement>): T? =
         PsiTreeUtil.getParentOfType(this, T::class.java, strict, stopAt)
 
-fun <T : PsiElement> PsiElement.parentOfType(vararg classes: KClass<out T>): T? {
-    return PsiTreeUtil.getParentOfType(this, *classes.map { it.java }.toTypedArray())
+fun <T : PsiElement> PsiElement.parentOfType(vararg classes: Class<out T>): T? {
+    return PsiTreeUtil.getParentOfType(this, *classes)
 }
 
 inline fun <reified T : PsiElement> PsiElement.contextOfType(strict: Boolean = true): T? =

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
@@ -9,6 +9,7 @@ import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
 import org.elm.lang.core.resolve.scope.ImportScope
 import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.resolve.scope.ModuleScope.getDeclaredValues
 import org.elm.lang.core.stubs.ElmPlaceholderRefStub
 
 
@@ -54,12 +55,12 @@ class ExposedOperatorModuleReference(exposedValue: ElmExposedOperator
 ) : ElmReferenceCached<ElmExposedOperator>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
+        return getDeclaredValues(element.elmFile)[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
         // TODO [kl] verify: this was copied from ElmExposedValue's ref
-        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
+        return getDeclaredValues(element.elmFile).array
     }
 }
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
@@ -54,8 +54,7 @@ class ExposedOperatorModuleReference(exposedValue: ElmExposedOperator
 ) : ElmReferenceCached<ElmExposedOperator>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
@@ -54,7 +54,8 @@ class ExposedOperatorModuleReference(exposedValue: ElmExposedOperator
 ) : ElmReferenceCached<ElmExposedOperator>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
@@ -70,7 +71,8 @@ class ExposedOperatorImportReference(exposedValue: ElmExposedOperator
 ) : ElmReferenceCached<ElmExposedOperator>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposedOperator.kt
@@ -7,8 +7,8 @@ import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.OPERATOR_IDENTIFIER
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.reference.ElmReferenceCached
+import org.elm.lang.core.resolve.scope.ExposedNames
 import org.elm.lang.core.resolve.scope.ImportScope
-import org.elm.lang.core.resolve.scope.ModuleScope
 import org.elm.lang.core.resolve.scope.ModuleScope.getDeclaredValues
 import org.elm.lang.core.stubs.ElmPlaceholderRefStub
 
@@ -71,17 +71,18 @@ class ExposedOperatorImportReference(exposedValue: ElmExposedOperator
 ) : ElmReferenceCached<ElmExposedOperator>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return getCandidates()?.get(element.referenceName)
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
+        return getCandidates()?.elements ?: emptyArray()
+    }
+
+    private fun getCandidates(): ExposedNames? {
         // TODO [kl] verify: this was copied from ElmExposedValue's ref
         val importClause = element.parentOfType<ElmImportClause>()
                 ?: error("should never happen: this ref must be in an import")
 
-        return ImportScope.fromImportDecl(importClause)
-                ?.getExposedValues()?.toTypedArray()
-                ?: emptyArray()
+        return ImportScope.fromImportDecl(importClause)?.getExposedValues()
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionDeclarationLeft.kt
@@ -54,8 +54,8 @@ class ElmFunctionDeclarationLeft : ElmStubbedNamedElementImpl<ElmFunctionDeclara
      *
      * e.g. `a`, `b`, `c`, `d`, and `e` in `foo a (b, (c, d)) {e} = 42`
      */
-    val namedParameters: List<ElmNameDeclarationPatternTag>
-        get() = PsiTreeUtil.collectElementsOfType(this, ElmNameDeclarationPatternTag::class.java).toList()
+    val namedParameters: Collection<ElmNameDeclarationPatternTag>
+        get() = PsiTreeUtil.collectElementsOfType(this, ElmNameDeclarationPatternTag::class.java)
 
 
     /** Return true if this declaration is not nested in a let-in expression */

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
@@ -50,7 +50,8 @@ class LocalOperatorReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
@@ -50,8 +50,7 @@ class LocalOperatorReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorConfig.kt
@@ -23,7 +23,7 @@ import org.elm.lang.core.resolve.scope.ModuleScope
 class ElmOperatorConfig(node: ASTNode) : ElmPsiElementImpl(node), ElmReferenceElement {
 
     val associativityKeyword: PsiElement
-        get() = findNotNullChildByType<PsiElement>(tokenSetOf(INFIX, INFIXL, INFIXR))
+        get() = findNotNullChildByType(tokenSetOf(INFIX, INFIXL, INFIXR))
 
     val precedence: PsiElement
         get() = findNotNullChildByType(NUMBER_LITERAL)
@@ -50,11 +50,11 @@ class LocalOperatorReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
+        return ModuleScope.getDeclaredValues(element.elmFile)[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
         // TODO [kl] filter the variants to just include binary operators
-        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
+        return ModuleScope.getDeclaredValues(element.elmFile).array
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmOperatorDeclarationLeft.kt
@@ -33,10 +33,6 @@ class ElmOperatorDeclarationLeft : ElmStubbedNamedElementImpl<ElmOperatorDeclara
         get() = PsiTreeUtil.getChildrenOfTypeAsList(this, ElmPattern::class.java)
 
 
-    val namedParameters: List<ElmNameIdentifierOwner>
-        get() {
-            val results = mutableListOf<ElmNameIdentifierOwner>()
-            results.addAll(PsiTreeUtil.collectElementsOfType(this, ElmLowerPattern::class.java))
-            return results
-        }
+    val namedParameters: Collection<ElmNameIdentifierOwner>
+        get() = PsiTreeUtil.collectElementsOfType(this, ElmLowerPattern::class.java)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.stubs.IStubElementType
 import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ElmStubbedElement
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
-import org.elm.lang.core.psi.ElmUnionPatternChildTag
 import org.elm.lang.core.stubs.ElmUpperCaseQIDStub
 
 /**
@@ -56,7 +55,12 @@ class ElmUpperCaseQID : ElmStubbedElement<ElmUpperCaseQIDStub>, ElmQID {
      * e.g. `"Foo.Bar.Quux"` for QID `Foo.Bar.Quux`
      */
     val fullName: String
-        get() = if (isQualified) "$qualifierPrefix.$refName" else refName
+        get() = when {
+            stub == null -> text
+            isQualified -> "$qualifierPrefix.$refName"
+            else -> refName
+        }
+
     /**
      * True if the identifier is qualified by a module name (in the case of union or
      * record constructors) or the module exists in a hierarchy (in the case of a pure

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.SmartList
 import org.elm.ide.icons.ElmIcons
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.stubs.ElmPlaceholderStub

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -105,10 +105,14 @@ class ElmValueDeclaration : ElmStubbedElement<ElmPlaceholderStub>, ElmDocTarget 
             // HACK: try to find the type annotation as best we can, keeping stub-safe.
             // TODO [kl] Look into parsing the type annotation as part of the value declaration.
             val fdl = functionDeclarationLeft
-            return if (stub != null && fdl != null) {
-                elmFile.getTypeAnnotations().firstOrNull { it.referenceName == fdl.name }
-            } else {
-                prevSiblings.withoutWsOrComments.firstOrNull() as? ElmTypeAnnotation
+            return when {
+                fdl == null -> null
+                stub != null -> {
+                    elmFile.stubDirectChildrenOfType<ElmTypeAnnotation>().firstOrNull { it.referenceName == fdl.name }
+                }
+                else -> {
+                    prevSiblings.withoutWsOrComments.firstOrNull() as? ElmTypeAnnotation
+                }
             }
         }
 

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -75,21 +75,25 @@ class ElmValueDeclaration : ElmStubbedElement<ElmPlaceholderStub>, ElmDocTarget 
     fun declaredNames(includeParameters: Boolean = true): List<ElmNameIdentifierOwner> {
         val namedElements = mutableListOf<ElmNameIdentifierOwner>()
 
-        if (functionDeclarationLeft != null) {
+        val fdl = functionDeclarationLeft
+        if (fdl != null) {
             // the most common case, a named function or value declaration
-            namedElements.add(functionDeclarationLeft!!)
-            if (includeParameters)
-                namedElements.addAll(functionDeclarationLeft!!.namedParameters)
+            namedElements.add(fdl)
+            if (includeParameters) namedElements.addAll(fdl.namedParameters)
+            return namedElements
 
-        } else if (operatorDeclarationLeft != null) {
+        }
+        val odl = operatorDeclarationLeft
+        if (odl != null) {
             // an operator declaration
-            namedElements.add(operatorDeclarationLeft!!)
-            if (includeParameters)
-                namedElements.addAll(operatorDeclarationLeft!!.namedParameters)
-
-        } else if (pattern != null) {
+            namedElements.add(odl)
+            if (includeParameters) namedElements.addAll(odl.namedParameters)
+            return namedElements
+        }
+        val pat = pattern
+        if (pat != null) {
             // value destructuring assignment (e.g. `(x,y) = (0,0)` in a let/in declaration)
-            namedElements.addAll(pattern!!.descendantsOfType<ElmNameIdentifierOwner>())
+            namedElements.addAll(pat.descendantsOfType())
         }
 
         return namedElements

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromImport.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromImport.kt
@@ -14,7 +14,8 @@ class ExposedTypeReferenceFromImport(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromImport.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromImport.kt
@@ -4,6 +4,7 @@ import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmExposedType
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.parentOfType
+import org.elm.lang.core.resolve.scope.ExposedNames
 import org.elm.lang.core.resolve.scope.ImportScope
 
 /**
@@ -14,17 +15,17 @@ class ExposedTypeReferenceFromImport(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return getCandidates()?.get(element.referenceName)
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
+        return getCandidates()?.elements ?: emptyArray()
+    }
+
+    private fun getCandidates(): ExposedNames? {
         val importClause = element.parentOfType<ElmImportClause>()
                 ?: error("should never happen: this ref must be in an import")
 
-        return ImportScope.fromImportDecl(importClause)
-                ?.getExposedTypes()?.toTypedArray()
-                ?: emptyArray()
+        return ImportScope.fromImportDecl(importClause)?.getExposedTypes()
     }
-
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
@@ -12,7 +12,7 @@ class ExposedTypeReferenceFromModuleDecl(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getCandidates().byName[element.referenceName]
+        return getCandidates()[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
@@ -12,7 +12,7 @@ class ExposedTypeReferenceFromModuleDecl(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        return variants.find { it.name == element.referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
@@ -12,11 +12,12 @@ class ExposedTypeReferenceFromModuleDecl(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return ModuleScope.getDeclaredTypesByName(element.elmFile)[element.referenceName]
+        return getCandidates().byName[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
-        return ModuleScope.getDeclaredTypes(element.elmFile).toTypedArray()
+        return getCandidates().array
     }
 
+    private fun getCandidates() = ModuleScope.getDeclaredTypes(element.elmFile)
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
@@ -12,8 +12,7 @@ class ExposedTypeReferenceFromModuleDecl(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return ModuleScope.getDeclaredTypesByName(element.elmFile)[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedTypeReferenceFromModuleDecl.kt
@@ -12,7 +12,8 @@ class ExposedTypeReferenceFromModuleDecl(exposedType: ElmExposedType)
     : ElmReferenceCached<ElmExposedType>(exposedType) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return variants.find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedUnionConstructorReference.kt
@@ -16,19 +16,20 @@ class ExposedUnionConstructorReference(exposedUnionConstructor: ElmExposedUnionC
 
     override fun resolveInner(): ElmNamedElement? {
         val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return getCandidates().find { it.name == referenceName }
     }
 
-    override fun getVariants(): Array<ElmNamedElement> {
+    override fun getVariants(): Array<ElmNamedElement> = getCandidates().toTypedArray()
+
+    private fun getCandidates(): List<ElmNamedElement> {
         // TODO [kl] maybe I should move this code into a new UnionTypeScope class for consistency?
         val parent = element.parentOfType<ElmExposedType>() ?: error("bad context")
-        val unionType = parent.reference.resolve() ?: return emptyArray()
+        val unionType = parent.reference.resolve() ?: return emptyList()
 
         if (unionType is ElmTypeDeclaration) {
-            return unionType.unionVariantList.toTypedArray()
+            return unionType.unionVariantList
         } else {
             error("resolved to unexpected element")
         }
     }
-
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedUnionConstructorReference.kt
@@ -15,7 +15,7 @@ class ExposedUnionConstructorReference(exposedUnionConstructor: ElmExposedUnionC
     : ElmReferenceCached<ElmExposedUnionConstructor>(exposedUnionConstructor) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        return variants.find { it.name == element.referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedUnionConstructorReference.kt
@@ -15,7 +15,8 @@ class ExposedUnionConstructorReference(exposedUnionConstructor: ElmExposedUnionC
     : ElmReferenceCached<ElmExposedUnionConstructor>(exposedUnionConstructor) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return variants.find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueImportReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueImportReference.kt
@@ -4,6 +4,7 @@ import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmExposedValue
 import org.elm.lang.core.psi.elements.ElmImportClause
 import org.elm.lang.core.psi.parentOfType
+import org.elm.lang.core.resolve.scope.ExposedNames
 import org.elm.lang.core.resolve.scope.ImportScope
 
 /**
@@ -13,17 +14,17 @@ class ExposedValueImportReference(exposedValue: ElmExposedValue)
     : ElmReferenceCached<ElmExposedValue>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return getCandidates()?.get(element.referenceName)
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
+        return getCandidates()?.elements ?: emptyArray()
+    }
+
+    private fun getCandidates(): ExposedNames? {
         val importClause = element.parentOfType<ElmImportClause>()
                 ?: error("should never happen: this ref must be in an import")
 
-        return ImportScope.fromImportDecl(importClause)
-                ?.getExposedValues()?.toTypedArray()
-                ?: emptyArray()
+        return ImportScope.fromImportDecl(importClause)?.getExposedValues()
     }
-
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueImportReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueImportReference.kt
@@ -13,7 +13,8 @@ class ExposedValueImportReference(exposedValue: ElmExposedValue)
     : ElmReferenceCached<ElmExposedValue>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
@@ -11,7 +11,8 @@ class ExposedValueModuleReference(exposedValue: ElmExposedValue)
     : ElmReferenceCached<ElmExposedValue>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return variants.find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
@@ -10,12 +10,9 @@ import org.elm.lang.core.resolve.scope.ModuleScope
 class ExposedValueModuleReference(exposedValue: ElmExposedValue)
     : ElmReferenceCached<ElmExposedValue>(exposedValue) {
 
-    override fun resolveInner(): ElmNamedElement? {
-        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
-    }
+    override fun resolveInner(): ElmNamedElement? = getCandidates()[element.referenceName]
 
-    override fun getVariants(): Array<ElmNamedElement> {
-        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
-    }
+    override fun getVariants(): Array<ElmNamedElement> = getCandidates().array
 
+    private fun getCandidates() = ModuleScope.getDeclaredValues(element.elmFile)
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
@@ -11,7 +11,7 @@ class ExposedValueModuleReference(exposedValue: ElmExposedValue)
     : ElmReferenceCached<ElmExposedValue>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        return variants.find { it.name == element.referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ExposedValueModuleReference.kt
@@ -11,8 +11,7 @@ class ExposedValueModuleReference(exposedValue: ElmExposedValue)
     : ElmReferenceCached<ElmExposedValue>(exposedValue) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
@@ -24,7 +24,8 @@ class LexicalValueReference(element: ElmReferenceElement)
      * will only resolve the first level of reference.
      */
     fun resolveShallow(): ElmNamedElement? {
-        return getCandidates().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return getCandidates().find { it.name == referenceName }
     }
 
     private fun getCandidates(): List<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LexicalValueReference.kt
@@ -25,10 +25,6 @@ class LexicalValueReference(element: ElmReferenceElement)
      */
     fun resolveShallow(): ElmNamedElement? {
         val referenceName = element.referenceName
-        return getCandidates().find { it.name == referenceName }
-    }
-
-    private fun getCandidates(): List<ElmNamedElement> {
-        return ExpressionScope(element).getVisibleValues()
+        return ExpressionScope(element).getVisibleValues().find { it.name == referenceName }
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
@@ -11,7 +11,8 @@ class LocalTopLevelValueReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants() =

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
@@ -5,16 +5,16 @@ import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.scope.ModuleScope
 
 /**
- * A reference to a value or a function name declared at the top level of the file containing [element]
+ * A reference to a value or a function name declared at the top level of the file containing an `element`
  */
 class LocalTopLevelValueReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
     }
 
-    override fun getVariants() =
-            ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
+    override fun getVariants(): Array<ElmNamedElement> {
+        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
+    }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/LocalTopLevelValueReference.kt
@@ -10,11 +10,9 @@ import org.elm.lang.core.resolve.scope.ModuleScope
 class LocalTopLevelValueReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
-    override fun resolveInner(): ElmNamedElement? {
-        return ModuleScope.getDeclaredValuesByName(element.elmFile)[element.referenceName]
-    }
+    override fun resolveInner(): ElmNamedElement? = getCandidates()[element.referenceName]
 
-    override fun getVariants(): Array<ElmNamedElement> {
-        return ModuleScope.getDeclaredValues(element.elmFile).toTypedArray()
-    }
+    override fun getVariants(): Array<ElmNamedElement> = getCandidates().array
+
+    private fun getCandidates() = ModuleScope.getDeclaredValues(element.elmFile)
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/ModuleNameQualifierReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/ModuleNameQualifierReference.kt
@@ -40,9 +40,10 @@ class ModuleNameQualifierReference<T : ElmReferenceElement>(
         val importDecls = ModuleScope.getImportDecls(clientFile)
 
         // First, check to see if it resolves to an aliased import
-        importDecls.mapNotNull { it.asClause }
-                .find { it.name == refText }
-                ?.let { return it }
+        for (decl in importDecls) {
+            val asClause = decl.asClause
+            if (asClause?.name == refText) return asClause
+        }
 
         // Otherwise, try to resolve the import directly
         val targetModuleName = GlobalScope.defaultAliases[refText] ?: refText

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedConstructorReference.kt
@@ -3,7 +3,7 @@ package org.elm.lang.core.resolve.reference
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmUpperCaseQID
 import org.elm.lang.core.resolve.ElmReferenceElement
-import org.elm.lang.core.resolve.scope.ImportScope
+import org.elm.lang.core.resolve.scope.QualifiedImportScope
 
 /**
  * Qualified reference to a union constructor or record constructor
@@ -11,19 +11,14 @@ import org.elm.lang.core.resolve.scope.ImportScope
 class QualifiedConstructorReference(referenceElement: ElmReferenceElement, val upperCaseQID: ElmUpperCaseQID
 ) : ElmReferenceCached<ElmReferenceElement>(referenceElement), QualifiedReference {
 
-    override fun getVariants(): Array<ElmNamedElement> =
-            emptyArray()
+    override fun getVariants(): Array<ElmNamedElement> = emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == nameWithoutQualifier }
+    override fun resolveInner(): ElmNamedElement? {
+        // TODO [kl] depending on context, we may need to restrict the variants to just union constructors
+        return QualifiedImportScope(qualifierPrefix, element.elmFile)
+                .getExposedConstructor(nameWithoutQualifier)
+    }
 
     override val qualifierPrefix = upperCaseQID.qualifierPrefix
     override val nameWithoutQualifier = element.referenceName
-
-    private fun getCandidates(): List<ElmNamedElement> {
-        // TODO [kl] depending on context, we may need to restrict the variants to just union constructors
-        return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
-                .flatMap { it.getExposedConstructors() }
-    }
-
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedTypeReference.kt
@@ -2,7 +2,7 @@ package org.elm.lang.core.resolve.reference
 
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.resolve.ElmReferenceElement
-import org.elm.lang.core.resolve.scope.ImportScope
+import org.elm.lang.core.resolve.scope.QualifiedImportScope
 
 /**
  * Qualified reference to a type
@@ -12,16 +12,12 @@ class QualifiedTypeReference(
         override val qualifierPrefix: String
 ) : ElmReferenceCached<ElmReferenceElement>(element), QualifiedReference {
 
-    override fun getVariants(): Array<ElmNamedElement> =
-            emptyArray()
+    override fun getVariants(): Array<ElmNamedElement> = emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == nameWithoutQualifier }
+    override fun resolveInner(): ElmNamedElement? {
+        return QualifiedImportScope(qualifierPrefix, element.elmFile)
+                .getExposedType(nameWithoutQualifier)
+    }
 
     override val nameWithoutQualifier = element.referenceName
-
-    private fun getCandidates(): List<ElmNamedElement> {
-        return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
-                .flatMap { it.getExposedTypes() }
-    }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedValueReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/QualifiedValueReference.kt
@@ -3,26 +3,22 @@ package org.elm.lang.core.resolve.reference
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmValueQID
 import org.elm.lang.core.resolve.ElmReferenceElement
-import org.elm.lang.core.resolve.scope.ImportScope
+import org.elm.lang.core.resolve.scope.QualifiedImportScope
 
 
 /**
  * Qualified reference to a value in an expression scope
  */
-class QualifiedValueReference(element: ElmReferenceElement, valueQID: ElmValueQID
-) : ElmReferenceCached<ElmReferenceElement>(element), QualifiedReference {
+class QualifiedValueReference(element: ElmReferenceElement, valueQID: ElmValueQID)
+    : ElmReferenceCached<ElmReferenceElement>(element), QualifiedReference {
 
-    override fun getVariants(): Array<ElmNamedElement> =
-            emptyArray()
+    override fun getVariants(): Array<ElmNamedElement> = emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == nameWithoutQualifier }
+    override fun resolveInner(): ElmNamedElement? {
+        return QualifiedImportScope(qualifierPrefix, element.elmFile)
+                .getExposedValue(nameWithoutQualifier)
+    }
 
     override val qualifierPrefix = valueQID.qualifierPrefix
     override val nameWithoutQualifier = element.referenceName
-
-    private fun getCandidates(): List<ElmNamedElement> {
-        return ImportScope.fromQualifierPrefixInModule(qualifierPrefix, element.elmFile)
-                .flatMap { it.getExposedValues() }
-    }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
@@ -11,8 +11,7 @@ class SimpleOperatorReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return variants.find { it.name == referenceName }
+       return ModuleScope.getVisibleValues(element.elmFile).allByName[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
@@ -11,11 +11,13 @@ class SimpleOperatorReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-       return ModuleScope.getVisibleValues(element.elmFile).allByName[element.referenceName]
+       return getCandidates()[element.referenceName]
     }
 
     override fun getVariants(): Array<ElmNamedElement> {
         // TODO [kl] filter the variants to just include binary operators
-        return ModuleScope.getVisibleValues(element.elmFile).all.toTypedArray()
+        return getCandidates().all.toTypedArray()
     }
+
+    private fun getCandidates() = ModuleScope.getVisibleValues(element.elmFile)
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleOperatorReference.kt
@@ -11,7 +11,8 @@ class SimpleOperatorReference(element: ElmReferenceElement)
     : ElmReferenceCached<ElmReferenceElement>(element) {
 
     override fun resolveInner(): ElmNamedElement? {
-        return getVariants().find { it.name == element.referenceName }
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
     }
 
     override fun getVariants(): Array<ElmNamedElement> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
@@ -13,8 +13,10 @@ class SimpleTypeReference(element: ElmReferenceElement)
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+    override fun resolveInner(): ElmNamedElement? {
+        val referenceName = element.referenceName
+        return getCandidates().find { it.name == referenceName }
+    }
 
     private fun getCandidates(): List<ElmNamedElement> {
         return ModuleScope.getVisibleTypes(element.elmFile).all

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleTypeReference.kt
@@ -14,11 +14,6 @@ class SimpleTypeReference(element: ElmReferenceElement)
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return getCandidates().find { it.name == referenceName }
-    }
-
-    private fun getCandidates(): List<ElmNamedElement> {
-        return ModuleScope.getVisibleTypes(element.elmFile).all
+        return ModuleScope.getVisibleTypes(element.elmFile)[element.referenceName]
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
@@ -14,8 +14,10 @@ class SimpleUnionConstructorReference(element: ElmReferenceElement)
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+    override fun resolveInner(): ElmNamedElement? {
+        val referenceName = element.referenceName
+        return getCandidates().find { it.name == referenceName }
+    }
 
     private fun getCandidates(): List<ElmNamedElement> =
             ModuleScope.getVisibleConstructors(element.elmFile).all

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionConstructorReference.kt
@@ -15,11 +15,7 @@ class SimpleUnionConstructorReference(element: ElmReferenceElement)
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return getCandidates().find { it.name == referenceName }
+        return ModuleScope.getVisibleConstructors(element.elmFile)[element.referenceName] as? ElmUnionVariant
     }
 
-    private fun getCandidates(): List<ElmNamedElement> =
-            ModuleScope.getVisibleConstructors(element.elmFile).all
-                    .filterIsInstance<ElmUnionVariant>()
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
@@ -11,8 +11,10 @@ class SimpleUnionOrRecordConstructorReference(element: ElmReferenceElement)
     override fun getVariants(): Array<ElmNamedElement> =
             emptyArray()
 
-    override fun resolveInner(): ElmNamedElement? =
-            getCandidates().find { it.name == element.referenceName }
+    override fun resolveInner(): ElmNamedElement? {
+        val referenceName = element.referenceName
+        return getCandidates().find { it.name == referenceName }
+    }
 
     private fun getCandidates(): List<ElmNamedElement> {
         return ModuleScope.getVisibleConstructors(element.elmFile).all

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/SimpleUnionOrRecordConstructorReference.kt
@@ -3,6 +3,7 @@ package org.elm.lang.core.resolve.reference
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.scope.ModuleScope
+import org.elm.lang.core.resolve.scope.VisibleNames
 
 
 class SimpleUnionOrRecordConstructorReference(element: ElmReferenceElement)
@@ -12,11 +13,6 @@ class SimpleUnionOrRecordConstructorReference(element: ElmReferenceElement)
             emptyArray()
 
     override fun resolveInner(): ElmNamedElement? {
-        val referenceName = element.referenceName
-        return getCandidates().find { it.name == referenceName }
-    }
-
-    private fun getCandidates(): List<ElmNamedElement> {
-        return ModuleScope.getVisibleConstructors(element.elmFile).all
+        return ModuleScope.getVisibleConstructors(element.elmFile)[element.referenceName]
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/TypeVariableReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/TypeVariableReference.kt
@@ -57,8 +57,10 @@ class TypeVariableReference(
                 .flatten()
     }
 
-    override fun resolveInner(): ElmNamedElement? =
-            variants.find { it.name == element.referenceName }
+    override fun resolveInner(): ElmNamedElement? {
+        val referenceName = element.referenceName
+        return variants.find { it.name == referenceName }
+    }
 
     private fun declaration(): PsiElement? {
         return element.ancestorsStrict.takeWhile { it !is ElmFile }.firstOrNull {

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
@@ -15,6 +15,7 @@ class ExpressionScope(val element: PsiElement) {
     fun getVisibleValues(): List<ElmNamedElement> {
 
         val results = mutableListOf<ElmNamedElement>()
+        val declAncestors = mutableListOf<ElmValueDeclaration>()
 
         treeWalkUp(element) {
             if (it is ElmFile) {
@@ -27,12 +28,13 @@ class ExpressionScope(val element: PsiElement) {
             }
 
             if (it is ElmValueDeclaration) {
+                declAncestors += it
                 results.addAll(it.declaredNames())
             }
 
             if (it is ElmLetInExpr) {
                 for (innerDecl in it.valueDeclarationList) {
-                    val includeParameters = element.ancestors.any { it === innerDecl }
+                    val includeParameters = innerDecl in declAncestors
                     results.addAll(innerDecl.declaredNames(includeParameters))
                 }
             }
@@ -52,7 +54,7 @@ class ExpressionScope(val element: PsiElement) {
     }
 }
 
-fun treeWalkUp(start: PsiElement, callback: (PsiElement) -> Boolean) {
+private fun treeWalkUp(start: PsiElement, callback: (PsiElement) -> Boolean) {
     var current: PsiElement? = start
     while (current != null) {
         val keepGoing = callback(current)

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
@@ -3,52 +3,75 @@ package org.elm.lang.core.resolve.scope
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.psi.ancestors
+import org.elm.lang.core.psi.ancestorsStrict
 import org.elm.lang.core.psi.elements.ElmAnonymousFunctionExpr
 import org.elm.lang.core.psi.elements.ElmCaseOfBranch
 import org.elm.lang.core.psi.elements.ElmLetInExpr
 import org.elm.lang.core.psi.elements.ElmValueDeclaration
 
 
-class ExpressionScope(val element: PsiElement) {
-
-    fun getVisibleValues(): List<ElmNamedElement> {
-
-        val results = mutableListOf<ElmNamedElement>()
+class ExpressionScope(private val element: PsiElement) {
+    /** Return a lazy sequence of all names visible to the [element] */
+    fun getVisibleValues(): Sequence<ElmNamedElement> {
         val declAncestors = mutableListOf<ElmValueDeclaration>()
-
-        treeWalkUp(element) {
-            when (it) {
-                is ElmFile -> {
-                    results.addAll(ModuleScope.getVisibleValues(it).all)
-                    return@treeWalkUp false // stop
-                }
-                is ElmValueDeclaration -> {
-                    declAncestors += it
-                    results.addAll(it.declaredNames())
-                }
-                is ElmLetInExpr -> {
-                    for (innerDecl in it.valueDeclarationList) {
-                        val includeParameters = innerDecl in declAncestors
-                        results.addAll(innerDecl.declaredNames(includeParameters))
+        return element.ancestorsStrict
+                .takeUntil { it is ElmFile }
+                .flatMap {
+                    when (it) {
+                        is ElmFile -> {
+                            ModuleScope.getVisibleValues(it).all.asSequence()
+                        }
+                        is ElmValueDeclaration -> {
+                            declAncestors += it
+                            it.declaredNames(includeParameters = true).asSequence()
+                        }
+                        is ElmLetInExpr -> {
+                            it.valueDeclarationList.asSequence()
+                                    .filter { innerDecl -> innerDecl !in declAncestors } // already visited
+                                    .flatMap { innerDecl ->
+                                        innerDecl.declaredNames(includeParameters = false).asSequence()
+                                    }
+                        }
+                        is ElmCaseOfBranch -> {
+                            it.destructuredNames.asSequence()
+                        }
+                        is ElmAnonymousFunctionExpr -> {
+                            it.namedParameters.asSequence()
+                        }
+                        else -> {
+                            emptySequence()
+                        }
                     }
                 }
-                is ElmCaseOfBranch -> results.addAll(it.destructuredNames)
-                is ElmAnonymousFunctionExpr -> results.addAll(it.namedParameters)
-            }
-
-            return@treeWalkUp true // keep going
-        }
-
-        return results
     }
 }
 
-private fun treeWalkUp(start: PsiElement, callback: (PsiElement) -> Boolean) {
-    var current: PsiElement? = start
-    while (current != null) {
-        val keepGoing = callback(current)
-        if (!keepGoing) break
-        current = current.parent
+private class TakeUntilSequence<T> (
+        private val sequence: Sequence<T>,
+        private val predicate: (T) -> Boolean
+) : Sequence<T> {
+    override fun iterator(): Iterator<T> = object : Iterator<T> {
+        val iterator = sequence.iterator()
+        var done = false
+
+        override fun next(): T {
+            if (!done && iterator.hasNext()) {
+                val item = iterator.next()
+                if (predicate(item)) {
+                    done = true
+                }
+                return item
+            }
+            throw NoSuchElementException()
+        }
+
+        override fun hasNext(): Boolean {
+            return !done && iterator.hasNext()
+        }
     }
+}
+
+/** Return elements of this sequence up to and including the first element for which [predicate] returns true */
+private fun <T> Sequence<T>.takeUntil(predicate: (T) -> Boolean): Sequence<T> {
+    return TakeUntilSequence(this, predicate)
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
@@ -23,10 +23,6 @@ class ExpressionScope(val element: PsiElement) {
                 return@treeWalkUp false // stop
             }
 
-            if (it is ElmNamedElement) {
-                results.add(it)
-            }
-
             if (it is ElmValueDeclaration) {
                 declAncestors += it
                 results.addAll(it.declaredNames())

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ExpressionScope.kt
@@ -18,29 +18,23 @@ class ExpressionScope(val element: PsiElement) {
         val declAncestors = mutableListOf<ElmValueDeclaration>()
 
         treeWalkUp(element) {
-            if (it is ElmFile) {
-                results.addAll(ModuleScope.getVisibleValues(it).all)
-                return@treeWalkUp false // stop
-            }
-
-            if (it is ElmValueDeclaration) {
-                declAncestors += it
-                results.addAll(it.declaredNames())
-            }
-
-            if (it is ElmLetInExpr) {
-                for (innerDecl in it.valueDeclarationList) {
-                    val includeParameters = innerDecl in declAncestors
-                    results.addAll(innerDecl.declaredNames(includeParameters))
+            when (it) {
+                is ElmFile -> {
+                    results.addAll(ModuleScope.getVisibleValues(it).all)
+                    return@treeWalkUp false // stop
                 }
-            }
-
-            if (it is ElmCaseOfBranch) {
-                results.addAll(it.destructuredNames)
-            }
-
-            if (it is ElmAnonymousFunctionExpr) {
-                results.addAll(it.namedParameters)
+                is ElmValueDeclaration -> {
+                    declAncestors += it
+                    results.addAll(it.declaredNames())
+                }
+                is ElmLetInExpr -> {
+                    for (innerDecl in it.valueDeclarationList) {
+                        val includeParameters = innerDecl in declAncestors
+                        results.addAll(innerDecl.declaredNames(includeParameters))
+                    }
+                }
+                is ElmCaseOfBranch -> results.addAll(it.destructuredNames)
+                is ElmAnonymousFunctionExpr -> results.addAll(it.namedParameters)
             }
 
             return@treeWalkUp true // keep going

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -1,16 +1,26 @@
 package org.elm.lang.core.resolve.scope
 
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.ParameterizedCachedValue
+import org.elm.lang.core.lookup.ClientLocation
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmModuleDeclaration
+import org.elm.lang.core.psi.globalModificationTracker
 import org.elm.lang.core.stubs.index.ElmModulesIndex
+import org.elm.workspace.elmWorkspace
 
+private val VISIBLE_VALUES_KEY: Key<ParameterizedCachedValue<List<ElmNamedElement>, ElmFile>> = Key.create("VISIBLE_VALUES_KEY")
+private val VISIBLE_TYPES_KEY: Key<ParameterizedCachedValue<List<ElmNamedElement>, ElmFile>> = Key.create("VISIBLE_TYPES_KEY")
+private val VISIBLE_CTORS_KEY: Key<ParameterizedCachedValue<List<ElmNamedElement>, ElmFile>> = Key.create("VISIBLE_CTORS_KEY")
 
 /**
  * The subset of implicitly exposed values, types and constructors provided by Elm's
  * standard library ("Core").
  */
-class GlobalScope private constructor(val clientFile: ElmFile) {
+class GlobalScope private constructor(private val clientFile: ElmFile) {
 
     companion object {
 
@@ -67,57 +77,82 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
             return ElmModulesIndex.getAll(listOf(implicitModuleName), clientFile)
                     .filter { it.elmFile.isCore() }
         }
+
+
+        private fun produceVisibleValues(clientFile: ClientLocation): List<ElmNamedElement> {
+            fun helper(moduleName: String) =
+                    ElmModulesIndex.get(moduleName, clientFile)
+                            ?.let { ModuleScope.getDeclaredValues(it.elmFile) }
+
+            val rest = mutableListOf<ElmNamedElement>()
+            helper("Basics")?.list?.let { rest.addAll(it) }
+            helper("List")?.get("::")?.let { rest.add(it) }
+
+            // TODO [drop 0.18] remove this line (the `!` operator was removed in 0.19)
+            helper("Platform.Cmd")?.get("!")?.let { rest.add(it) }
+
+            return rest
+        }
+
+
+        // this function should also return List, but, unlike all the other global types, Elm doesn't
+        // define it anywhere, so there's no element to return
+        private fun produceVisibleTypes(location: ClientLocation): List<ElmNamedElement> {
+            fun helper(moduleName: String) =
+                    ElmModulesIndex.get(moduleName, location)
+                            ?.let { ModuleScope.getDeclaredTypes(it.elmFile) }
+
+            val rest = mutableListOf<ElmNamedElement>()
+            helper("Basics")?.list?.let { rest.addAll(it) }
+            helper("Char")?.get("Char")?.let { rest.add(it) }
+            helper("Maybe")?.get("Maybe")?.let { rest.add(it) }
+            helper("Result")?.get("Result")?.let { rest.add(it) }
+            helper("String")?.get("String")?.let { rest.add(it) }
+            helper("Platform")?.get("Program")?.let { rest.add(it) }
+            helper("Platform.Cmd")?.get("Cmd")?.let { rest.add(it) }
+            helper("Platform.Sub")?.get("Sub")?.let { rest.add(it) }
+            return rest
+        }
+
+        private fun produceVisibleConstructors(location: ClientLocation): List<ElmNamedElement> {
+            fun helper(moduleName: String) =
+                    ElmModulesIndex.get(moduleName, location)
+                            ?.let { ModuleScope.getDeclaredConstructors(it.elmFile) }
+
+            val rest = mutableListOf<ElmNamedElement>()
+            helper("Basics")?.list?.let { rest.addAll(it) }
+            helper("Maybe")?.let { ctors ->
+                ctors["Just"]?.let { rest.add(it) }
+                ctors["Nothing"]?.let { rest.add(it) }
+            }
+            helper("Result")?.let { ctors ->
+                ctors["Ok"]?.let { rest.add(it) }
+                ctors["Err"]?.let { rest.add(it) }
+            }
+            return rest
+        }
     }
 
     fun getVisibleValues(): List<ElmNamedElement> {
-        // ModuleScope.getDeclaredValues is cached, so there's no need to cache the results of this
-        // function.
-        fun helper(moduleName: String) =
-                ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope.getDeclaredValues(it.elmFile).list }
-                        ?: emptyList()
-
-        val rest = mutableListOf<ElmNamedElement>()
-        rest.addAll(helper("Basics"))
-        rest.addAll(helper("List").filter { it.name == "::" })
-
-        // TODO [drop 0.18] remove this line (the `!` operator was removed in 0.19)
-        rest.addAll(helper("Platform.Cmd").filter { it.name == "!" })
-
-        return rest
+        val elmProject = clientFile.elmProject ?: return produceVisibleValues(clientFile)
+        return CachedValuesManager.getManager(clientFile.project).getParameterizedCachedValue(elmProject, VISIBLE_VALUES_KEY, {
+            CachedValueProvider.Result.create(produceVisibleValues(it), it.globalModificationTracker)
+        }, /*trackValue*/ false, /*parameter*/ clientFile)
     }
 
-    // this function should also return List, but, unlike all the other global types, Elm doesn't
-    // define it anywhere, so there's no element to return
-    fun getVisibleTypes(): List<ElmNamedElement> {
-        fun helper(moduleName: String) =
-                ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope.getDeclaredTypes(it.elmFile).list }
-                        ?: emptyList()
 
-        val rest = mutableListOf<ElmNamedElement>()
-        rest.addAll(helper("Basics"))
-        rest.addAll(helper("Char").filter { it.name == "Char" })
-        rest.addAll(helper("Maybe").filter { it.name == "Maybe" })
-        rest.addAll(helper("Result").filter { it.name == "Result" })
-        rest.addAll(helper("String").filter { it.name == "String" })
-        rest.addAll(helper("Platform").filter { it.name == "Program" })
-        rest.addAll(helper("Platform.Cmd").filter { it.name == "Cmd" })
-        rest.addAll(helper("Platform.Sub").filter { it.name == "Sub" })
-        return rest
+    fun getVisibleTypes(): List<ElmNamedElement> {
+        val elmProject = clientFile.elmProject ?: return produceVisibleTypes(clientFile)
+        return CachedValuesManager.getManager(clientFile.project).getParameterizedCachedValue(elmProject, VISIBLE_TYPES_KEY, {
+            CachedValueProvider.Result.create(produceVisibleTypes(it), it.globalModificationTracker)
+        }, /*trackValue*/ false, /*parameter*/ clientFile)
     }
 
 
     fun getVisibleConstructors(): List<ElmNamedElement> {
-        fun helper(moduleName: String) =
-                ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope.getDeclaredConstructors(it.elmFile).list }
-                        ?: emptyList()
-
-        val rest = mutableListOf<ElmNamedElement>()
-        rest.addAll(helper("Basics"))
-        rest.addAll(helper("Maybe").filter { it.name == "Just" || it.name == "Nothing" })
-        rest.addAll(helper("Result").filter { it.name == "Ok" || it.name == "Err" })
-        return rest
+        val elmProject = clientFile.elmProject ?: return produceVisibleConstructors(clientFile)
+        return CachedValuesManager.getManager(clientFile.project).getParameterizedCachedValue(elmProject, VISIBLE_CTORS_KEY, {
+            CachedValueProvider.Result.create(produceVisibleConstructors(it), it.globalModificationTracker)
+        }, /*trackValue*/ false, /*parameter*/ clientFile)
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -15,8 +15,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
     companion object {
 
         fun forElmFile(elmFile: ElmFile): GlobalScope? {
-            if (elmFile.elmProject == null) return null
-            if (elmFile.isCore()) {
+            if (elmFile.elmProject?.isCore() != false) {
                 // The `elm/core` standard library does not have an implicit global scope. It must explicitly
                 // import modules like `List`, `String`, etc.
                 return null

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -75,7 +75,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
         // function.
         fun helper(moduleName: String) =
                 ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope.getDeclaredValues(it.elmFile) }
+                        ?.let { ModuleScope.getDeclaredValues(it.elmFile).list }
                         ?: emptyList()
 
         val rest = mutableListOf<ElmNamedElement>()
@@ -93,7 +93,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
     fun getVisibleTypes(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
                 ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope.getDeclaredTypes(it.elmFile) }
+                        ?.let { ModuleScope.getDeclaredTypes(it.elmFile).list }
                         ?: emptyList()
 
         val rest = mutableListOf<ElmNamedElement>()
@@ -112,7 +112,7 @@ class GlobalScope private constructor(val clientFile: ElmFile) {
     fun getVisibleConstructors(): List<ElmNamedElement> {
         fun helper(moduleName: String) =
                 ElmModulesIndex.get(moduleName, clientFile)
-                        ?.let { ModuleScope.getDeclaredConstructors(it.elmFile) }
+                        ?.let { ModuleScope.getDeclaredConstructors(it.elmFile).list }
                         ?: emptyList()
 
         val rest = mutableListOf<ElmNamedElement>()

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/GlobalScope.kt
@@ -134,7 +134,7 @@ class GlobalScope private constructor(private val clientFile: ElmFile) {
     }
 
     fun getVisibleValues(): List<ElmNamedElement> {
-        val elmProject = clientFile.elmProject ?: return produceVisibleValues(clientFile)
+        val elmProject = clientFile.elmProject ?: return emptyList()
         return CachedValuesManager.getManager(clientFile.project).getParameterizedCachedValue(elmProject, VISIBLE_VALUES_KEY, {
             CachedValueProvider.Result.create(produceVisibleValues(it), it.globalModificationTracker)
         }, /*trackValue*/ false, /*parameter*/ clientFile)
@@ -142,7 +142,7 @@ class GlobalScope private constructor(private val clientFile: ElmFile) {
 
 
     fun getVisibleTypes(): List<ElmNamedElement> {
-        val elmProject = clientFile.elmProject ?: return produceVisibleTypes(clientFile)
+        val elmProject = clientFile.elmProject ?: return emptyList()
         return CachedValuesManager.getManager(clientFile.project).getParameterizedCachedValue(elmProject, VISIBLE_TYPES_KEY, {
             CachedValueProvider.Result.create(produceVisibleTypes(it), it.globalModificationTracker)
         }, /*trackValue*/ false, /*parameter*/ clientFile)
@@ -150,7 +150,7 @@ class GlobalScope private constructor(private val clientFile: ElmFile) {
 
 
     fun getVisibleConstructors(): List<ElmNamedElement> {
-        val elmProject = clientFile.elmProject ?: return produceVisibleConstructors(clientFile)
+        val elmProject = clientFile.elmProject ?: return emptyList()
         return CachedValuesManager.getManager(clientFile.project).getParameterizedCachedValue(elmProject, VISIBLE_CTORS_KEY, {
             CachedValueProvider.Result.create(produceVisibleConstructors(it), it.globalModificationTracker)
         }, /*trackValue*/ false, /*parameter*/ clientFile)

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -79,12 +79,12 @@ class ImportScope(val elmFile: ElmFile) {
                 ?: return emptyList()
 
         if (moduleDecl.exposesAll)
-            return ModuleScope.getDeclaredValues(elmFile)
+            return ModuleScope.getDeclaredValues(elmFile).list
 
         val exposingList = moduleDecl.exposingList
                 ?: return emptyList()
 
-        val declaredValues = ModuleScope.getDeclaredValues(elmFile)
+        val declaredValues = ModuleScope.getDeclaredValues(elmFile).array
         val exposedNames = mutableSetOf<String>()
         exposingList.exposedValueList.mapTo(exposedNames) { it.referenceName }
         exposingList.exposedOperatorList.mapTo(exposedNames) { it.referenceName }
@@ -106,13 +106,13 @@ class ImportScope(val elmFile: ElmFile) {
                 ?: return emptyList()
 
         if (moduleDecl.exposesAll)
-            return ModuleScope.getDeclaredTypes(elmFile)
+            return ModuleScope.getDeclaredTypes(elmFile).list
 
         val exposedTypeList = moduleDecl.exposingList?.exposedTypeList
                 ?: return emptyList()
 
         val exposedNames = exposedTypeList.mapTo(mutableSetOf()) { it.referenceName }
-        return ModuleScope.getDeclaredTypes(elmFile).filter { it.name in exposedNames }
+        return ModuleScope.getDeclaredTypes(elmFile).array.filter { it.name in exposedNames }
     }
 
     /**
@@ -129,7 +129,7 @@ class ImportScope(val elmFile: ElmFile) {
                 ?: return emptyList()
 
         if (moduleDecl.exposesAll)
-            return ModuleScope.getDeclaredConstructors(elmFile)
+            return ModuleScope.getDeclaredConstructors(elmFile).list
 
         val exposedTypeList = moduleDecl.exposingList?.exposedTypeList
                 ?: return emptyList()
@@ -137,7 +137,7 @@ class ImportScope(val elmFile: ElmFile) {
         val types = ModuleScope.getDeclaredTypes(elmFile)
 
         return exposedTypeList.flatMap { exposedType ->
-            val type = types.find { t -> t.name == exposedType.referenceName }
+            val type = types[exposedType.referenceName]
             val ctors = exposedType.exposedUnionConstructors
             when {
                 exposedType.exposesAll -> {

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -66,12 +66,12 @@ class QualifiedImportScope(
     /** Lazily yield all individual scopes that can contain exposed names with this prefix */
     private fun scopes(): Sequence<ImportScope> = sequence {
         if (importsOnly) {
-            yieldAll(implicitScopes())
             yieldAll(explicitScopes())
+            yieldAll(implicitScopes())
         } else {
             val projectWideScopes = ElmModulesIndex.getAll(listOf(qualifierPrefix), clientFile)
                     .asSequence().map { ImportScope(it.elmFile) }
-            val allScopes = projectWideScopes + implicitScopes() + explicitScopes()
+            val allScopes = explicitScopes() + implicitScopes() + projectWideScopes
             yieldAll(allScopes.distinctBy { it.elmFile.virtualFile.path })
         }
     }

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -12,13 +12,75 @@ import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.psi.globalModificationTracker
 import org.elm.lang.core.stubs.index.ElmModulesIndex
 
-private val EXPOSED_VALUES_KEY: Key<ParameterizedCachedValue<List<ElmNamedElement>, ElmFile>> = Key.create("EXPOSED_VALUES_KEY")
-private val EXPOSED_TYPES_KEY: Key<ParameterizedCachedValue<List<ElmNamedElement>, ElmFile>> = Key.create("EXPOSED_TYPES_KEY")
-private val EXPOSED_CONSTRUCTORS_KEY: Key<ParameterizedCachedValue<List<ElmNamedElement>, ElmFile>> = Key.create("EXPOSED_CONSTRUCTORS_KEY")
+private val EXPOSED_VALUES_KEY: Key<ParameterizedCachedValue<ExposedNames, ElmFile>> = Key.create("EXPOSED_VALUES_KEY")
+private val EXPOSED_TYPES_KEY: Key<ParameterizedCachedValue<ExposedNames, ElmFile>> = Key.create("EXPOSED_TYPES_KEY")
+private val EXPOSED_CONSTRUCTORS_KEY: Key<ParameterizedCachedValue<ExposedNames, ElmFile>> = Key.create("EXPOSED_CONSTRUCTORS_KEY")
 
-data class ExposedNames(val elements: List<ElmNamedElement>) {
+class ExposedNames(val elements: Array<ElmNamedElement>) {
+    constructor(elements: List<ElmNamedElement>) : this(elements.toTypedArray())
+
     private val byName = elements.associateByTo(mutableMapOf()) { it.name }.apply { remove(null) }
     operator fun get(key: String?) = byName[key]
+}
+
+/**
+ * A scope of exposed names for the module named by [qualifierPrefix] reachable
+ * via [clientFile]. By default, the import scopes will be found by crawling the
+ * explicit import declarations in [clientFile] and automatically adding the
+ * implicit imports from Elm's Core standard library.
+ *
+ * @param qualifierPrefix The name of a module or an alias
+ * @param clientFile The Elm file from which the search should be performed
+ * @param importsOnly If true, include only modules reachable via imports (implicit and explicit).
+ *                    Otherwise, include all modules which could be reached by the file's [ElmProject]
+ */
+class QualifiedImportScope(
+        private val qualifierPrefix: String,
+        private val clientFile: ElmFile,
+        private val importsOnly: Boolean = true
+) {
+    fun getExposedValue(name: String): ElmNamedElement? {
+        return scopes().mapNotNull { it.getExposedValues()[name] }.firstOrNull()
+    }
+
+    fun getExposedValues(): Sequence<ElmNamedElement> {
+        return scopes().flatMap { it.getExposedValues().elements.asSequence() }
+    }
+
+    fun getExposedType(name: String): ElmNamedElement? {
+        return scopes().mapNotNull { it.getExposedTypes()[name] }.firstOrNull()
+    }
+
+    fun getExposedTypes(): Sequence<ElmNamedElement> {
+        return scopes().flatMap { it.getExposedTypes().elements.asSequence() }
+    }
+
+    fun getExposedConstructor(name: String): ElmNamedElement? {
+        return scopes().mapNotNull { it.getExposedConstructors()[name] }.firstOrNull()
+    }
+
+    fun getExposedConstructors(): Sequence<ElmNamedElement> {
+        return scopes().flatMap { it.getExposedConstructors().elements.asSequence() }
+    }
+
+    /** Lazily yield all individual scopes that can contain exposed names with this prefix */
+    private fun scopes(): Sequence<ImportScope> = sequence {
+        if (importsOnly) {
+            yieldAll(implicitScopes())
+            yieldAll(explicitScopes())
+        } else {
+            val projectWideScopes = ElmModulesIndex.getAll(listOf(qualifierPrefix), clientFile)
+                    .asSequence().map { ImportScope(it.elmFile) }
+            val allScopes = projectWideScopes + implicitScopes() + explicitScopes()
+            yieldAll(allScopes.distinctBy { it.elmFile.virtualFile.path })
+        }
+    }
+
+    private fun implicitScopes() = GlobalScope.implicitModulesMatching(qualifierPrefix, clientFile)
+            .asSequence().map { ImportScope(it.elmFile) }
+
+    private fun explicitScopes() = ModuleScope.importDeclsForQualifierPrefix(clientFile, qualifierPrefix)
+            .asSequence().mapNotNull { ImportScope.fromImportDecl(it) }
 }
 
 /**
@@ -30,7 +92,6 @@ data class ExposedNames(val elements: List<ElmNamedElement>) {
 class ImportScope(val elmFile: ElmFile) {
 
     companion object {
-
         /**
          * Returns an [ImportScope] for the module which is being imported by [importDecl].
          */
@@ -39,43 +100,14 @@ class ImportScope(val elmFile: ElmFile) {
             return ElmModulesIndex.get(moduleName, importDecl.elmFile)
                     ?.let { ImportScope(it.elmFile) }
         }
-
-        /**
-         * Returns an [ImportScope] for the module named by [qualifierPrefix] reachable
-         * via [clientFile]. By default, the import scopes will be found by crawling the
-         * explicit import declarations in [clientFile] and automatically adding the
-         * implicit imports from Elm's Core standard library.
-         *
-         * @param qualifierPrefix The name of a module or an alias
-         * @param clientFile The Elm file from which the search should be performed
-         * @param importsOnly If true, include only modules reachable via imports (implicit and explicit).
-         *                    Otherwise, include all modules which could be reached by the file's [ElmProject]
-         */
-        fun fromQualifierPrefixInModule(qualifierPrefix: String, clientFile: ElmFile, importsOnly: Boolean = true): List<ImportScope> {
-            val implicitScopes = GlobalScope.implicitModulesMatching(qualifierPrefix, clientFile)
-                    .map { ImportScope(it.elmFile) }
-
-            val explicitScopes = ModuleScope.importDeclsForQualifierPrefix(clientFile, qualifierPrefix)
-                    .mapNotNull { fromImportDecl(it) }
-
-            return if (importsOnly) {
-                implicitScopes + explicitScopes
-            } else {
-                val projectWideScopes = ElmModulesIndex.getAll(listOf(qualifierPrefix), clientFile)
-                        .map { ImportScope(it.elmFile) }
-                val allScopes = projectWideScopes + implicitScopes + explicitScopes
-                allScopes.distinctBy { it.elmFile.virtualFile.path }
-            }
-        }
     }
-
 
     /**
      * Returns all value declarations exposed by this module.
      */
-    fun getExposedValues(): List<ElmNamedElement> {
+    fun getExposedValues(): ExposedNames {
         return CachedValuesManager.getManager(elmFile.project).getParameterizedCachedValue(elmFile, EXPOSED_VALUES_KEY, {
-            CachedValueProvider.Result.create(produceExposedValues(), elmFile.globalModificationTracker)
+            CachedValueProvider.Result.create(ExposedNames(produceExposedValues()), elmFile.globalModificationTracker)
         }, /*trackValue*/ false, /*parameter*/ elmFile)
     }
 
@@ -100,9 +132,9 @@ class ImportScope(val elmFile: ElmFile) {
     /**
      * Returns all union type and type alias declarations exposed by this module.
      */
-    fun getExposedTypes(): List<ElmNamedElement> {
+    fun getExposedTypes(): ExposedNames {
         return CachedValuesManager.getManager(elmFile.project).getParameterizedCachedValue(elmFile, EXPOSED_TYPES_KEY, {
-            CachedValueProvider.Result.create(produceExposedTypes(), elmFile.globalModificationTracker)
+            CachedValueProvider.Result.create(ExposedNames(produceExposedTypes()), elmFile.globalModificationTracker)
         }, false, elmFile)
     }
 
@@ -123,9 +155,9 @@ class ImportScope(val elmFile: ElmFile) {
     /**
      * Returns all union and record constructors exposed by this module.
      */
-    fun getExposedConstructors(): List<ElmNamedElement> {
+    fun getExposedConstructors(): ExposedNames {
         return CachedValuesManager.getManager(elmFile.project).getParameterizedCachedValue(elmFile, EXPOSED_CONSTRUCTORS_KEY, {
-            CachedValueProvider.Result.create(produceExposedConstructors(), elmFile.globalModificationTracker)
+            CachedValueProvider.Result.create(ExposedNames(produceExposedConstructors()), elmFile.globalModificationTracker)
         }, false, elmFile)
     }
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ImportScope.kt
@@ -107,7 +107,7 @@ class ImportScope(val elmFile: ElmFile) {
      */
     fun getExposedValues(): ExposedNames {
         return CachedValuesManager.getManager(elmFile.project).getParameterizedCachedValue(elmFile, EXPOSED_VALUES_KEY, {
-            CachedValueProvider.Result.create(ExposedNames(produceExposedValues()), elmFile.globalModificationTracker)
+            CachedValueProvider.Result.create(ExposedNames(produceExposedValues()), it.globalModificationTracker)
         }, /*trackValue*/ false, /*parameter*/ elmFile)
     }
 
@@ -134,7 +134,7 @@ class ImportScope(val elmFile: ElmFile) {
      */
     fun getExposedTypes(): ExposedNames {
         return CachedValuesManager.getManager(elmFile.project).getParameterizedCachedValue(elmFile, EXPOSED_TYPES_KEY, {
-            CachedValueProvider.Result.create(ExposedNames(produceExposedTypes()), elmFile.globalModificationTracker)
+            CachedValueProvider.Result.create(ExposedNames(produceExposedTypes()), it.globalModificationTracker)
         }, false, elmFile)
     }
 
@@ -157,7 +157,7 @@ class ImportScope(val elmFile: ElmFile) {
      */
     fun getExposedConstructors(): ExposedNames {
         return CachedValuesManager.getManager(elmFile.project).getParameterizedCachedValue(elmFile, EXPOSED_CONSTRUCTORS_KEY, {
-            CachedValueProvider.Result.create(ExposedNames(produceExposedConstructors()), elmFile.globalModificationTracker)
+            CachedValueProvider.Result.create(ExposedNames(produceExposedConstructors()), it.globalModificationTracker)
         }, false, elmFile)
     }
 

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -222,7 +222,7 @@ object ModuleScope {
 
     private fun getVisibleImportValues(importClause: ElmImportClause): List<ExposedElement> {
         val allExposedValues = ImportScope.fromImportDecl(importClause)
-                ?.getExposedValues()
+                ?.getExposedValues()?.elements
                 ?: return emptyList()
 
         if (importClause.exposesAll)
@@ -244,21 +244,21 @@ object ModuleScope {
 
     private fun getAllImportValues(importClause: ElmImportClause): List<ExposedElement> {
         return ImportScope.fromImportDecl(importClause)
-                ?.getExposedValues()
+                ?.getExposedValues()?.elements
                 ?.map { ExposedElement(importClause.exposesAll, it) }
                 ?: return emptyList()
     }
 
     private fun getAllImportTypes(importClause: ElmImportClause): List<ExposedElement> {
         return ImportScope.fromImportDecl(importClause)
-                ?.getExposedTypes()
+                ?.getExposedTypes()?.elements
                 ?.map { ExposedElement(importClause.exposesAll, it) }
                 ?: return emptyList()
     }
 
     private fun getAllImportConstructors(importClause: ElmImportClause): List<ExposedElement> {
         return ImportScope.fromImportDecl(importClause)
-                ?.getExposedConstructors()
+                ?.getExposedConstructors()?.elements
                 ?.map { ExposedElement(importClause.exposesAll, it) }
                 ?: return emptyList()
     }
@@ -289,11 +289,11 @@ object ModuleScope {
 
     private fun getVisibleImportTypes(importClause: ElmImportClause): List<ElmNamedElement> {
         val allExposedTypes = ImportScope.fromImportDecl(importClause)
-                ?.getExposedTypes()
+                ?.getExposedTypes()?.elements
                 ?: return emptyList()
 
         if (importClause.exposesAll)
-            return allExposedTypes
+            return allExposedTypes.asList()
 
         // intersect the names exposed by the module with the names declared
         // in this import clause's exposing list.
@@ -332,11 +332,11 @@ object ModuleScope {
 
     private fun getVisibleImportConstructors(importClause: ElmImportClause): List<ElmNamedElement> {
         val allExposedConstructors = ImportScope.fromImportDecl(importClause)
-                ?.getExposedConstructors()
+                ?.getExposedConstructors()?.elements
                 ?: return emptyList()
 
         if (importClause.exposesAll)
-            return allExposedConstructors
+            return allExposedConstructors.asList()
 
         val exposedTypes = importClause.exposingList?.exposedTypeList
                 ?: return emptyList()

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -56,7 +56,7 @@ class DeclaredNames(
     val list get() = array.asList()
 
     /** The elements associated by element name */
-    val byName = array.associateByTo(mutableMapOf()) { it.name }
+    private val byName = array.associateByTo(mutableMapOf()) { it.name }
             .apply { remove(null) }
 
     operator fun get(key: String?): ElmNamedElement? = byName[key]

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -89,6 +89,11 @@ sealed class ElmProject(
                 is ElmPackageProject -> elmVersion.contains(version.xyz)
             }
 
+    /**
+     * Return `true` iff this package is the core package for the current version of Elm.
+     */
+    open fun isCore(): Boolean = false
+
     companion object {
 
         fun parse(manifestPath: Path, repo: ElmPackageRepository, ignoreTestDeps: Boolean = false): ElmProject {
@@ -219,7 +224,11 @@ class ElmPackageProject(
         val name: String,
         val version: Version,
         val exposedModules: List<String>
-) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories)
+) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories) {
+    override fun isCore(): Boolean {
+        return (name == "elm/core" || name == "elm-lang/core") // TODO [drop 0.18] remove "elm-core/lang" clause
+    }
+}
 
 
 private fun ExactDependenciesDTO.depsToPackages(repo: ElmPackageRepository) =


### PR DESCRIPTION
This PR contains a number of micro and macro optimizations that improve the performance of reference resolve 50-500%, depending on the project. Larger projects see more benefit due to improved caching.

Please double check my cache invalidation, I believe I'm using the correct modification trackers, but it's worth another set of eyes. Also feel free to veto any of the changes if you feel they complicate the code too much.

Here are some of the larger changes:

## ModuleScope

Although these loops were already cached, they were cached as a list of elements. Most reference implementations that used this scope would copy the returned list to an array (in `getVariants`), then filter that array down the the element that matches their name (in `resolveInner`).

The elements are now cached as both an array and a map of name to element, so now we don't make any copies, and `resolveInner` can do an O(1) map lookup. As an additional benefit, we only look up the element's `referenceName` once, where we were previously looking it up for each element in the array being searched.

## ImportScope

These results are now cached in a form similar to the form used in `ModuleScope`.

More importantly, calculating the values has been improved. Previously, calculating exposed names involved resolving the reference of each name in the exposing list. To do so, we would walk up from the reference to the file, then call a `ModuleScope.getDeclared*` function and filter the list for a matching name. But since all the exposed elements are defined in the same file, we now only call `ModuleScope` once and filter all the declarations in one pass. 

## ExpressionScope

This scope is very hot, but isn't amenable to caching due to the fact that the tree walk is unique for each reference, and retrieving a cached value is slow enough that caching intermediate results (e.g. `ElmValueDeclaration.declaredNames`) is a pessimization.

The main improvement to this scope is making the tree walk lazy so that e.g. resolving a reference to a function parameter doesn't need to call `ModuleScope.getVisibleValues`.

## GlobalScope

Since these results are the same for all files in a project, the results are now cached on the `ElmProject`. Additionally, the loops benefit from the improvements to `ModuleScope`

## Microoptimizations

I'm not going to list every change here, but there are a number of places that would walk over the same part of the Psi tree repeatedly. For example, `ElmUpperCaseQID.fillName`, which is a hot function, would gather all it's children into a list three times (once each for `isQualified`, `qualifierPrefix`, and `refName`). Now that function just calls `text` if it isn't a stub.