### PR TITLE
Optimize type inference

### DIFF
--- a/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
+++ b/src/main/kotlin/org/elm/ide/docs/ElmDocumentationProvider.kt
@@ -5,10 +5,11 @@ import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.lang.documentation.DocumentationMarkup
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
-import org.elm.lang.core.psi.*
-import org.elm.lang.core.psi.ElmTypes.BLOCK_COMMENT
-import org.elm.lang.core.psi.ElmTypes.DOC_COMMENT
+import org.elm.lang.core.psi.ElmDocTarget
+import org.elm.lang.core.psi.ElmNamedElement
+import org.elm.lang.core.psi.ElmPsiElement
 import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.psi.parentOfType
 import org.elm.lang.core.resolve.scope.ModuleScope
 import org.elm.lang.core.resolve.scope.QualifiedImportScope
 import org.elm.lang.core.types.*

--- a/src/main/kotlin/org/elm/ide/inspections/import/AddQualifierFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/import/AddQualifierFix.kt
@@ -13,7 +13,7 @@ import org.elm.lang.core.psi.elements.Flavor.*
 import org.elm.lang.core.resolve.ElmReferenceElement
 import org.elm.lang.core.resolve.scope.ModuleScope
 import org.elm.lang.core.resolve.scope.VisibleNames
-import org.elm.lang.core.types.moduleName
+import org.elm.lang.core.psi.moduleName
 import org.elm.openapiext.isUnitTestMode
 import org.elm.openapiext.runWriteCommandAction
 import org.jetbrains.annotations.TestOnly

--- a/src/main/kotlin/org/elm/ide/intentions/TyFunctionGenerator.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/TyFunctionGenerator.kt
@@ -11,7 +11,7 @@ import org.elm.lang.core.types.Ty
 import org.elm.lang.core.types.TyUnion
 import org.elm.lang.core.types.allDeclarations
 import org.elm.lang.core.types.findTy
