### PR TITLE
Fixes for 'duplicate declaration' inspection

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmDuplicateDeclarationInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmDuplicateDeclarationInspection.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElementVisitor
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNameIdentifierOwner
 import org.elm.lang.core.psi.ElmNamedElement
+import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
 import org.elm.lang.core.psi.elements.ElmLetInExpr
 import org.elm.lang.core.resolve.scope.ExpressionScope
 import org.elm.lang.core.resolve.scope.ModuleScope
@@ -42,7 +43,12 @@ private fun checkLetIn(element: ElmLetInExpr, holder: ProblemsHolder) {
     // individually. The values visible to all children are the same, so we only need to call
     // ExpressionScope once. This also prevents duplicate errors when sibling declarations have the
     // same name.
-    checkValues(holder, ExpressionScope(decls[0]).getVisibleValues())
+    //
+    // Elm lets you shadow imported names, including auto-imported names, so only count names
+    // declared in this file as shadowable.
+    val values = ExpressionScope(decls[0]).getVisibleValues()
+            .filter { it.containingFile == holder.file }
+    checkValues(holder, values)
 }
 
 private fun checkValues(holder: ProblemsHolder, values: Sequence<ElmNamedElement>) {

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmValueDeclaration.kt
@@ -79,7 +79,7 @@ class ElmValueDeclaration : ElmStubbedElement<ElmPlaceholderStub>, ElmDocTarget 
                 includeParameters -> assignee + assignee.namedParameters
                 else -> listOf(assignee)
             }
-            is ElmPattern -> descendantsOfType()
+            is ElmPattern -> assignee.descendantsOfType()
             is ElmOperatorDeclarationLeft -> when {
                 includeParameters -> assignee + assignee.namedParameters
                 else -> listOf(assignee)

--- a/src/test/kotlin/org/elm/ide/inspections/ElmDuplicateDeclarationInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmDuplicateDeclarationInspectionTest.kt
@@ -74,4 +74,45 @@ main =
     in
     foo
 """)
+
+    fun `test nested dupe of top-level in destructured assignment`() = checkByText("""
+<error descr="Multiple declarations with name 'foo'">foo</error> = 0
+main =
+    let
+        (<error descr="Multiple declarations with name 'foo'">foo</error>, bar) = (1, 2)
+    in
+    foo
+""")
+
+    fun `test no dupes in right-hand-side of destructured assignment`() = checkByText("""
+main =
+    let
+        (x, y) =
+            case (0, 0) of
+                (a, 0) -> (1, 2)
+                (0, a) -> (3, 4)
+    in
+    x
+""")
+
+    fun `test no dupes of imported names`() = checkByFileTree("""
+        --@ Main.elm
+        import Foo exposing (foo)
+        import Bar exposing (..)
+        main =
+            let
+                foo = 0
+                bar = 1
+            in
+            2
+          --^
+
+        --@ Foo.elm
+        module Foo exposing (..)
+        foo = ()
+
+        --@ Bar.elm
+        module Bar exposing (..)
+        bar = ()
+        """.trimIndent())
 }


### PR DESCRIPTION
There were a couple of problems here.

1. Issue #631 reported an exception on the `master` branch caused by the 'duplicate declaration' inspection trying to report an error on a file _other than_ the file being inspected.
2. The inspection was also triggering false positives in certain shadowing contexts. Elm's shadowing rules are confusing and undocumented. It's apparently okay to shadow a name that you import from another module. So I relaxed the inspection in this case (which indirectly fixed the first problem/exception).
3. There was a bug in `ElmValueDeclaration.declaredNames()` where it erroneously included names from the right-hand-side of destructuring assignments. This was causing additional false positives.