### PR TITLE
Support configurable indent size

### DIFF
--- a/src/main/kotlin/org/elm/ide/formatter/settings/ElmCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/elm/ide/formatter/settings/ElmCodeStyleSettingsProvider.kt
@@ -1,0 +1,53 @@
+package org.elm.ide.formatter.settings
+
+import com.intellij.application.options.CodeStyleAbstractConfigurable
+import com.intellij.application.options.CodeStyleAbstractPanel
+import com.intellij.application.options.IndentOptionsEditor
+import com.intellij.application.options.TabbedLanguageCodeStylePanel
+import com.intellij.psi.codeStyle.*
+import org.elm.lang.core.ElmLanguage
+
+
+class ElmCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
+    override fun getConfigurableDisplayName() = ElmLanguage.displayName
+
+    override fun createConfigurable(settings: CodeStyleSettings, modelSettings: CodeStyleSettings): CodeStyleConfigurable {
+        return object : CodeStyleAbstractConfigurable(settings, modelSettings, configurableDisplayName) {
+            override fun createPanel(settings: CodeStyleSettings): CodeStyleAbstractPanel =
+                    ElmCodeStyleMainPanel(currentSettings, settings)
+        }
+    }
+
+    private class ElmCodeStyleMainPanel(currentSettings: CodeStyleSettings, settings: CodeStyleSettings) :
+            TabbedLanguageCodeStylePanel(ElmLanguage, currentSettings, settings) {
+
+        override fun initTabs(settings: CodeStyleSettings?) {
+            addIndentOptionsTab(settings)
+        }
+    }
+}
+
+class ElmLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
+    override fun getLanguage() = ElmLanguage
+
+    // No sample, since we don't have a formatter.
+    // An empty string causes an NPE, so we use a zero-width space instead.
+    override fun getCodeSample(settingsType: SettingsType) = "\u200B"
+
+    // no setting other than indent yet
+    override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) {}
+
+    override fun getIndentOptionsEditor(): IndentOptionsEditor? = ElmOptionsEditor()
+}
+
+
+private class ElmOptionsEditor : IndentOptionsEditor() {
+    // Only expose the indent field. Setting this in customizeSettings doesn't seem to have an effect.
+    override fun addComponents() {
+        super.addComponents()
+        showStandardOptions("INDENT_SIZE")
+    }
+}
+
+
+

--- a/src/main/kotlin/org/elm/ide/formatter/settings/ElmCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/elm/ide/formatter/settings/ElmCodeStyleSettingsProvider.kt
@@ -37,17 +37,17 @@ class ElmLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
     // no setting other than indent yet
     override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) {}
 
+    // If we ever add formatting support, we'll probably want to return a plain
+    // `SmartIndentOptionsEditor()` rather than this custom one.
     override fun getIndentOptionsEditor(): IndentOptionsEditor? = ElmOptionsEditor()
 }
 
 
 private class ElmOptionsEditor : IndentOptionsEditor() {
-    // Only expose the indent field. Setting this in customizeSettings doesn't seem to have an effect.
+    // Only expose the indent field. Setting this in `customizeSettings` doesn't seem to have an
+    // effect.
     override fun addComponents() {
         super.addComponents()
         showStandardOptions("INDENT_SIZE")
     }
 }
-
-
-

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.inspections
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.psi.PsiDocumentManager
 import org.elm.lang.core.lookup.ElmLookup
 import org.elm.lang.core.psi.ElmPsiFactory
@@ -52,10 +53,11 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
     }
 
     private fun addPatterns(patterns: List<String>) {
+        val indent = " ".repeat(CodeStyle.getIndentOptions(element.containingFile).INDENT_SIZE)
         val factory = ElmPsiFactory(element.project)
         val existingBranches = element.branches
-        val indent = document!!.getIndent(element.startOffset) + "    "
-        val elements = factory.createCaseOfBranches(indent, patterns)
+        val existingIndent = document!!.getIndent(element.startOffset)
+        val elements = factory.createCaseOfBranches(existingIndent, indent, patterns)
         // Add the two or first generated branch, which are the indent
         // and newline
         var start = elements.first().prevSibling.prevSibling
@@ -69,7 +71,7 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
 
         // Without a value in the last branch, the virtual end token ends up before the trailing
         // whitespace, so we can't grab it from the factory element and need to add it separately.
-        val trailingWs = factory.createElements("\n$indent    ")
+        val trailingWs = factory.createElements("\n$existingIndent$indent$indent")
         element.addRange(trailingWs.first(), trailingWs.last())
     }
 

