### PR TITLE
Add options to disable individual line marker types

### DIFF
--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmExposureLineMarkerProvider.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.lineMarkers
 
+import com.intellij.codeInsight.daemon.GutterIconDescriptor
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
@@ -20,6 +21,9 @@ import org.elm.lang.core.psi.elements.findMatchingItemFor
  * that are exposed by the containing module.
  */
 class ElmExposureLineMarkerProvider : LineMarkerProvider {
+    companion object {
+        val OPTION = GutterIconDescriptor.Option("elm.exposed", "Exposed declaration", ElmIcons.EXPOSED_GUTTER)
+    }
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
         if (element.elementType !in listOf(LOWER_CASE_IDENTIFIER, UPPER_CASE_IDENTIFIER)) return null
@@ -41,10 +45,6 @@ class ElmExposureLineMarkerProvider : LineMarkerProvider {
             else ->
                 null
         }
-    }
-
-    override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<LineMarkerInfo<PsiElement>>) {
-        // we don't need to add anything here
     }
 }
 

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmLineMarkerProvider.kt
@@ -1,0 +1,41 @@
+package org.elm.ide.lineMarkers
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmFile
+import org.elm.lang.core.psi.parentOfType
+
+class ElmLineMarkerProvider : LineMarkerProviderDescriptor() {
+    companion object {
+        private val OPTIONS = arrayOf(ElmExposureLineMarkerProvider.OPTION, ElmRecursiveCallLineMarkerProvider.OPTION)
+    }
+
+    override fun getName(): String? = "Elm line markers"
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
+
+    // This provides the options to show in Settings > Editor > General > Gutter Icons
+    override fun getOptions(): Array<Option> = OPTIONS
+
+    override fun collectSlowLineMarkers(elements: MutableList<PsiElement>, result: MutableCollection<LineMarkerInfo<PsiElement>>) {
+        val first = elements.firstOrNull() ?: return
+        if (DumbService.getInstance(first.project).isDumb || first.parentOfType<ElmFile>()?.elmProject == null) return
+
+        // Create the providers each time this function is called, since they may have internal state
+        val providers = mutableListOf<LineMarkerProvider>()
+        if (ElmExposureLineMarkerProvider.OPTION.isEnabled) providers.add(ElmExposureLineMarkerProvider())
+        if (ElmRecursiveCallLineMarkerProvider.OPTION.isEnabled) providers.add(ElmRecursiveCallLineMarkerProvider())
+
+        if (providers.isEmpty()) return
+
+        for (element in elements) {
+            ProgressManager.checkCanceled()
+            for (provider in providers) {
+                provider.getLineMarkerInfo(element)?.let { result.add(it) }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProvider.kt
@@ -1,60 +1,57 @@
 package org.elm.ide.lineMarkers
 
+import com.intellij.codeInsight.daemon.GutterIconDescriptor
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
-import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.util.FunctionUtil
 import org.elm.ide.icons.ElmIcons
-import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.ElmTypes.LOWER_CASE_IDENTIFIER
-import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
-import org.elm.lang.core.psi.elements.*
-import org.elm.lang.core.resolve.ElmReferenceElement
+import org.elm.lang.core.psi.ancestorsStrict
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.psi.elements.ElmValueExpr
+import org.elm.lang.core.psi.elements.ElmValueQID
 
 /**
  * Put an icon in the gutter for top-level declarations (types, functions, values)
  * that are exposed by the containing module.
  */
 class ElmRecursiveCallLineMarkerProvider : LineMarkerProvider {
+    companion object {
+        val OPTION = GutterIconDescriptor.Option("elm.recursive", "Recursive call", ElmIcons.RECURSIVE_CALL)
+    }
 
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
+    private val lines = mutableSetOf<Int>() // Only one marker per line
 
-    override fun collectSlowLineMarkers(
-            elements: List<PsiElement>,
-            result: MutableCollection<LineMarkerInfo<PsiElement>>
-    ) {
-        // we use the slow pass since we need to resolve references
+    override fun getLineMarkerInfo(el: PsiElement): LineMarkerInfo<*>? {
+        // We only call this from ElmLineMarkerProvider.collectSlowLineMarkers, so it's ok to resolve references
+        if (el.elementType != LOWER_CASE_IDENTIFIER) return null
+        val qid = el.parent as? ElmValueQID ?: return null
+        if (qid.qualifiers.isNotEmpty()) return null
+        val valueExpr = qid.parent as? ElmValueExpr ?: return null
+        val functionCall = valueExpr.parent as? ElmFunctionCallExpr ?: return null
+        if (functionCall.target != valueExpr) return null
 
-        val lines = mutableSetOf<Int>() // Only one marker per line
+        val ref = valueExpr.reference.resolve()
+        val nearestFunc = functionCall.ancestorsStrict.filterIsInstance<ElmValueDeclaration>()
+                .firstOrNull()?.functionDeclarationLeft
+        if (nearestFunc != ref) return null // not recursive
 
-        for (el in elements) {
-            if (el.elementType != LOWER_CASE_IDENTIFIER) continue
-            val qid = el.parent as? ElmValueQID ?: continue
-            if (qid.qualifiers.isNotEmpty()) continue
-            val valueExpr = qid.parent as? ElmValueExpr ?: continue
-            val functionCall = valueExpr.parent as? ElmFunctionCallExpr ?: continue
-            if (functionCall.target != valueExpr) continue
-
-            val ref = valueExpr.reference.resolve()
-            val nearestFunc = functionCall.ancestorsStrict.filterIsInstance<ElmValueDeclaration>()
-                    .firstOrNull()?.functionDeclarationLeft
-            if (nearestFunc != ref) continue // not recursive
-
-            val doc = PsiDocumentManager.getInstance(el.project).getDocument(el.containingFile) ?: continue
-            val lineNumber = doc.getLineNumber(el.textOffset)
-            if (lines.add(lineNumber)) {
-                result.add(LineMarkerInfo(
-                        el,
-                        el.textRange,
-                        ElmIcons.RECURSIVE_CALL,
-                        FunctionUtil.constant("Recursive call"),
-                        null,
-                        GutterIconRenderer.Alignment.RIGHT)
-                )
-            }
+        val doc = PsiDocumentManager.getInstance(el.project).getDocument(el.containingFile) ?: return null
+        val lineNumber = doc.getLineNumber(el.textOffset)
+        if (lines.add(lineNumber)) {
+            return LineMarkerInfo(
+                    el,
+                    el.textRange,
+                    ElmIcons.RECURSIVE_CALL,
+                    FunctionUtil.constant("Recursive call"),
+                    null,
+                    GutterIconRenderer.Alignment.RIGHT)
         }
+        return null
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -281,10 +281,7 @@
         <backspaceHandlerDelegate implementation="org.elm.ide.typing.ElmBackspaceHandler"/>
         <codeInsight.parameterInfo language="Elm" implementationClass="org.elm.ide.hints.ElmParameterInfoHandler"/>
         <codeInsight.typeInfo language="Elm" implementationClass="org.elm.ide.hints.ElmExpressionTypeProvider"/>
-        <codeInsight.lineMarkerProvider language="Elm"
-                                        implementationClass="org.elm.ide.lineMarkers.ElmExposureLineMarkerProvider"/>
-        <codeInsight.lineMarkerProvider language="Elm"
-                                        implementationClass="org.elm.ide.lineMarkers.ElmRecursiveCallLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="Elm" implementationClass="org.elm.ide.lineMarkers.ElmLineMarkerProvider"/>
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
         <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.refactoring.ElmImportOptimizer"/>


### PR DESCRIPTION
This consolidates all line marker providers into a single `LineMarkerProviderDescriptor` implementation that calls out to the individual providers and handles registering and checking options, as well as the boilerplate for `collectSlowLineMarkers`. Individual providers can just implement `getLineMarkerInfo`. Providers are created for each call to `collectSlowLineMarkers`, so they can have internal state if they need to.

Fixes #590

![Capture](https://user-images.githubusercontent.com/1109214/72278382-bf83eb80-35e8-11ea-99ce-9a59f6836ee1.PNG)
