### PR TITLE
Incomplete pattern inspection applies at whole case expression

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
@@ -21,20 +21,20 @@ class ElmIncompletePatternInspection : ElmLocalInspection() {
             else -> arrayOf(AddWildcardBranchFix())
         }
 
-        holder.registerProblem(element.firstChild, "Case expression is not exhaustive", *fixes)
+        holder.registerProblem(element, "Case expression is not exhaustive", *fixes)
     }
 }
 
 private class AddMissingBranchesFix : NamedQuickFix("Add missing case branches") {
     override fun applyFix(element: PsiElement, project: Project) {
-        val parent = element.parent as? ElmCaseOfExpr ?: return
-        MissingCaseBranchAdder(parent).addMissingBranches()
+        val caseExpr = element as? ElmCaseOfExpr ?: return
+        MissingCaseBranchAdder(caseExpr).addMissingBranches()
     }
 }
 
 private class AddWildcardBranchFix : NamedQuickFix("Add '_' branch", LOW) {
     override fun applyFix(element: PsiElement, project: Project) {
-        val parent = element.parent as? ElmCaseOfExpr ?: return
-        MissingCaseBranchAdder(parent).addWildcardBranch()
+        val caseExpr = element as? ElmCaseOfExpr ?: return
+        MissingCaseBranchAdder(caseExpr).addWildcardBranch()
     }
 }


### PR DESCRIPTION
if case expression is missing branches then whole case expression is invalid not only the keyword `case`

now it looks like this
<img width="293" alt="image" src="https://user-images.githubusercontent.com/2387356/79011489-70584300-7b64-11ea-8ee4-de25c73754eb.png">
