### PR TITLE
Fix bug that broke the add-import fix

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/import/AddImportFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/import/AddImportFix.kt
@@ -61,7 +61,7 @@ class AddImportFix : NamedQuickFix("Import", Priority.HIGH) {
             // we can't import the function we're annotating
             if (refElement is ElmTypeAnnotation) return null
 
-            val typeAllowed = element.parentOfType<ElmTypeExpression>() != null
+            val typeAllowed = element is ElmTypeRef || element.parentOfType<ElmTypeExpression>() != null
             val name = refElement.referenceName
             val candidates = ElmLookup.findByName<ElmExposableTag>(name, refElement.elmFile)
                     .filter {

--- a/src/main/kotlin/org/elm/ide/inspections/import/AddImportFix.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/import/AddImportFix.kt
@@ -61,7 +61,7 @@ class AddImportFix : NamedQuickFix("Import", Priority.HIGH) {
             // we can't import the function we're annotating
             if (refElement is ElmTypeAnnotation) return null
 
-            val typeAllowed = element is ElmTypeRef || element.parentOfType<ElmTypeExpression>() != null
+            val typeAllowed = element is ElmTypeRef
             val name = refElement.referenceName
             val candidates = ElmLookup.findByName<ElmExposableTag>(name, refElement.elmFile)
                     .filter {

--- a/src/test/kotlin/org/elm/ide/inspections/import/AddImportFixTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/import/AddImportFixTest.kt
@@ -123,6 +123,31 @@ import Foo exposing (Bar)
 main : Bar
 """)
 
+    fun `test importing a type on the RHS of a type alias declaration`() = check(
+            """
+--@ main.elm
+type alias Foo = Bar{-caret-}
+--@ Foo.elm
+module Foo exposing (..)
+type Bar = ()
+""",
+            """
+import Foo exposing (Bar)
+type alias Foo = Bar
+""")
+
+    fun `test importing a type on the RHS of a union type declaration`() = check(
+            """
+--@ main.elm
+type Foo = Foo Bar{-caret-}
+--@ Foo.elm
+module Foo exposing (..)
+type Bar = ()
+""",
+            """
+import Foo exposing (Bar)
+type Foo = Foo Bar
+""")
 
     fun `test multiple import candidates`() = checkAutoImportFixByTextWithMultipleChoice(
             """


### PR DESCRIPTION
Fixes #643 

The bug affected importing a type in the right-hand side of a union type declaration.

e.g. `Bar` in: 
```elm
type Foo = Foo Bar
```

The PSI tree looked like this
<img width="465" alt="blah" src="https://user-images.githubusercontent.com/84525/79246842-b7d21e00-7e47-11ea-86a1-a9df7004e655.png">

The problem was that the element's parent was not an `ElmTypeExpression`, and as far as I can tell, it would be incorrect to change the BNF to use an `ElmTypeExpression` on the RHS of a variant (due to how things need to be parenthesized here).