-import org.elm.lang.core.types.moduleName
+import org.elm.lang.core.psi.moduleName
 
 
 abstract class TyFunctionGenerator(

--- a/src/main/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/elm/ide/lineMarkers/ElmRecursiveCallLineMarkerProvider.kt
@@ -31,7 +31,7 @@ class ElmRecursiveCallLineMarkerProvider : LineMarkerProvider {
         // We only call this from ElmLineMarkerProvider.collectSlowLineMarkers, so it's ok to resolve references
         if (el.elementType != LOWER_CASE_IDENTIFIER) return null
         val qid = el.parent as? ElmValueQID ?: return null
-        if (qid.qualifiers.isNotEmpty()) return null
+        if (qid.isQualified) return null
         val valueExpr = qid.parent as? ElmValueExpr ?: return null
         val functionCall = valueExpr.parent as? ElmFunctionCallExpr ?: return null
         if (functionCall.target != valueExpr) return null

--- a/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.util.CachedValuesManager
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.stubs.index.ElmNamedElementIndex
-import org.elm.lang.core.types.moduleName
+import org.elm.lang.core.psi.moduleName
 import org.elm.openapiext.findFileByPathTestAware
 import org.elm.workspace.ElmPackageProject
 import org.elm.workspace.ElmProject

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmQID.kt
@@ -19,6 +19,11 @@ interface ElmQID : ElmPsiElement {
      */
     val qualifiers: List<PsiElement>
 
+    /**
+     * The text of the span of elements that make up [qualifiers]
+     *
+     * e.g. `Json.Decode` in the expression `Json.Decode.maybe`
+     */
     val qualifierPrefix: String
 
     /** Returns true if the qualified ID refers to Elm's "Kernel" modules,
@@ -27,9 +32,9 @@ interface ElmQID : ElmPsiElement {
      */
     val isKernelModule: Boolean
         get() {
-            val moduleName = upperCaseIdentifierList.joinToString(".") { it.text }
-            return moduleName.startsWith("Elm.Kernel.")
-                    || moduleName.startsWith("Native.") // TODO [drop 0.18] remove the "Native" clause
+            val text = text
+            return text.startsWith("Elm.Kernel.")
+                    || text.startsWith("Native.") // TODO [drop 0.18] remove the "Native" clause
         }
 
     val isQualified: Boolean

--- a/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/PsiElement.kt
@@ -226,3 +226,10 @@ fun PsiElement.outermostDeclaration(strict: Boolean): ElmValueDeclaration? =
                 .takeWhile { it !is ElmFile }
                 .filterIsInstance<ElmValueDeclaration>()
                 .firstOrNull { it.isTopLevel }
+
+/**
+ * Return the name from module declaration of the file containing this element, or the empty string
+ * if there isn't one.
+ */
+val ElmPsiElement.moduleName: String
+    get() = elmFile.getModuleDecl()?.name ?: ""

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmUpperCaseQID.kt
@@ -5,8 +5,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ElmStubbedElement
+import org.elm.lang.core.psi.ElmTypes
 import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
 import org.elm.lang.core.stubs.ElmUpperCaseQIDStub
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * An identifier that refers to a Module, Union Constructor, or Record Constructor,
@@ -38,7 +41,7 @@ class ElmUpperCaseQID : ElmStubbedElement<ElmUpperCaseQIDStub>, ElmQID {
      * e.g. `""` for QID `Foo`
      */
     override val qualifierPrefix: String
-        get() = stub?.qualifierPrefix ?: qualifiers.joinToString(".") { it.text }
+        get() = stub?.qualifierPrefix ?: text.let { it.take(max(0, it.lastIndexOf('.'))) }
 
     /**
      * The right-most name in a potentially qualified name.
@@ -47,7 +50,7 @@ class ElmUpperCaseQID : ElmStubbedElement<ElmUpperCaseQIDStub>, ElmQID {
      * e.g. `"Foo"` for QID `Foo`
      */
     val refName: String
-        get() = stub?.refName ?: upperCaseIdentifierList.last().text
+        get() = stub?.refName ?: text.let { it.drop(it.lastIndexOf(".") + 1) }
 
     /**
      * The fully qualified name. Equivalent to `PsiElement#text` but stub-safe.
@@ -69,5 +72,5 @@ class ElmUpperCaseQID : ElmStubbedElement<ElmUpperCaseQIDStub>, ElmQID {
      * TODO [kl] this double-duty is a bit strange. Maybe make a separate Psi element?
      */
     override val isQualified: Boolean
-        get() = qualifierPrefix != ""
+        get() = stub?.let { it.qualifierPrefix != "" } ?: (findChildByType<PsiElement>(ElmTypes.DOT) != null)
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueQID.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueQID.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.ElmPsiElementImpl
 import org.elm.lang.core.psi.ElmQID
 import org.elm.lang.core.psi.ElmTypes.*
+import kotlin.math.max
 
 /**
  * A value identifier, possibly qualified by the module/alias that contains the value.
@@ -26,7 +27,7 @@ class ElmValueQID(node: ASTNode) : ElmPsiElementImpl(node), ElmQID {
         get() = upperCaseIdentifierList
 
     override val qualifierPrefix: String
-        get() = qualifiers.joinToString(".") { it.text }
+        get() = text.let { it.take(max(0, it.lastIndexOf('.'))) }
 
     /**
      * The value identifier

--- a/src/main/kotlin/org/elm/lang/core/resolve/reference/RecordFieldReference.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/reference/RecordFieldReference.kt
@@ -31,8 +31,7 @@ abstract class RecordFieldReference<T : ElmReferenceElement>(
     override fun isSoft(): Boolean = true
 
     final override fun multiResolve(): List<ElmNamedElement> {
-        val ty1 = getTy()
-        val ty = ty1 as? TyRecord ?: return emptyList()
+        val ty = getTy() as? TyRecord ?: return emptyList()
         return ty.fieldReferences.get(element.referenceName)
     }
 

--- a/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
@@ -6,7 +6,7 @@ import org.elm.lang.core.psi.ElmNamedElement
  * A table that tracks references for [TyRecord] fields. Can be [frozen] to prevent updates.
  */
 data class RecordFieldReferenceTable(
-        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = mutableMapOf(),
+        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = HashMap(4, 1f),
         val frozen: Boolean = false
 ) {
     /** Get all references for a [field], or an empty list if there are none. */
@@ -18,7 +18,7 @@ data class RecordFieldReferenceTable(
     fun addAll(other: RecordFieldReferenceTable) {
         if (frozen || other.refsByField === this.refsByField) return
         for ((field, refs) in other.refsByField) {
-            refsByField.getOrPut(field) { mutableSetOf() } += refs
+            refsByField.getOrPut(field) { HashSet(refs.size, 1f) } += refs
         }
     }
 
@@ -32,7 +32,9 @@ data class RecordFieldReferenceTable(
 
     fun copy(frozen: Boolean = this.frozen): RecordFieldReferenceTable {
         return RecordFieldReferenceTable(
-                refsByField.mapValuesTo(mutableMapOf()) { (_, v) -> v.toMutableSet() },
+                refsByField.mapValuesTo(HashMap(refsByField.size)) { (_, v) ->
+                    HashSet<ElmNamedElement>(v.size, 1f).apply { addAll(v) }
+                },
                 frozen
         )
     }

--- a/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
@@ -6,7 +6,7 @@ import org.elm.lang.core.psi.ElmNamedElement
  * A table that tracks references for [TyRecord] fields. Can be [frozen] to prevent updates.
  */
 data class RecordFieldReferenceTable(
-        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = HashMap(4, 1f),
+        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = LinkedHashMap(4, 1f),
         val frozen: Boolean = false
 ) {
     /** Get all references for a [field], or an empty list if there are none. */
@@ -32,7 +32,7 @@ data class RecordFieldReferenceTable(
 
     fun copy(frozen: Boolean = this.frozen): RecordFieldReferenceTable {
         return RecordFieldReferenceTable(
-                refsByField.mapValuesTo(HashMap(refsByField.size)) { (_, v) ->
+                refsByField.mapValuesTo(LinkedHashMap(refsByField.size)) { (_, v) ->
                     HashSet<ElmNamedElement>(v.size, 1f).apply { addAll(v) }
                 },
                 frozen

--- a/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
@@ -32,9 +32,8 @@ class RecordFieldReferenceTable private constructor(
     fun addAll(other: RecordFieldReferenceTable) {
         if (frozen || other.refsByField === this.refsByField) return
         for ((field, refs) in other.refsByField) {
-            // Don't use putAll here, since that function will resize the table to hold (size + 1) elements
             val set = refsByField.getOrPut(field) { newSet(refs.size) }
-            refs.forEach { set.add(it) }
+            set.addAll(refs)
         }
     }
 
@@ -48,10 +47,10 @@ class RecordFieldReferenceTable private constructor(
         refsByField.mapValuesTo(newRefs) { (field, set) ->
             val otherSet = other.refsByField[field].orEmpty()
             val initialSetCapacity = set.size + otherSet.count { it !in set }
-            newSet(initialSetCapacity).apply { otherSet.forEach { add(it) } }
+            newSet(initialSetCapacity).apply { addAll(otherSet) }
         }
         other.refsByField.forEach { (k, s) ->
-            newRefs.getOrPut(k) { newSet(s.size).apply { s.forEach { add(it) } } }
+            newRefs.getOrPut(k) { newSet(s.size).apply { addAll(s) } }
         }
         return RecordFieldReferenceTable(newRefs)
     }
@@ -68,5 +67,5 @@ class RecordFieldReferenceTable private constructor(
 
 private fun newSet(initialCapacity: Int): MutableSet<ElmNamedElement> {
     // > 99% of these sets have 1 element, so we use a set optimized for that use case
-    return if (initialCapacity <= 1) SmartHashSet(-1, 1f) else SmartHashSet(initialCapacity, 1f)
+    return  SmartHashSet(initialCapacity, 1f)
 }

--- a/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/RecordFieldReferenceTable.kt
@@ -5,10 +5,12 @@ import org.elm.lang.core.psi.ElmNamedElement
 /**
  * A table that tracks references for [TyRecord] fields. Can be [frozen] to prevent updates.
  */
-data class RecordFieldReferenceTable(
-        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = LinkedHashMap(4, 1f),
-        val frozen: Boolean = false
+class RecordFieldReferenceTable(
+        private var refsByField: MutableMap<String, MutableSet<ElmNamedElement>> = LinkedHashMap(4, 1f)
 ) {
+    var frozen = false
+        private set
+
     /** Get all references for a [field], or an empty list if there are none. */
     fun get(field: String): List<ElmNamedElement> {
         return refsByField[field]?.toList().orEmpty()
@@ -35,17 +37,12 @@ data class RecordFieldReferenceTable(
         other.refsByField.forEach { (k, s) ->
             newRefs.getOrPut(k) { HashSet<ElmNamedElement>(s.size, 1f).apply { addAll(s) } }
         }
-        return RecordFieldReferenceTable(newRefs, frozen = false)
+        return RecordFieldReferenceTable(newRefs)
     }
 
-    fun freeze(): RecordFieldReferenceTable {
-        if (frozen) return this
-        return RecordFieldReferenceTable(
-                refsByField.mapValuesTo(LinkedHashMap(refsByField.size)) { (_, v) ->
-                    HashSet<ElmNamedElement>(v.size, 1f).apply { addAll(v) }
-                },
-                frozen = true
-        )
+    /** Prevent further modifications to this table. Tables cannot be unfrozen. */
+    fun freeze() {
+        frozen = true
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -68,6 +68,12 @@ data class TyRecord(
         override val alias: AliasInfo? = null,
         val fieldReferences: RecordFieldReferenceTable = RecordFieldReferenceTable()
 ) : Ty() {
+    companion object {
+        // Empty records occur in code like `foo : BaseRecord {}`, where they create a type from an
+        // extension record with no extra fields.
+        val emptyRecord = TyRecord(emptyMap(), null, null, RecordFieldReferenceTable().apply { freeze() })
+    }
+
     /** true if this record has a base name, and will match a subset of a record's fields */
     val isSubset: Boolean get() = baseTy != null
 
@@ -232,11 +238,11 @@ private fun Ty.allVars(result: MutableList<TyVar>) {
         is TyVar -> result.add(this)
         is TyTuple -> types.forEach { it.allVars(result) }
         is TyRecord -> {
-            fields.values.forEach { it.allVars(result) };
+            fields.values.forEach { it.allVars(result) }
             baseTy?.allVars(result)
         }
         is MutableTyRecord -> {
-            fields.values.forEach { it.allVars(result) };
+            fields.values.forEach { it.allVars(result) }
             baseTy?.allVars(result)
         }
         is TyUnion -> parameters.forEach { it.allVars(result) }
@@ -244,11 +250,7 @@ private fun Ty.allVars(result: MutableList<TyVar>) {
             ret.allVars(result)
             parameters.forEach { it.allVars(result) }
         }
-        is TyUnit -> {
-        }
-        is TyUnknown -> {
-        }
-        TyInProgressBinding -> {
+        is TyUnit, is TyUnknown, TyInProgressBinding -> {
         }
     }
 }

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -275,9 +275,6 @@ fun Ty.anyVar(orIsUnfrozenRecord: Boolean = false, predicate: (TyVar) -> Boolean
     } || alias?.parameters?.any { it.anyVar(orIsUnfrozenRecord, predicate) } == true
 }
 
-fun Ty.containsNoVars() = !anyVar { true }
-fun Ty.containsUnfrozenRecord() = anyVar(orIsUnfrozenRecord = true) { false }
-
 data class DeclarationInTy(val module: String, val name: String, val isUnion: Boolean)
 
 /** Create a lazy sequence of all union and alias instances within a [Ty]. */

--- a/src/main/kotlin/org/elm/lang/core/types/Ty.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/Ty.kt
@@ -314,3 +314,13 @@ fun Ty.allDeclarations(
         it.parameters.forEach { p -> yieldAll(p.allDeclarations()) }
     }
 }
+
+/** Extract the typeclass for a var name if it is one, or null if it's a normal var */
+fun TyVar.typeclassName(): String? = when {
+    name.length < 6 -> null // "number".length == 6
+    name.startsWith("number") -> "number"
+    name.startsWith("appendable") -> "appendable"
+    name.startsWith("comparable") -> "comparable"
+    name.startsWith("compappend") -> "compappend"
+    else -> null
+}

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -262,9 +262,7 @@ class TypeExpression(
     private fun recordTypeDeclType(record: ElmRecordType): TyRecord {
         val fieldElements = record.fieldTypeList
         val fieldTys = fieldElements.associate { it.name to typeExpressionType(it.typeExpression) }
-        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(LinkedHashMap(max(4, fieldElements.size), 1f)) {
-            it.name to HashSet<ElmNamedElement>(1, 1f).apply { add(it) }
-        })
+        val fieldReferences = RecordFieldReferenceTable.fromElements(fieldElements)
         val baseId = record.baseTypeIdentifier
         val baseTy = baseId?.reference?.resolve()?.let { getTyVar(it) } ?: baseId?.let { TyVar(it.referenceName) }
         return TyRecord(fieldTys, baseTy, fieldReferences = fieldReferences)

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -257,7 +257,7 @@ class TypeExpression(
     private fun recordTypeDeclType(record: ElmRecordType): TyRecord {
         val fieldElements = record.fieldTypeList
         val fieldTys = fieldElements.associate { it.name to typeExpressionType(it.typeExpression) }
-        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(HashMap(max(4, fieldElements.size), 1f)) {
+        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(LinkedHashMap(max(4, fieldElements.size), 1f)) {
             it.name to HashSet<ElmNamedElement>(1, 1f).apply { add(it) }
         })
         val baseId = record.baseTypeIdentifier

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -10,6 +10,7 @@ import org.elm.lang.core.diagnostics.ElmDiagnostic
 import org.elm.lang.core.diagnostics.TypeArgumentCountError
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
+import kotlin.math.max
 
 
 // Changes to type expressions always invalidate the whole project, since they influence inferred
@@ -256,8 +257,8 @@ class TypeExpression(
     private fun recordTypeDeclType(record: ElmRecordType): TyRecord {
         val fieldElements = record.fieldTypeList
         val fieldTys = fieldElements.associate { it.name to typeExpressionType(it.typeExpression) }
-        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(mutableMapOf()) {
-            it.name to mutableSetOf<ElmNamedElement>(it)
+        val fieldReferences = RecordFieldReferenceTable(fieldElements.associateTo(HashMap(max(4, fieldElements.size), 1f)) {
+            it.name to HashSet<ElmNamedElement>(1, 1f).apply { add(it) }
         })
         val baseId = record.baseTypeIdentifier
         val baseTy = baseId?.reference?.resolve()?.let { getTyVar(it) } ?: baseId?.let { TyVar(it.referenceName) }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -261,6 +261,7 @@ class TypeExpression(
 
     private fun recordTypeDeclType(record: ElmRecordType): TyRecord {
         val fieldElements = record.fieldTypeList
+        if (fieldElements.isEmpty()) return TyRecord.emptyRecord
         val fieldTys = fieldElements.associate { it.name to typeExpressionType(it.typeExpression) }
         val fieldReferences = RecordFieldReferenceTable.fromElements(fieldElements)
         val baseId = record.baseTypeIdentifier

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -28,9 +28,10 @@ private val TY_VARIANT_CACHE_KEY: Key<CachedValue<ParameterizedInferenceResult<V
 fun ElmTypeDeclaration.typeExpressionInference(): ParameterizedInferenceResult<TyUnion> {
     val cachedValue = CachedValuesManager.getCachedValue(this, TY_UNION_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = false).beginTypeDeclarationInference(this)
+        TypeReplacement.freeze(inferenceResult.value)
         CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     }
-    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true) as TyUnion)
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value) as TyUnion)
 }
 
 fun ElmTypeAliasDeclaration.typeExpressionInference(): ParameterizedInferenceResult<Ty> = typeExpressionInference(mutableSetOf())
@@ -38,26 +39,29 @@ fun ElmTypeAliasDeclaration.typeExpressionInference(): ParameterizedInferenceRes
 private fun ElmTypeAliasDeclaration.typeExpressionInference(activeAliases: MutableSet<ElmTypeAliasDeclaration>): ParameterizedInferenceResult<Ty> {
     val cachedValue = CachedValuesManager.getManager(project).getParameterizedCachedValue(this, TY_ALIAS_CACHE_KEY, { useActiveAliases ->
         val inferenceResult = TypeExpression(this, rigidVars = false, activeAliases = useActiveAliases).beginTypeAliasDeclarationInference(this)
+        TypeReplacement.freeze(inferenceResult.value)
         CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     },  /*trackValue*/ false, /*parameter*/ activeAliases)
-    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true))
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
 }
 
 
 fun ElmPortAnnotation.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
     val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = false).beginPortAnnotationInference(this)
+        TypeReplacement.freeze(inferenceResult.value)
         CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     }
-    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true))
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
 }
 
 fun ElmUnionVariant.typeExpressionInference(): ParameterizedInferenceResult<Ty> {
     val cachedValue = CachedValuesManager.getCachedValue(this, TY_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = false).beginUnionConstructorInference(this)
+        TypeReplacement.freeze(inferenceResult.value)
         CachedValueProvider.Result.create(inferenceResult, globalModificationTracker)
     }
-    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value, freeze = true))
+    return cachedValue.copy(value = TypeReplacement.freshenVars(cachedValue.value))
 }
 
 /**
@@ -75,7 +79,8 @@ fun ElmTypeAnnotation.typeExpressionInference(rigid: Boolean = true): InferenceR
 
     val cachedValue = CachedValuesManager.getCachedValue(typeRef, TY_ANNOTATION_CACHE_KEY) {
         val inferenceResult = TypeExpression(this, rigidVars = true).beginTypeRefInference(typeRef)
-        val frozenResult =  inferenceResult.copy(ty = TypeReplacement.freeze(inferenceResult.ty))
+        val frozenResult =  inferenceResult.copy(ty = TypeReplacement.replace(inferenceResult.ty, emptyMap()))
+        TypeReplacement.freeze(inferenceResult.ty)
 
         val trackers = when (parentModificationTracker) {
             null -> arrayOf(globalModificationTracker)
@@ -195,8 +200,8 @@ class TypeExpression(
     /** Get the type for an entire type expression */
     private fun typeExpressionType(typeExpr: ElmTypeExpression): Ty {
         val segments = typeExpr.allSegments.map { typeSignatureDeclType(it) }
-        return when {
-            segments.size == 1 -> segments.last()
+        return when (segments.size) {
+            1 -> segments.last()
             else -> TyFunction(segments.dropLast(1), segments.last()).uncurry()
         }
     }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -819,7 +819,7 @@ private class InferenceScope(
         if (typeRefTy is TyFunction) {
             patterns.zip(typeRefTy.parameters) { pat, ty -> bindPattern(pat, ty, true) }
         }
-        annotationVars = typeRefTy.allVars().toList()
+        annotationVars = typeRefTy.allVars()
         return ParameterBindingResult.Annotated(typeRefTy, patterns.size)
     }
 
@@ -1262,7 +1262,7 @@ private class InferenceScope(
         if (ty1 === ty2) return
 
         fun assign(k: TyVar, v: Ty) {
-            if (v.allVars(includeAlias = true).any { it == k }) throw InfiniteTypeException()
+            if (v.anyVar { it == k }) throw InfiniteTypeException()
             replacements[k] = v
         }
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -477,6 +477,10 @@ private class InferenceScope(
         val fieldName = fieldIdentifier.text
 
         if (targetTy is TyVar) {
+            if (targetTy.rigid) {
+                diagnostics += RecordBaseIdError(target, targetTy)
+                return TyUnknown()
+            }
             val ty = TyVar("b")
             trackReplacement(targetTy, MutableTyRecord(mutableMapOf(fieldName to ty), TyVar("a")))
             expressionTypes[expr] = ty

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -300,8 +300,6 @@ private class InferenceScope(
     }
 
     private fun inferBinOpExpr(expr: ElmBinOpExpr): Ty {
-        if (expr.hasErrors) return TyUnknown()
-
         val parts: List<ElmBinOpPartTag> = expr.parts.toList()
 
         // Get the operator types and precedences. We don't have to worry about invalid
@@ -366,8 +364,6 @@ private class InferenceScope(
             }
 
     private fun inferFunctionCall(expr: ElmFunctionCallExpr): Ty {
-        if (expr.hasErrors) return TyUnknown()
-
         val target = expr.target
         val arguments = expr.arguments.toList()
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1168,8 +1168,8 @@ private class InferenceScope(
      * Check if a [ty2] can that compares unequal to a [ty1] can be unified with it
      */
     private fun varsAssignable(ty1: TyVar, ty2: TyVar): Boolean {
-        val tc1 = getTypeclassName(ty1)
-        val tc2 = getTypeclassName(ty2)
+        val tc1 = ty1.typeclassName()
+        val tc2 = ty2.typeclassName()
 
         return when {
             !ty1.rigid && tc1 == null -> true
@@ -1265,8 +1265,8 @@ private class InferenceScope(
         // assigning anything to a variable constrains the type of that variable
         if (ty2 is TyVar && (ty2 !in replacements || ty1 !is TyVar && replacements[ty2] is TyVar)) {
             if (ty1 is TyVar) {
-                val tc1 = getTypeclassName(ty1)
-                val tc2 = getTypeclassName(ty2)
+                val tc1 = ty1.typeclassName()
+                val tc2 = ty2.typeclassName()
                 if (tc1 == null && tc2 != null) {
                     // There's an edge case where an assignment like `a => number`
                     // should constrain `a` to be a `number`, rather than `number` to be an `a`.
@@ -1338,10 +1338,6 @@ data class ParameterizedInferenceResult<T>(
         val value: T
 )
 
-val ElmPsiElement.moduleName: String
-    get() = elmFile.getModuleDecl()?.name ?: ""
-
-
 /** Return [count] [TyVar]s named a, b, ... z, a1, b1, ... */
 private fun uniqueVars(count: Int): List<TyVar> {
     return varNames().take(count).map { TyVar(it) }.toList()
@@ -1369,15 +1365,6 @@ private fun elementAllowsShadowing(element: ElmPsiElement): Boolean {
 }
 
 fun isInferable(ty: Ty): Boolean = ty !is TyUnknown
-
-/** Extract the typeclass for a var name if it is one, or null if it's a normal var*/
-fun getTypeclassName(ty: TyVar): String? = when {
-    ty.name.startsWith("number") -> "number"
-    ty.name.startsWith("appendable") -> "appendable"
-    ty.name.startsWith("comparable") -> "comparable"
-    ty.name.startsWith("compappend") -> "compappend"
-    else -> null
-}
 
 /** Throw an [IllegalStateException] with [message] augmented with information about [element] */
 fun error(element: ElmPsiElement, message: String): Nothing {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1370,11 +1370,14 @@ private fun elementAllowsShadowing(element: ElmPsiElement): Boolean {
 
 fun isInferable(ty: Ty): Boolean = ty !is TyUnknown
 
-/** extracts the typeclass from a [TyVar] name if it is a typeclass */
-private val TYPECLASS_REGEX = Regex("^(number|appendable|comparable|compappend).*")
-
 /** Extract the typeclass for a var name if it is one, or null if it's a normal var*/
-fun getTypeclassName(ty: TyVar): String? = TYPECLASS_REGEX.matchEntire(ty.name)?.groups?.get(1)?.value
+fun getTypeclassName(ty: TyVar): String? = when {
+    ty.name.startsWith("number") -> "number"
+    ty.name.startsWith("appendable") -> "appendable"
+    ty.name.startsWith("comparable") -> "comparable"
+    ty.name.startsWith("compappend") -> "compappend"
+    else -> null
+}
 
 /** Throw an [IllegalStateException] with [message] augmented with information about [element] */
 fun error(element: ElmPsiElement, message: String): Nothing {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -45,7 +45,7 @@ private class TypeRenderer(
         // avoid confusion. This is common with multiple unannotated functions, where they'll each
         // have types inferred as `a`, `b`, etc.
         val takenNames = varDisplayNames.values
-        if (getTypeclassName(ty) == null && ty.name in takenNames) {
+        if (ty.typeclassName() == null && ty.name in takenNames) {
             val displayName = possibleNames.first { it !in takenNames }
             varDisplayNames[ty] = displayName
             return displayName

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -1,5 +1,8 @@
 package org.elm.lang.core.types
 
+import com.intellij.codeInspection.SmartHashMap
+import com.intellij.util.SmartFMap
+
 /**
  * This class performs deep replacement of a set of [TyVar]s in a [Ty] with a set of new types,
  * which could also be [TyVar]s.
@@ -169,7 +172,7 @@ class TypeReplacement(
             else -> replacedBase
         }
 
-        val declaredFields = fields.mapValues { (_, it) -> replace(it) }
+        val declaredFields = fields.mapValuesTo(HashMap(fields.size, 1f)) { (_, it) -> replace(it) }
         val baseFields = (replacedBase as? TyRecord)?.fields.orEmpty()
         val baseFieldRefs = (replacedBase as? TyRecord)?.fieldReferences
 
@@ -196,7 +199,7 @@ class TypeReplacement(
     // When we replace a var, the new ty may itself contain vars, and so we need to recursively
     // replace the ty before we can replace the var we were given as an argument.
     // After the recursive replacement, we avoid repeating work by storing the final ty and tracking
-    // of the fact that it's replacement is complete with the `hasBeenAccessed` flag.
+    // of the fact that its replacement is complete with the `hasBeenAccessed` flag.
     private fun getReplacement(key: TyVar): Ty? {
         if (key !in replacements && (freshen || varsToRemainRigid != null)) {
             if (key.rigid && (varsToRemainRigid == null || key in varsToRemainRigid)) return null // never freshen rigid vars

--- a/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeReplacement.kt
@@ -91,7 +91,7 @@ class TypeReplacement(
 
     private fun Ty.wouldChange(): Boolean {
         val changeAllVars = freshen || varsToRemainRigid != null
-        return anyVar(orIsUnfrozenRecord = freeze) { changeAllVars || it in replacements }
+        return anyVar(orIsMutableRecord = !keepRecordsMutable, orIsUnfrozenRecord = freeze) { changeAllVars || it in replacements }
     }
 
     /** A map of var to (has been accessed, ty) */

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -285,7 +285,7 @@
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>
         <lang.importOptimizer language="Elm" implementationClass="org.elm.ide.refactoring.ElmImportOptimizer"/>
-        <colorProvider language="Elm" implementation="org.elm.ide.color.ElmColorProvider" />
+        <colorProvider language="Elm" implementation="org.elm.ide.color.ElmColorProvider"/>
         <codeStyleSettingsProvider implementation="org.elm.ide.formatter.settings.ElmCodeStyleSettingsProvider"/>
         <langCodeStyleSettingsProvider implementation="org.elm.ide.formatter.settings.ElmLanguageCodeStyleSettingsProvider"/>
 

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceFrozenCacheTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceFrozenCacheTest.kt
@@ -1,0 +1,96 @@
+package org.elm.ide.inspections.inference
+
+import org.elm.lang.ElmTestBase
+import org.elm.lang.core.psi.ElmPsiElement
+import org.elm.lang.core.psi.directChildrenOfType
+import org.elm.lang.core.psi.elements.ElmPortAnnotation
+import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
+import org.elm.lang.core.psi.elements.ElmTypeDeclaration
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.types.*
+import org.intellij.lang.annotations.Language
+
+/**
+ * Tests that all cached TyRecords are frozen and immutable. Variant inference results don't need to be
+ * frozen, since they're never used in other inference.
+ */
+class TypeInferenceFrozenCacheTest : ElmTestBase() {
+    fun `test port`() = doTest("""
+port module Main exposing (..)
+port p1 : () -> {f: ()}
+type alias R = {f2 : ()}
+port p2 : () -> R
+""")
+
+    fun `test type`() = doTest("""
+type alias R = {f2 : ()}
+type T a
+    = V1 {f: a}
+    | V2
+
+main : T R
+main = V2
+""")
+
+    fun `test parameterized alias`() = doTest("""
+type alias R a = {a | f : ()}
+type alias R2 = R { f2 : () }
+""")
+
+    fun `test annotation`() = doTest("""
+type alias R a = {a | f : ()}
+main : R { f2 : () } -> ()
+main _ = ()
+""")
+
+    fun `test expression types`() = doTest("""
+type alias R a = {a | f : ()}
+foo : R { f2 : () } -> R { f2 : () }
+foo a = a
+
+main a b =
+    let
+        bar = foo b
+        baz = a.a
+    in
+    (bar.f2, baz.b, b)
+""")
+
+    private fun doTest(@Language("Elm") code: String) {
+        InlineFile(code)
+        myFixture.file.directChildrenOfType<ElmPsiElement>().forEach { elem ->
+            when (elem) {
+                is ElmValueDeclaration -> checkResult(elem.findInference()!!)
+                is ElmTypeAliasDeclaration -> checkResult(elem.typeExpressionInference())
+                is ElmPortAnnotation -> checkResult(elem.typeExpressionInference())
+                is ElmTypeDeclaration -> checkResult(elem.typeExpressionInference())
+            }
+        }
+    }
+
+    private fun checkResult(r: InferenceResult) = checkResult(r.expressionTypes, r.diagnostics, r.ty)
+    private fun checkResult(r: ParameterizedInferenceResult<out Ty>) = checkResult(null, r.diagnostics, r.value)
+    private fun checkResult(expressionTypes: Map<ElmPsiElement, Ty>? = null, diagnostics: List<*>, ty: Ty) {
+        assertEmpty(diagnostics)
+        ty.assertFrozen()
+        expressionTypes?.values?.forEach { it.assertFrozen() }
+    }
+
+    private fun Ty.assertFrozen() {
+        when (this) {
+            is TyTuple -> types.forEach { it.assertFrozen() }
+            is TyRecord -> {
+                fields.values.forEach { it.assertFrozen() }
+                baseTy?.assertFrozen()
+                assertTrue("not frozen: $this", fieldReferences.frozen)
+            }
+            is MutableTyRecord -> fail("MutableTyRecord found: $this")
+            is TyUnion -> parameters.forEach { it.assertFrozen() }
+            is TyFunction -> {
+                ret.assertFrozen()
+                parameters.forEach { it.assertFrozen() }
+            }
+        }
+        alias?.parameters?.forEach { it.assertFrozen() }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceFrozenCacheTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceFrozenCacheTest.kt
@@ -56,6 +56,15 @@ main a b =
     (bar.f2, baz.b, b)
 """)
 
+    fun `test modifying extension record in lambda`() = doTest("""
+type alias R a = {a | f : ()}
+type alias S = { g: () }
+
+main : R S -> R S
+main r = 
+    (\s -> { s | g = () }) r
+""")
+
     private fun doTest(@Language("Elm") code: String) {
         InlineFile(code)
         myFixture.file.directChildrenOfType<ElmPsiElement>().forEach { elem ->

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -981,7 +981,7 @@ type Baz c d = Baz { f3 : c , f4 : Foo d -> Foo d }
 main : Baz (e -> ()) e -> Bar e
 main (Baz baz) =
     Bar
-        <error descr="Type mismatch.Required: { f1 : e → (), f2 : Foo ((), e) }Found: { f1 : e → (), f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), e)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
+        <error descr="Type mismatch.Required: { f2 : Foo ((), e), f1 : e → () }Found: { f2 : Foo e, f1 : e → () }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), e)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
         , f2 = baz.f4 Foo
         }</error>
 """)

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -613,7 +613,7 @@ type Foo a b = Foo
 type Bar c = Bar
 
 foo : Foo d (e -> f) -> Bar e -> Foo d f
-foo a = Debug.todo ""
+foo a b = Foo
 
 bar : Foo g g
 bar = Foo

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -126,6 +126,16 @@ main =
     <error descr="Type mismatch.Required: ()Found: List String → List String">appL map foo</error>
 """)
 
+    fun `test field access on rigid var`() = checkByText("""
+main : a -> a
+main a = <error descr="Type must be a record.Found: a">a</error>.foo
+""")
+
+    fun `test field accessor function on rigid var`() = checkByText("""
+main : a -> a
+main a = .foo <error descr="Type mismatch.Required: { a | foo : b }Found: a">a</error>
+""")
+
     fun `test passing function type with vars to operator`() = checkByText("""
 appL : (a -> b) -> a -> b
 appL f x = f x

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -981,7 +981,7 @@ type Baz c d = Baz { f3 : c , f4 : Foo d -> Foo d }
 main : Baz (e -> ()) e -> Bar e
 main (Baz baz) =
     Bar
-        <error descr="Type mismatch.Required: { f2 : Foo ((), e), f1 : e → () }Found: { f2 : Foo e, f1 : e → () }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), e)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
+        <error descr="Type mismatch.Required: { f1 : e → (), f2 : Foo ((), e) }Found: { f1 : e → (), f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), e)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
         , f2 = baz.f4 Foo
         }</error>
 """)

--- a/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
@@ -3,7 +3,7 @@ package org.elm.lang.core.lookup
 import org.elm.TestClientLocation
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
-import org.elm.lang.core.types.moduleName
+import org.elm.lang.core.psi.moduleName
 import org.elm.workspace.CustomElmStdlibVariant
 import org.elm.workspace.ElmWorkspaceTestBase
 import org.elm.workspace.Version


### PR DESCRIPTION
This wraps up my optimization works started in #585, with a focus on the type inference code. Inference in general spends > 60% of its time resolving references, so there isn't a huge opportunity for speedups. Most of the remaining 40% is spent in type replacement, so that's where I focused my effort.

In total, this PR speeds up total inference time by around 10%, but more importantly decreases the memory usage of the inference cache by about half.

The speedups mostly comes from reducing redundant tree walking and redundant type replacement copying.

The memory reduction is due partially to reducing copies in type replacement, allowing more shared references, but mostly by no longer allocating any extra capacity in the cached data structures. 

While working on this, I found a couple of minor bugs in inference that I've fixed and added tests for.