### PR TITLE
Enable support for IntelliJ 2020.1

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -256,7 +256,7 @@
     See http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
     Note that the range is half-open: [since-build, until-build)
      -->
-    <idea-version since-build="191.4212.41" until-build="193.*"/>
+    <idea-version since-build="191.4212.41" until-build="201.*"/>
 
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
I tested it with the EAP and didn't see any problems.