### PR TITLE
Fix memory leaks in quick fixes

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmExposingAliasVariantsInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmExposingAliasVariantsInspection.kt
@@ -28,7 +28,7 @@ class ElmExposingAliasVariantsInspection : LocalInspectionTool() {
 }
 
 private class RemoveExposingListQuickFix : NamedQuickFix("Remove (..)") {
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        (descriptor.psiElement as? ElmExposedType)?.exposedUnionConstructors?.delete()
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        (element as? ElmExposedType)?.exposedUnionConstructors?.delete()
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmExposingAliasVariantsInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmExposingAliasVariantsInspection.kt
@@ -1,14 +1,13 @@
 package org.elm.ide.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.PsiFile
 import org.elm.lang.core.psi.elements.ElmExposedType
-import org.elm.lang.core.psi.elements.ElmExposedUnionConstructors
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 
 /**
@@ -22,26 +21,18 @@ class ElmExposingAliasVariantsInspection : LocalInspectionTool() {
                 if (element !is ElmExposedType) return
 
                 if (element.exposedUnionConstructors != null && element.reference.resolve() is ElmTypeAliasDeclaration) {
-                    holder.registerProblem(element, "Invalid (..) on alias import", RemoveExposingListQuickFix(element))
+                    holder.registerProblem(element, "Invalid (..) on alias import", RemoveExposingListQuickFix())
                 }
             }
         }
     }
 }
 
-private class RemoveExposingListQuickFix(element: ElmExposedType) : LocalQuickFixOnPsiElement(element) {
-    override fun getText(): String = "Remove (..)"
-    override fun getFamilyName(): String = text
+private class RemoveExposingListQuickFix : LocalQuickFix {
+    override fun getName(): String = "Remove (..)"
+    override fun getFamilyName(): String = name
 
-    override fun isAvailable(): Boolean {
-        return super.isAvailable() && getExposedVariants() != null
-    }
-
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        getExposedVariants()?.delete()
-    }
-
-    private fun getExposedVariants(): ElmExposedUnionConstructors? {
-        return (startElement as? ElmExposedType)?.exposedUnionConstructors
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        (descriptor.psiElement as? ElmExposedType)?.exposedUnionConstructors?.delete()
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmExposingAliasVariantsInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmExposingAliasVariantsInspection.kt
@@ -1,7 +1,6 @@
 package org.elm.ide.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
@@ -28,10 +27,7 @@ class ElmExposingAliasVariantsInspection : LocalInspectionTool() {
     }
 }
 
-private class RemoveExposingListQuickFix : LocalQuickFix {
-    override fun getName(): String = "Remove (..)"
-    override fun getFamilyName(): String = name
-
+private class RemoveExposingListQuickFix : NamedQuickFix("Remove (..)") {
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         (descriptor.psiElement as? ElmExposedType)?.exposedUnionConstructors?.delete()
     }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.intention.PriorityAction.Priority.LOW
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import org.elm.ide.inspections.MissingCaseBranchAdder.Result.MissingVariants
 import org.elm.ide.inspections.MissingCaseBranchAdder.Result.NoMissing
 import org.elm.lang.core.psi.ElmPsiElement
@@ -26,15 +27,15 @@ class ElmIncompletePatternInspection : ElmLocalInspection() {
 }
 
 private class AddMissingBranchesFix : NamedQuickFix("Add missing case branches") {
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val element = descriptor.psiElement.parent as? ElmCaseOfExpr ?: return
-        MissingCaseBranchAdder(element).addMissingBranches()
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        val parent = element.parent as? ElmCaseOfExpr ?: return
+        MissingCaseBranchAdder(parent).addMissingBranches()
     }
 }
 
 private class AddWildcardBranchFix : NamedQuickFix("Add '_' branch", LOW) {
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val element = descriptor.psiElement.parent as? ElmCaseOfExpr ?: return
-        MissingCaseBranchAdder(element).addWildcardBranch()
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        val parent = descriptor.psiElement.parent as? ElmCaseOfExpr ?: return
+        MissingCaseBranchAdder(parent).addWildcardBranch()
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmLocalInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmLocalInspection.kt
@@ -3,9 +3,8 @@ package org.elm.ide.inspections
 import com.intellij.codeInsight.intention.PriorityAction
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.elm.lang.core.psi.ElmPsiElement
@@ -23,7 +22,18 @@ abstract class ElmLocalInspection : LocalInspectionTool() {
     abstract fun visitElement(element: ElmPsiElement, holder: ProblemsHolder, isOnTheFly: Boolean)
 }
 
-/** A [LocalQuickFix] base class that takes care of some of the boilerplate */
+/**
+ * A [LocalQuickFix] base class that takes care of some of the boilerplate
+ *
+ * Note: [LocalQuickFix] implementations should never store a reference to a [PsiElement], since the
+ * PSI may change between the time that they're created and called, causing the elements to be
+ * invalid or leak memory.
+ *
+ * You can get the element this quick fix is applied to with `descriptor.psiElement`.
+ *
+ * If you really need a reference to an element other than the one this fix is shown on, you can implement
+ * [LocalQuickFixOnPsiElement], which holds weak references to one or two elements.
+ */
 abstract class NamedQuickFix(
         private val fixName: String,
         private val fixPriority: PriorityAction.Priority = PriorityAction.Priority.NORMAL

--- a/src/main/kotlin/org/elm/ide/inspections/ElmLocalInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmLocalInspection.kt
@@ -1,10 +1,8 @@
 package org.elm.ide.inspections
 
 import com.intellij.codeInsight.intention.PriorityAction
-import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
-import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.elm.lang.core.psi.ElmPsiElement
@@ -29,10 +27,8 @@ abstract class ElmLocalInspection : LocalInspectionTool() {
  * PSI may change between the time that they're created and called, causing the elements to be
  * invalid or leak memory.
  *
- * You can get the element this quick fix is applied to with `descriptor.psiElement`.
- *
  * If you really need a reference to an element other than the one this fix is shown on, you can implement
- * [LocalQuickFixOnPsiElement], which holds weak references to one or two elements.
+ * [LocalQuickFixOnPsiElement], which holds a weak reference to an element.
  */
 abstract class NamedQuickFix(
         private val fixName: String,
@@ -41,4 +37,9 @@ abstract class NamedQuickFix(
     override fun getName(): String = fixName
     override fun getFamilyName(): String = name
     override fun getPriority(): PriorityAction.Priority = fixPriority
+    final override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        applyFix(descriptor.psiElement ?: return, project, descriptor)
+    }
+
+    abstract fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor)
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmLocalInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmLocalInspection.kt
@@ -21,18 +21,14 @@ abstract class ElmLocalInspection : LocalInspectionTool() {
     }
 
     abstract fun visitElement(element: ElmPsiElement, holder: ProblemsHolder, isOnTheFly: Boolean)
+}
 
-    protected inline fun quickFix(
-            name: String,
-            familyName: String = name,
-            priority: PriorityAction.Priority = PriorityAction.Priority.NORMAL,
-            crossinline fix: (Project, ProblemDescriptor) -> Unit
-    ): LocalQuickFix = object : LocalQuickFix, PriorityAction {
-        override fun getName(): String = name
-        override fun getFamilyName(): String = familyName
-        override fun getPriority(): PriorityAction.Priority = priority
-        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            fix(project, descriptor)
-        }
-    }
+/** A [LocalQuickFix] base class that takes care of some of the boilerplate */
+abstract class NamedQuickFix(
+        private val fixName: String,
+        private val fixPriority: PriorityAction.Priority = PriorityAction.Priority.NORMAL
+) : LocalQuickFix, PriorityAction {
+    override fun getName(): String = fixName
+    override fun getFamilyName(): String = name
+    override fun getPriority(): PriorityAction.Priority = fixPriority
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnresolvedReferenceInspection.kt
@@ -52,8 +52,8 @@ class ElmUnresolvedReferenceInspection : ElmLocalInspection() {
 
             val description = "Unresolved reference '${ref.canonicalText}'"
             val fixes = mutableListOf<LocalQuickFix>()
-            if (AddImportFix(element).isAvailable) fixes += AddImportFix(element)
-            if (AddQualifierFix(element).isAvailable) fixes += AddQualifierFix(element)
+            if (AddImportFix.isAvailable(element)) fixes += AddImportFix()
+            if (AddQualifierFix.isAvailable(element)) fixes += AddQualifierFix()
             holder.registerProblem(element, description, LIKE_UNKNOWN_SYMBOL, errorRange, *fixes.toTypedArray())
         }
     }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnresolvedReferenceInspection.kt
@@ -1,6 +1,6 @@
 package org.elm.ide.inspections
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType.LIKE_UNKNOWN_SYMBOL
 import com.intellij.codeInspection.ProblemHighlightType.WEAK_WARNING
 import com.intellij.codeInspection.ProblemsHolder
@@ -51,7 +51,7 @@ class ElmUnresolvedReferenceInspection : ElmLocalInspection() {
             val errorRange = (element as? ElmTypeRef)?.upperCaseQID?.textRangeInParent
 
             val description = "Unresolved reference '${ref.canonicalText}'"
-            val fixes = mutableListOf<LocalQuickFixOnPsiElement>()
+            val fixes = mutableListOf<LocalQuickFix>()
             if (AddImportFix(element).isAvailable) fixes += AddImportFix(element)
             if (AddQualifierFix(element).isAvailable) fixes += AddQualifierFix(element)
             holder.registerProblem(element, description, LIKE_UNKNOWN_SYMBOL, errorRange, *fixes.toTypedArray())

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -55,8 +55,8 @@ private fun ProblemsHolder.markUnused(elem: PsiElement, message: String) {
 }
 
 private class OptimizeImportsFix : NamedQuickFix("Optimize imports") {
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val file = descriptor.psiElement.containingFile as? ElmFile ?: return
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        val file = element.containingFile as? ElmFile ?: return
         OptimizeImportsProcessor(project, file).run()
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.PsiFile
 import org.elm.lang.core.psi.ElmExposedItemTag
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.elements.ElmAsClause
@@ -52,14 +51,14 @@ class ElmUnusedImportInspection : LocalInspectionTool() {
 
 
 private fun ProblemsHolder.markUnused(elem: PsiElement, message: String) {
-    val file = elem.containingFile as? ElmFile ?: return
-    registerProblem(elem, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, OptimizeImportsFix(file))
+    registerProblem(elem, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, OptimizeImportsFix())
 }
 
-private class OptimizeImportsFix(file: ElmFile) : LocalQuickFixOnPsiElement(file)  {
-    override fun getText() = "Optimize imports"
+private class OptimizeImportsFix : LocalQuickFix {
+    override fun getName() = "Optimize imports"
     override fun getFamilyName() = name
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val file = descriptor.psiElement.containingFile as? ElmFile ?: return
         OptimizeImportsProcessor(project, file).run()
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedImportInspection.kt
@@ -54,9 +54,7 @@ private fun ProblemsHolder.markUnused(elem: PsiElement, message: String) {
     registerProblem(elem, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, OptimizeImportsFix())
 }
 
-private class OptimizeImportsFix : LocalQuickFix {
-    override fun getName() = "Optimize imports"
-    override fun getFamilyName() = name
+private class OptimizeImportsFix : NamedQuickFix("Optimize imports") {
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val file = descriptor.psiElement.containingFile as? ElmFile ?: return
         OptimizeImportsProcessor(project, file).run()

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -1,7 +1,9 @@
 package org.elm.ide.inspections
 
+import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiSearchHelper
 import com.intellij.psi.search.PsiSearchHelper.SearchCostResult.TOO_MANY_OCCURRENCES
@@ -48,22 +50,19 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
         }
     }
 
-    private fun isProgramEntryPoint(element: ElmNameIdentifierOwner): Boolean =
-            when {
-                element is ElmFunctionDeclarationLeft ->
-                    element.name == "main" || element.isElmTestEntryPoint()
-                element is ElmPortAnnotation -> isExposed(element)
-                else -> false
-            }
+    private fun isProgramEntryPoint(element: ElmNameIdentifierOwner): Boolean {
+        return when (element) {
+            is ElmFunctionDeclarationLeft -> element.name == "main" || element.isElmTestEntryPoint()
+            is ElmPortAnnotation -> isExposed(element)
+            else -> false
+        }
+    }
 
 
     private fun markAsUnused(holder: ProblemsHolder, element: ElmNameIdentifierOwner, name: String) {
-        val fixes = if (element is ElmLowerPattern) {
-            arrayOf(quickFix("Rename to _") { project, _ ->
-                element.replace(ElmPsiFactory(project).createAnythingPattern())
-            })
-        } else {
-            emptyArray()
+        val fixes = when (element) {
+            is ElmLowerPattern -> arrayOf(RenameToWildcardFix())
+            else -> emptyArray()
         }
         holder.registerProblem(
                 element.nameIdentifier,
@@ -74,6 +73,12 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
     }
 }
 
+private class RenameToWildcardFix : NamedQuickFix("Rename to _") {
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        (descriptor.psiElement.parent as? ElmLowerPattern)
+                ?.replace(ElmPsiFactory(project).createAnythingPattern())
+    }
+}
 
 private fun ElmFunctionDeclarationLeft.isElmTestEntryPoint(): Boolean {
     val decl = parentOfType<ElmValueDeclaration>() ?: return false

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiSearchHelper
 import com.intellij.psi.search.PsiSearchHelper.SearchCostResult.TOO_MANY_OCCURRENCES
@@ -74,8 +75,8 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
 }
 
 private class RenameToWildcardFix : NamedQuickFix("Rename to _") {
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        (descriptor.psiElement.parent as? ElmLowerPattern)
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        (element.parent as? ElmLowerPattern)
                 ?.replace(ElmPsiFactory(project).createAnythingPattern())
     }
 }

--- a/src/main/kotlin/org/elm/ide/inspections/import/AddImportFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/import/AddImportFix.kt
@@ -74,9 +74,9 @@ class AddImportFix : NamedQuickFix("Import") {
         }
     }
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val file = descriptor.psiElement.containingFile as? ElmFile ?: return
-        val context = findApplicableContext(descriptor.psiElement) ?: return
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        val file = element.containingFile as? ElmFile ?: return
+        val context = findApplicableContext(element) ?: return
         when (context.candidates.size) {
             0 -> error("should not happen: must be at least one candidate")
             1 -> {

--- a/src/main/kotlin/org/elm/ide/inspections/import/AddQualifierFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/import/AddQualifierFix.kt
@@ -67,8 +67,8 @@ class AddQualifierFix : NamedQuickFix("Qualify name") {
         }
     }
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val context = findApplicableContext(descriptor.psiElement) ?: return
+    override fun applyFix(element: PsiElement, project: Project, descriptor: ProblemDescriptor) {
+        val context = findApplicableContext(element) ?: return
 
         when (context.candidates.size) {
             0 -> error("should not happen: must be at least one candidate")


### PR DESCRIPTION
According to Kotlin's [inspection authoring guidelines](https://github.com/JetBrains/kotlin/blob/master/docs/intentions_inspections_quickfixes.md):

> There shouldn't be PSI elements stored in QuickFix classes (val psi: PsiElement) as such elements might be invalidated and can lead to memory leaks. Smart pointer (check SmartPsiElementPointer class and createSmartPointer() function) can be used when such storage is absolutely necessary.

The `quickFix` convenience function I wrote encouraged callers to capture PsiElements in the lambda, so I removed it in favor of a `NamedQuickFix` base class and stopped storing PsiElements. I also removed usages of `LocalQuickFixOnPsiElement` when not necessary, and added docs so we don't forget this limitation.