--- a/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/MissingCaseBranchAdder.kt
@@ -8,6 +8,8 @@ import org.elm.lang.core.psi.elements.ElmAnythingPattern
 import org.elm.lang.core.psi.elements.ElmCaseOfExpr
 import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.psi.elements.ElmUnionPattern
+import org.elm.lang.core.psi.indentStyle
+import org.elm.lang.core.psi.oneLevelOfIndentation
 import org.elm.lang.core.psi.startOffset
 import org.elm.lang.core.resolve.scope.ModuleScope
 import org.elm.lang.core.types.*
@@ -53,7 +55,7 @@ class MissingCaseBranchAdder(val element: ElmCaseOfExpr) {
     }
 
     private fun addPatterns(patterns: List<String>) {
-        val indent = " ".repeat(CodeStyle.getIndentOptions(element.containingFile).INDENT_SIZE)
+        val indent = element.indentStyle.oneLevelOfIndentation
         val factory = ElmPsiFactory(element.project)
         val existingBranches = element.branches
         val existingIndent = document!!.getIndent(element.startOffset)

--- a/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandler.kt
@@ -123,7 +123,7 @@ private class ExpressionReplacer(
      */
     fun introduceLet(elementToReplace: PsiElement) {
         val existingIndent = DocumentUtil.getIndent(editor.document, elementToReplace.startOffset).toString()
-        val indent = " ".repeat(CodeStyle.getIndentOptions(elementToReplace.containingFile).INDENT_SIZE)
+        val indent = elementToReplace.indentStyle.oneLevelOfIndentation
         val newDeclBodyText = chosenExpr.textWithNormalizedIndents
         val newIdentifierElement = project.runWriteCommandAction {
             val newLetExpr = if (elementToReplace !== chosenExpr) {
@@ -149,7 +149,7 @@ private class ExpressionReplacer(
         val file = letExpr.elmFile
         val anchor = letExpr.valueDeclarationList.last()
         val existingIndent = DocumentUtil.getIndent(editor.document, anchor.startOffset)
-        val indent = " ".repeat(CodeStyle.getIndentOptions(file).INDENT_SIZE)
+        val indent = file.indentStyle.oneLevelOfIndentation
         val indentedDeclExpr = chosenExpr.textWithNormalizedIndents.lines()
                 .joinToString("\n") { "$existingIndent$indent$it" }
         val textToInsert = "\n\n$existingIndent${identifier.text} =\n$indentedDeclExpr"

--- a/src/main/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandler.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandler.kt
@@ -104,7 +104,7 @@ class ElmOnEnterIndentHandler : EnterHandlerDelegateAdapter() {
 
         // IntelliJ will match leading whitespace of previous lines, so we only need
         // to indent one level, even for deeply nested let-in declarations.
-        val textToInsert = " ".repeat(CodeStyle.getIndentOptions(file).INDENT_SIZE)
+        val textToInsert = file.indentStyle.oneLevelOfIndentation
         document.insertString(caretOffset, textToInsert)
         caretAdvanceRef.set(textToInsert.length)
 

--- a/src/main/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandler.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandler.kt
@@ -7,7 +7,8 @@
 
 package org.elm.ide.typing
 
-import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate
+import com.intellij.application.options.CodeStyle
+import com.intellij.codeInsight.CodeInsightSettings
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate.Result
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegateAdapter
 import com.intellij.openapi.actionSystem.DataContext
@@ -35,7 +36,7 @@ import org.elm.lang.core.psi.elements.ElmTypeDeclaration
  * "smart" indentation to make it easy to write Elm code, especially
  * since Elm's parser depends on indentation as an implicit delimiter.
  */
-class ElmOnEnterSmartIndentHandler : EnterHandlerDelegateAdapter() {
+class ElmOnEnterIndentHandler : EnterHandlerDelegateAdapter() {
 
     override fun preprocessEnter(
             file: PsiFile,
@@ -44,11 +45,10 @@ class ElmOnEnterSmartIndentHandler : EnterHandlerDelegateAdapter() {
             caretAdvanceRef: Ref<Int>,
             dataContext: DataContext,
             originalHandler: EditorActionHandler?
-    ): EnterHandlerDelegate.Result {
+    ): Result {
+        if (file !is ElmFile) return Result.Continue
+        if (!CodeInsightSettings.getInstance()!!.SMART_INDENT_ON_ENTER) return Result.Continue
 
-        if (file !is ElmFile) {
-            return Result.Continue
-        }
 
         // get current document and commit any changes, so we'll get latest PSI
         val document = editor.document
@@ -102,10 +102,9 @@ class ElmOnEnterSmartIndentHandler : EnterHandlerDelegateAdapter() {
         }
 
 
-        // TODO [kl] stop assuming that the user wants 4-space indents
         // IntelliJ will match leading whitespace of previous lines, so we only need
         // to indent one level, even for deeply nested let-in declarations.
-        val textToInsert = "    "
+        val textToInsert = " ".repeat(CodeStyle.getIndentOptions(file).INDENT_SIZE)
         document.insertString(caretOffset, textToInsert)
         caretAdvanceRef.set(textToInsert.length)
 

--- a/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
+++ b/src/main/kotlin/org/elm/ide/typing/ElmSmartEnterProcessor.kt
@@ -55,7 +55,7 @@ class ElmSmartEnterProcessor : SmartEnterProcessorWithFixers() {
 
 private class ElmEnterProcessor : SmartEnterProcessorWithFixers.FixEnterProcessor() {
     override fun doEnter(atCaret: PsiElement, file: PsiFile, editor: Editor, modified: Boolean): Boolean {
-        val indent = CodeStyle.getIndentOptions(file).INDENT_SIZE
+        val indent = file.indentStyle.INDENT_SIZE
 
         if (modified && atCaret is ElmCaseOfExpr && atCaret.branches.isNotEmpty()) {
             val branch = atCaret.branches.first()
@@ -94,8 +94,7 @@ private class ElmEnterProcessor : SmartEnterProcessorWithFixers.FixEnterProcesso
 
 private abstract class ElmSmartEnterFixer : SmartEnterProcessorWithFixers.Fixer<ElmSmartEnterProcessor>() {
     final override fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement) {
-        val indent = " ".repeat(CodeStyle.getIndentOptions(element.containingFile).INDENT_SIZE)
-        apply(editor, processor, element, indent)
+        apply(editor, processor, element, element.indentStyle.oneLevelOfIndentation)
     }
 
     abstract fun apply(editor: Editor, processor: ElmSmartEnterProcessor, element: PsiElement, indent: String)

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -26,8 +26,15 @@ SOFTWARE.
 
 package org.elm.lang.core.psi
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.extapi.psi.StubBasedPsiElementBase
-import com.intellij.psi.*
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.StubBasedPsiElement
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import com.intellij.psi.impl.source.PsiFileImpl
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.IElementType
@@ -38,7 +45,6 @@ import org.elm.lang.core.lexer.ElmLayoutLexer
 import org.elm.lang.core.psi.ElmTypes.VIRTUAL_END_DECL
 import org.elm.lang.core.psi.elements.ElmValueDeclaration
 import org.elm.lang.core.stubs.ElmFileStub
-import kotlin.reflect.KClass
 
 
 val PsiElement.descendants: Sequence<PsiElement> get() = directChildren.flatMap { sequenceOf(it) + it.descendants }
@@ -172,7 +178,6 @@ inline val <T : StubElement<*>> StubBasedPsiElement<T>.greenStub: T?
     get() = (this as? StubBasedPsiElementBase<T>)?.greenStub
 
 
-
 val PsiElement.startOffset: Int
     get() = textRange.startOffset
 
@@ -187,8 +192,21 @@ val PsiElement.endOffset: Int
 fun PsiElement.offsetIn(owner: PsiElement): Int =
         ancestors.takeWhile { it != owner }.sumBy { it.startOffsetInParent }
 
-val PsiElement.hasErrors : Boolean
+val PsiElement.hasErrors: Boolean
     get() = PsiTreeUtil.hasErrorElements(this)
+
+val PsiFile.indentStyle: CommonCodeStyleSettings.IndentOptions
+    get() = CodeStyle.getIndentOptions(this)
+
+val PsiElement.indentStyle: CommonCodeStyleSettings.IndentOptions
+    get() = containingFile.indentStyle
+
+/**
+ * Return a string containing a number of spaces equal to the current
+ * [indent size][CommonCodeStyleSettings.IndentOptions.INDENT_SIZE]
+ */
+val CommonCodeStyleSettings.IndentOptions.oneLevelOfIndentation: String
+    get() = " ".repeat(INDENT_SIZE)
 
 // Elm-specific helpers
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -251,7 +251,7 @@
         <additionalTextAttributes scheme="Darcula" file="colorSchemes/ElmDarcula.xml"/>
         <annotator language="Elm" implementationClass="org.elm.ide.highlight.ElmSyntaxHighlightAnnotator"/>
         <colorSettingsPage implementation="org.elm.ide.color.ElmColorSettingsPage"/>
-        <enterHandlerDelegate implementation="org.elm.ide.typing.ElmOnEnterSmartIndentHandler"/>
+        <enterHandlerDelegate implementation="org.elm.ide.typing.ElmOnEnterIndentHandler"/>
         <fileTypeFactory implementation="org.elm.lang.core.ElmFileTypeFactory"/>
         <internalFileTemplate name="Elm Module"/>
         <moduleType id="ELM_MODULE" implementationClass="org.elm.ide.project.ElmModuleType"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -286,6 +286,8 @@
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
         <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.refactoring.ElmImportOptimizer"/>
         <colorProvider language="Elm" implementation="org.elm.ide.color.ElmColorProvider" />
+        <codeStyleSettingsProvider implementation="org.elm.ide.formatter.settings.ElmCodeStyleSettingsProvider"/>
+        <langCodeStyleSettingsProvider implementation="org.elm.ide.formatter.settings.ElmLanguageCodeStyleSettingsProvider"/>
 
         <!-- Inspections -->
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -4,6 +4,7 @@ import com.intellij.application.options.CodeStyle
 import junit.framework.TestCase
 import org.elm.lang.ElmTestBase
 import org.elm.lang.core.psi.ElmExpressionTag
+import org.elm.lang.core.psi.indentStyle
 import org.intellij.lang.annotations.Language
 
 class ElmIntroduceVariableHandlerTest : ElmTestBase() {
@@ -486,7 +487,7 @@ f =
   in
   4 + number
 """) {
-        CodeStyle.getIndentOptions(myFixture.file).INDENT_SIZE = 2
+        myFixture.file.indentStyle.INDENT_SIZE = 2
         doIntroduceVariable(listOf("3", "4 + 3"), 0)
     }
 

--- a/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/refactoring/ElmIntroduceVariableHandlerTest.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.refactoring
 
+import com.intellij.application.options.CodeStyle
 import junit.framework.TestCase
 import org.elm.lang.ElmTestBase
 import org.elm.lang.core.psi.ElmExpressionTag
@@ -472,6 +473,22 @@ f number =
     number1
 """)
 
+    // CODE STYLE
+
+    fun `test creates let-in with custom code style`() = checkByText("""
+f =
+  4 + {-caret-}3
+""", """
+f =
+  let
+    number =
+      3
+  in
+  4 + number
+""") {
+        CodeStyle.getIndentOptions(myFixture.file).INDENT_SIZE = 2
+        doIntroduceVariable(listOf("3", "4 + 3"), 0)
+    }
 
     // HELPERS
 

--- a/src/test/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandlerTest.kt
@@ -1,9 +1,10 @@
 package org.elm.ide.typing
 
+import com.intellij.application.options.CodeStyle
 import org.intellij.lang.annotations.Language
 
 
-class ElmOnEnterSmartIndentHandlerTest: ElmTypingTestBase() {
+class ElmOnEnterIndentHandlerTest : ElmTypingTestBase() {
 
 
     fun `test after function equals at EOF`() = doTest("""
@@ -149,10 +150,19 @@ type Foo =
 {-caret-}
 """)
 
+    fun `test indentation code style settings`() {
+        checkByText("f ={-caret-}", """
+            |f =
+            |  {-caret-}
+            """.trimMargin()) {
+            CodeStyle.getIndentOptions(myFixture.file).INDENT_SIZE = 2
+            myFixture.type('\n')
+        }
+    }
 
     fun doTest(@Language("Elm") before: String, @Language("Elm") after: String) {
-        InlineFile(before).withCaret()
-        myFixture.type('\n')
-        myFixture.checkResult(replaceCaretMarker(after))
+        checkByText(before, after) {
+            myFixture.type('\n')
+        }
     }
 }

--- a/src/test/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/typing/ElmOnEnterIndentHandlerTest.kt
@@ -1,6 +1,7 @@
 package org.elm.ide.typing
 
 import com.intellij.application.options.CodeStyle
+import org.elm.lang.core.psi.indentStyle
 import org.intellij.lang.annotations.Language
 
 
@@ -155,7 +156,7 @@ type Foo =
             |f =
             |  {-caret-}
             """.trimMargin()) {
-            CodeStyle.getIndentOptions(myFixture.file).INDENT_SIZE = 2
+            myFixture.file.indentStyle.INDENT_SIZE = 2
             myFixture.type('\n')
         }
     }

--- a/src/test/kotlin/org/elm/ide/typing/ElmSmartEnterProcessorTest.kt
+++ b/src/test/kotlin/org/elm/ide/typing/ElmSmartEnterProcessorTest.kt
@@ -1,5 +1,6 @@
 package org.elm.ide.typing
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.actionSystem.IdeActions
 import org.elm.lang.ElmTestBase
 import org.intellij.lang.annotations.Language
@@ -225,10 +226,36 @@ foo =
         ()
 """)
 
-    private fun doTest(@Language("Elm") before: String, @Language("Elm") after: String) =
-            // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
-            // significant for this test.
-            checkByText(before, after.replace("--EOL", "")) {
-                myFixture.performEditorAction(IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
-            }
+    fun `test case expression with custom indent`() = checkByText("""
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+  case it of{-caret-}
+""", """
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+  case it of
+    Bar ->
+      {-caret-}
+
+    Baz ->
+      --EOL
+
+    Qux ->
+
+""".replace("--EOL", "")) {
+        CodeStyle.getIndentOptions(myFixture.file).INDENT_SIZE = 2
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
+    }
+
+    private fun doTest(@Language("Elm") before: String, @Language("Elm") after: String) {
+        // We use the --EOL marker to avoid editors trimming trailing whitespace, which is
+        // significant for this test.
+        checkByText(before, after.replace("--EOL", "")) {
+            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
+        }
+    }
 }

--- a/src/test/kotlin/org/elm/ide/typing/ElmSmartEnterProcessorTest.kt
+++ b/src/test/kotlin/org/elm/ide/typing/ElmSmartEnterProcessorTest.kt
@@ -3,6 +3,7 @@ package org.elm.ide.typing
 import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.actionSystem.IdeActions
 import org.elm.lang.ElmTestBase
+import org.elm.lang.core.psi.indentStyle
 import org.intellij.lang.annotations.Language
 
 class ElmSmartEnterProcessorTest : ElmTestBase() {
@@ -247,7 +248,7 @@ foo it =
     Qux ->
 
 """.replace("--EOL", "")) {
-        CodeStyle.getIndentOptions(myFixture.file).INDENT_SIZE = 2
+        myFixture.file.indentStyle.INDENT_SIZE = 2
         myFixture.performEditorAction(IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
     }
 

--- a/src/test/kotlin/org/elm/lang/ElmTestBase.kt
+++ b/src/test/kotlin/org/elm/lang/ElmTestBase.kt
@@ -208,7 +208,7 @@ abstract class ElmTestBase : LightPlatformCodeInsightFixtureTestCase(), ElmTestC
         }
     }
 
-    protected fun replaceCaretMarker(text: String) =
+    protected fun replaceCaretMarker(@Language("Elm") text: String) =
             text.replace("{-caret-}", "<caret>")
 
     protected fun applyQuickFix(name: String) {


### PR DESCRIPTION
This PR adds support for a very basic Elm code style: we allow only a custom indent size. The enter handlers and intentions that generate code were updated to check the code style.

Fixes #567