### PR TITLE
Fix types resolving to incorrect definition

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
@@ -129,10 +129,10 @@ private fun buildSearchScope(includeTests: Boolean, p: ElmProject, intellijProje
      *  NOTE: if the inputs to this function change (e.g. adding a parameter),
      *        you must take that into account when retrieving the cached value.
      */
-    val (srcDirPaths, dependencies) = if (includeTests)
-        Pair(p.allSourceDirs, p.allResolvedDependencies)
-    else
-        Pair(p.absoluteSourceDirectories.asSequence(), p.dependencies.asSequence())
+    val (srcDirPaths, dependencies) = when {
+        includeTests -> p.allSourceDirs to p.allResolvedDependencies
+        else -> p.absoluteSourceDirectories.asSequence() to p.dependencies.direct.asSequence()
+    }
 
     val srcDirs = srcDirPaths.mapNotNull { findFileByPathTestAware(it) }.toList()
     val srcDirScope = GlobalSearchScopesCore.directoriesScope(intellijProject, true, *(srcDirs.toTypedArray()))

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmFile.kt
@@ -50,7 +50,7 @@ class ElmFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ElmLan
         get() = project.elmWorkspace.findProjectForFile(originalFile.virtualFile)
 
     override val isInTestsDirectory: Boolean
-        // This is call often during reference resolve, and the system-independent path comparison
+        // This is called often during reference resolve, and the system-independent path comparison
         // is slow enough that the result is worth caching
         get() = CachedValuesManager.getCachedValue(this, IS_IN_TESTS_DIRECTORY_KEY) {
             elmProject?.let { elmProj ->

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmExposingList.kt
@@ -26,7 +26,7 @@ class ElmExposingList : ElmStubbedElement<ElmExposingListStub> {
         get() = findChildByType(DOUBLE_DOT)
 
     val exposesAll: Boolean
-        get() = stub?.exposesAll ?: doubleDot != null
+        get() = stub?.exposesAll ?: (doubleDot != null)
 
     /**
      * Returns the opening parenthesis element.

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -299,7 +299,7 @@ object ModuleScope {
         // intersect the names exposed by the module with the names declared
         // in this import clause's exposing list.
         val locallyExposedNames = importClause.exposingList?.exposedTypeList
-                ?.mapTo(mutableSetOf<String>()) { it.upperCaseIdentifier.text }
+                ?.mapTo(mutableSetOf<String>()) { it.referenceName }
                 ?: return emptyList()
         return allExposedTypes.filter { locallyExposedNames.contains(it.name) }
     }

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -27,7 +27,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             dir("src") {
                 elm("Main.elm", """
                     import Foo
@@ -63,7 +63,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                             "indirect": {}
                         }
                     }
-                    """.trimIndent())
+                    """)
                 dir("src") {
                     elm("Main.elm", """
                     module Main exposing (..)
@@ -88,7 +88,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                         "indirect": {}
                     }
                 }
-                """.trimIndent())
+                """)
             dir("src") {
                 elm("FooBar.elm", """
                     module FooBar exposing (x)
@@ -144,7 +144,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             dir("src") {
                 elm("Main.elm", """
                     import Foo
@@ -184,7 +184,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             dir("src") {
                 elm("Main.elm", """
                     import Time
@@ -218,7 +218,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             dir("src") {
                 elm("Main.elm", """
                     import Parser.Advanced -- this module is part of elm/parser, but it's not exposed
@@ -255,7 +255,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                             "indirect": {}
                         }
                     }
-                    """.trimIndent())
+                    """)
                 dir("src") {
                     elm("Main.elm", """
                     import Parser
@@ -282,7 +282,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                             "indirect": {}
                         }
                     }
-                    """.trimIndent())
+                    """)
                 dir("src") {
                     elm("Main.elm", """
                     import Parser
@@ -354,7 +354,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             if (!useDefaultTestsLocation)
                 file("elm.intellij.json", """{"test-directory": "custom-tests"}""")
             dir(testsFolder) {
@@ -390,7 +390,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             dir("src") {
                 elm("Main.elm", """
                     import Test
@@ -435,7 +435,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     "indirect": {}
                 }
             }
-            """.trimIndent())
+            """)
             if (!useDefaultTestsLocation)
                 file("elm.intellij.json", """{"test-directory": "custom-tests"}""")
             dir(testsFolder) {
@@ -451,36 +451,33 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
     }
 
 
-    // TODO [kl] re-enable once a distinction is made between direct and indirect deps
-//    fun `test does not resolve modules which are not direct dependencies`() {
-//        buildProject {
-//            project("elm.json", """
-//            {
-//                "type": "application",
-//                "source-directories": [
-//                    "src"
-//                ],
-//                "elm-version": "0.19.1",
-//                "dependencies": {
-//                    "direct": {},
-//                    "indirect": {
-//                        "elm/time": "1.0.0"
-//                    }
-//                },
-//                "test-dependencies": {
-//                    "direct": {},
-//                    "indirect": {}
-//                }
-//            }
-//            """.trimIndent())
-//            dir("src") {
-//                elm("Main.elm", """
-//                    import Time
-//                           --^
-//                """.trimIndent())
-//            }
-//        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", shouldNotResolve = true)
-//    }
-
-
+    fun `test does not resolve modules which are not direct dependencies`() {
+        buildProject {
+            project("elm.json", """
+            {
+                "type": "application",
+                "source-directories": [
+                    "src"
+                ],
+                "elm-version": "0.19.1",
+                "dependencies": {
+                    "direct": {},
+                    "indirect": {
+                        "elm/time": "1.0.0"
+                    }
+                },
+                "test-dependencies": {
+                    "direct": {},
+                    "indirect": {}
+                }
+            }
+            """)
+            dir("src") {
+                elm("Main.elm", """
+                    import Time
+                           --^
+                """.trimIndent())
+            }
+        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", shouldNotResolve = true)
+    }
 }

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -96,16 +96,25 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         checkEquals(Version(0, 19, 1), elmProject.elmVersion)
         checkEquals(setOf(Paths.get("src"), Paths.get("vendor")), elmProject.sourceDirectories.toSet())
 
-        checkEquals(setOf(
-                "elm/core" to Version(1, 0, 0),
-                "elm/html" to Version(1, 0, 0),
-                "elm/virtual-dom" to Version(1, 0, 2)
-        ), elmProject.dependencies.map { it.name to it.version }.toSet())
+        checkDependencies(elmProject.dependencies,
+                direct = mapOf(
+                        "elm/core" to Version(1, 0, 0),
+                        "elm/html" to Version(1, 0, 0)
+                ),
+                indirect = mapOf(
+                        "elm/virtual-dom" to Version(1, 0, 2)
+                )
+        )
 
-        checkEquals(setOf(
-                "elm-explorations/test" to Version(1, 0, 0),
-                "elm/random" to Version(1, 0, 0)
-        ), elmProject.testDependencies.map { it.name to it.version }.toSet())
+        checkDependencies(elmProject.testDependencies,
+                direct = mapOf(
+                        "elm-explorations/test" to Version(1, 0, 0)
+                ),
+                indirect = mapOf(
+                        "elm/random" to Version(1, 0, 0)
+                )
+
+        )
     }
 
     fun `test can attach package json files`() {
@@ -157,16 +166,17 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         // The source directory for Elm 0.19 packages is implicitly "src". It cannot be changed.
         checkEquals(setOf(Paths.get("src")), elmProject.sourceDirectories.toSet())
 
-        checkEquals(setOf("elm/core" to Version(1, 0, 0)),
-                elmProject.dependencies.map { it.name to it.version }.toSet())
+        checkDependencies(elmProject.dependencies,
+                direct = mapOf("elm/core" to Version(1, 0, 0))
+        )
 
-        checkEquals(setOf("elm-explorations/test" to Version(1, 0, 0)),
-                elmProject.testDependencies.map { it.name to it.version }.toSet())
+        checkDependencies(elmProject.testDependencies,
+                direct = mapOf("elm-explorations/test" to Version(1, 0, 0))
+        )
 
         checkEquals(setOf("Json.Decode", "Json.Encode"),
                 elmProject.exposedModules.toSet())
     }
-
 
     fun `test can attach multiple Elm projects`() {
         val testProject = fileTree {
@@ -301,8 +311,9 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         checkEquals(Version(0, 18, 0), elmProject.elmVersion)
 
-        checkEquals(setOf("elm-lang/core" to Version(5, 1, 1)),
-                elmProject.dependencies.map { it.name to it.version }.toSet())
+        checkDependencies(elmProject.dependencies,
+                direct = mapOf("elm-lang/core" to Version(5, 1, 1))
+        )
     }
 
     // TODO [drop 0.18] remove this test
@@ -405,8 +416,9 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         // Elm 0.18 packages can specify a source directory (unlike Elm 0.19)
         checkEquals(setOf(Paths.get(".")), elmProject.sourceDirectories.toSet())
 
-        checkEquals(setOf("elm-lang/core" to Version(5, 1, 1)),
-                elmProject.dependencies.map { it.name to it.version }.toSet())
+        checkDependencies(elmProject.dependencies,
+                direct = mapOf("elm-lang/core" to Version(5, 1, 1))
+        )
 
         checkEquals(listOf("Foo", "Bar"), elmProject.exposedModules)
     }
@@ -555,6 +567,11 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
     }
 
     // END OF TESTS RELATED TO SIDECAR MANIFEST (elm.intellij.json)
+
+    private fun checkDependencies(actual: ElmProject.Dependencies, direct: Map<String, Version>, indirect: Map<String, Version> = emptyMap()) {
+        checkEquals(actual.direct.associate { it.name to it.version }, direct)
+        checkEquals(actual.indirect.associate { it.name to it.version }, indirect)
+    }
 }
 
 


### PR DESCRIPTION
1. Stop resolving references to indirect dependencies
2. Fix a bug that would cause `ElmExposingList.exposesAll` to always return true in the presence of stubs. This caused names not actually imported in a module to be treated as visible.

Fixes #547 
Fixes #531