### PR TITLE
List.map to List.Foldr refactoring

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -1,0 +1,41 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.ancestors
+import org.elm.lang.core.psi.elements.ElmExposingList
+import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
+
+class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Context>() {
+//    data class Context(val nameToExpose: String, val exposingList: ElmExposingList)
+    data class Context(val mapInvocation: ElmFunctionCallExpr)
+
+    override fun startInWriteAction(): Boolean {
+        return true
+    }
+
+    override fun getFamilyName(): String {
+        return ""
+    }
+
+
+    override fun getText(): String {
+        return "Convert List.map to List.foldr"
+    }
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        // TODO return null if
+        return Context(element.ancestors.filterIsInstance<ElmFunctionCallExpr>().first())
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+
+        val elmPsiFactory = ElmPsiFactory(project)
+
+        context.mapInvocation.replace(elmPsiFactory.createFunctionCallExpr("List.foldr (\\item result -> f item :: result) [] items"))
+    }
+
+}

--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -10,10 +10,6 @@ import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
 class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Context>() {
     data class Context(val mapInvocation: ElmFunctionCallExpr)
 
-    override fun startInWriteAction(): Boolean {
-        return true
-    }
-
     override fun getFamilyName(): String {
         return ""
     }

--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -32,11 +32,11 @@ class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Cont
 
         val elmPsiFactory = ElmPsiFactory(project)
         val first = context.mapInvocation.arguments.toList().first()
-        val second = context.mapInvocation.arguments.toList().get(1)
+        val second = context.mapInvocation.arguments.toList().getOrNull(1)
 
         val functionName = "List.foldr"
         val innerFunctionName = first.text
-        val itemsExpression = second.text
+        val itemsExpression = second?.let { it.text }.orEmpty()
         val multilineFunction = innerFunctionName.contains('\n')
         val functionCallText =
                 if (!multilineFunction) {

--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -3,10 +3,8 @@ package org.elm.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.elm.lang.core.psi.ElmPsiFactory
 import org.elm.lang.core.psi.ancestors
-import org.elm.lang.core.psi.elements.ElmExposingList
 import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
 
 class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Context>() {
@@ -34,8 +32,14 @@ class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Cont
     override fun invoke(project: Project, editor: Editor, context: Context) {
 
         val elmPsiFactory = ElmPsiFactory(project)
+        val first = context.mapInvocation.arguments.toList().first()
+        val second = context.mapInvocation.arguments.toList().get(1)
 
-        context.mapInvocation.replace(elmPsiFactory.createFunctionCallExpr("List.foldr (\\item result -> f item :: result) [] items"))
+        val functionName = "List.foldr"
+        val innerFunctionName = first.text
+        val itemsExpression = second.text
+        val functionCallText = "$functionName (\\item result -> $innerFunctionName item :: result) [] $itemsExpression"
+        context.mapInvocation.replace(elmPsiFactory.createFunctionCallExpr(functionCallText))
     }
 
 }

--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -8,7 +8,6 @@ import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
 
 class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Context>() {
-//    data class Context(val nameToExpose: String, val exposingList: ElmExposingList)
     data class Context(val mapInvocation: ElmFunctionCallExpr)
 
     override fun startInWriteAction(): Boolean {
@@ -38,7 +37,28 @@ class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Cont
         val functionName = "List.foldr"
         val innerFunctionName = first.text
         val itemsExpression = second.text
-        val functionCallText = "$functionName (\\item result -> $innerFunctionName item :: result) [] $itemsExpression"
+        val multilineFunction = innerFunctionName.contains('\n')
+        val functionCallText =
+                if (!multilineFunction) {
+                    "$functionName (\\item result -> $innerFunctionName item :: result) [] $itemsExpression"
+                } else {
+                    """List.foldr
+        (\item result ->
+            greet
+                (case thing of
+                    Hello ->
+                        "Hello"
+
+                    Hi ->
+                        "Hi"
+                )
+                item
+                :: result
+        )
+        []
+        names
+""".trimIndent()
+                }
         context.mapInvocation.replace(elmPsiFactory.createFunctionCallExpr(functionCallText))
     }
 

--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -14,14 +14,18 @@ class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Cont
         return ""
     }
 
-
     override fun getText(): String {
         return "Convert List.map to List.foldr"
     }
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
-        // TODO return null if
-        return Context(element.ancestors.filterIsInstance<ElmFunctionCallExpr>().first())
+        return element.ancestors.filterIsInstance<ElmFunctionCallExpr>().firstOrNull()?.let {
+            if (it.target.text == "List.map") {
+                Context(it)
+            } else {
+                null
+            }
+        }
     }
 
     override fun invoke(project: Project, editor: Editor, context: Context) {

--- a/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MapToFoldIntention.kt
@@ -42,24 +42,29 @@ class MapToFoldIntention : ElmAtCaretIntentionActionBase<MapToFoldIntention.Cont
                 if (!multilineFunction) {
                     "$functionName (\\item result -> $innerFunctionName item :: result) [] $itemsExpression"
                 } else {
+                    val indentedFunction = addIndentLevels(1, innerFunctionName)
                     """List.foldr
         (\item result ->
-            greet
-                (case thing of
-                    Hello ->
-                        "Hello"
-
-                    Hi ->
-                        "Hi"
-                )
+        $indentedFunction
                 item
                 :: result
         )
         []
-        names
+        $itemsExpression
 """.trimIndent()
                 }
         context.mapInvocation.replace(elmPsiFactory.createFunctionCallExpr(functionCallText))
     }
 
+}
+
+fun addIndentLevels(indentBy: Int, original: String): String {
+    return original.lines().map {
+        if (it.isEmpty()) {
+            it
+        } else {
+            " ".repeat(indentBy * 4) + it
+        }
+    }
+            .joinToString(separator = "\n")
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -118,6 +118,10 @@ class ElmPsiFactory(private val project: Project) {
             createFromText("f = $text")
                     ?: error("Invalid string: `$text`")
 
+    fun createFunctionCallExpr(text: String): ElmFunctionCallExpr =
+            createFromText("f = $text")
+                    ?: error("Invalid function call expr: `$text`")
+
     fun createNumberConstant(num: String): ElmNumberConstantExpr =
             createFromText("f = $num")
                     ?: error("Invalid number: `$num`")

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -126,6 +126,11 @@ class ElmPsiFactory(private val project: Project) {
             createFromText("f = $num")
                     ?: error("Invalid number: `$num`")
 
+    fun createLambda(lambdaText: String): ElmParenthesizedExpr {
+        return createFromText("f = ($lambdaText)")
+                ?: error("Invalid lambda: `$lambdaText`")
+    }
+
     fun createAnythingPattern(): ElmAnythingPattern =
             createFromText("f _ = 1")
                     ?: error("Invalid anything pattern")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -387,6 +387,10 @@
             <category>Elm</category>
         </intentionAction>
         <intentionAction>
+            <className>org.elm.ide.intentions.MapToFoldIntention</className>
+            <category>Elm</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.elm.ide.intentions.MakeAnnotationIntention</className>
             <category>Elm</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/MapToFoldIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/MapToFoldIntention/after.elm.template
@@ -1,0 +1,4 @@
+module User exposing (<spot>name, age</spot>)
+
+name = "Bob"
+age = 42

--- a/src/main/resources/intentionDescriptions/MapToFoldIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/MapToFoldIntention/after.elm.template
@@ -1,4 +1,4 @@
-module User exposing (<spot>name, age</spot>)
+module Example exposing (example)
 
-name = "Bob"
-age = 42
+example numbers =
+    <spot>List.foldr (\item result -> (\n -> n * 2) item :: result) [] numbers</spot>

--- a/src/main/resources/intentionDescriptions/MapToFoldIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/MapToFoldIntention/before.elm.template
@@ -1,0 +1,4 @@
+module User exposing (<spot>name</spot>)
+
+name = "Bob"
+age = 42

--- a/src/main/resources/intentionDescriptions/MapToFoldIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/MapToFoldIntention/before.elm.template
@@ -1,4 +1,4 @@
-module User exposing (<spot>name</spot>)
+module Example exposing (example)
 
-name = "Bob"
-age = 42
+example numbers =
+    <spot>List.map (\n -> n * 2) numbers</spot>

--- a/src/main/resources/intentionDescriptions/MapToFoldIntention/description.html
+++ b/src/main/resources/intentionDescriptions/MapToFoldIntention/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Add a function or type to a module's <code>exposing</code> list.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/MapToFoldIntention/description.html
+++ b/src/main/resources/intentionDescriptions/MapToFoldIntention/description.html
@@ -1,5 +1,5 @@
 <html lang="en">
 <body>
-Add a function or type to a module's <code>exposing</code> list.
+Turn a <code>List.map</code> expression into the equivalent <code>List.foldr</code>. This gives you access to the running accumulated value so you can easily use that form when you need additional context.
 </body>
 </html>

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -44,7 +44,7 @@ greet greetWord name =
 f0 = 
     List.foldr
         (\item result ->
-            greet
+            (greet
                 (case thing of
                     Hello ->
                         "Hello"
@@ -52,6 +52,7 @@ f0 =
                     Hi ->
                         "Hi"
                 )
+            )
                 item
                 :: result
         )

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -82,4 +82,76 @@ f0 =
     |> List.foldr (\item result -> f item :: result) []
 """)
 
+
+    fun `test preserves indentation from surrounding context`() = doAvailableTest(
+            """
+module Foo exposing (view)
+
+view : Model -> { title : String, content : Html Msg }
+view model =
+    { title = "Conduit"
+    , content =
+        div [ class "home-page" ]
+            [ viewBanner
+            , div [ class "container page" ]
+                [ [ case model.feed of
+                        Loaded feed ->
+                                [ div [ class "feed-toggle" ] <|
+                                    List.concat
+                                        [ [ viewTabs
+                                                (Session.cred model.session)
+                                                model.feedTab
+                                          ]
+                                        , List.m{-caret-}ap
+                                            (Html.map
+                                                GotFeedMsg
+                                            )
+                                            (Feed.viewArticles model.timeZone
+                                                feed
+                                            )
+                                        , [ Feed.viewPagination ClickedFeedPage model.feedPage feed ]
+                                        ]
+                                ]
+
+                        Loading ->
+                            []
+""", """
+module Foo exposing (view)
+
+view : Model -> { title : String, content : Html Msg }
+view model =
+    { title = "Conduit"
+    , content =
+        div [ class "home-page" ]
+            [ viewBanner
+            , div [ class "container page" ]
+                [ [ case model.feed of
+                        Loaded feed ->
+                                [ div [ class "feed-toggle" ] <|
+                                    List.concat
+                                        [ [ viewTabs
+                                                (Session.cred model.session)
+                                                model.feedTab
+                                          ]
+                                        , List.foldr
+                                            (\item result ->
+                                                (Html.map
+                                                    GotFeedMsg
+                                                )
+                                                    item
+                                                    :: result
+                                            )
+                                            []
+                                            (Feed.viewArticles model.timeZone
+                                                feed
+                                            )
+                                        , [ Feed.viewPagination ClickedFeedPage model.feedPage feed ]
+                                        ]
+                                ]
+
+                        Loading ->
+                            []
+""")
+
+
 }

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -15,4 +15,48 @@ f0 =
     List.foldr (\item result -> f item :: result) [] items
 """)
 
+
+    fun `test transforms functions with case statements`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+
+greet greetWord name =
+    greetWord ++ ", " ++ name ++ "!"
+
+f0 = 
+    List.ma{-caret-}p
+        (greet
+            (case thing of
+                Hello ->
+                    "Hello"
+
+                Hi ->
+                    "Hi"
+            )
+        )
+        names
+""", """
+module Foo exposing (f0)
+
+greet greetWord name =
+    greetWord ++ ", " ++ name ++ "!"
+
+f0 = 
+    List.foldr
+        (\item result ->
+            greet
+                (case thing of
+                    Hello ->
+                        "Hello"
+
+                    Hi ->
+                        "Hi"
+                )
+                item
+                :: result
+        )
+        []
+        names
+""")
+
 }

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -153,5 +153,28 @@ view model =
                             []
 """)
 
+    fun `test introduces unique parameter names`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+
+item = ()
+item1 = ()
+result = ()
+result1 = ()
+
+f0 = 
+    List.m{-caret-}ap f items
+""", """
+module Foo exposing (f0)
+
+item = ()
+item1 = ()
+result = ()
+result1 = ()
+
+f0 = 
+    List.foldr (\item2 result2 -> f item2 :: result2) [] items
+""")
+
 
 }

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -60,4 +60,11 @@ f0 =
         names
 """)
 
+    fun `test not available for functions besides map`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    List.filt{-caret-}er f items
+""")
+
 }

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -67,4 +67,19 @@ f0 =
     List.filt{-caret-}er f items
 """)
 
+
+
+    fun `test piped function`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    items
+    |> List.m{-caret-}ap f
+""", """
+module Foo exposing (f0)
+f0 = 
+    items
+    |> List.foldr (\item result -> f item :: result) []
+""")
+
 }

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -4,7 +4,7 @@ package org.elm.ide.intentions
 class MapToFoldIntentionTest : ElmIntentionTestBase(MapToFoldIntention()) {
 
 
-    fun `test expose a function`() = doAvailableTest(
+    fun `test converts to fold`() = doAvailableTest(
             """
 module Foo exposing (f0)
 f0 = 

--- a/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/MapToFoldIntentionTest.kt
@@ -1,0 +1,18 @@
+package org.elm.ide.intentions
+
+
+class MapToFoldIntentionTest : ElmIntentionTestBase(MapToFoldIntention()) {
+
+
+    fun `test expose a function`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    List.m{-caret-}ap f items
+""", """
+module Foo exposing (f0)
+f0 = 
+    List.foldr (\item result -> f item :: result) [] items
+""")
+
+}


### PR DESCRIPTION
Hey @klazuka, here's a PR for the `List.map` -> `List.foldr` refactoring that @avh4 and I built in the live stream.

Here's a demo:

![Screen Recording 2020-08-08 at 03 20 42 PM](https://user-images.githubusercontent.com/1384166/89720801-fd809c80-d98a-11ea-8835-2914c9c7cbc2.gif)

A few notable features:

- If the foldr argument is multiline, it will do multiformatting formatting. Otherwise it will format on a single line.
- It preserves whitespace to ensure that the semantics of any `case` statements or `let` bindings are preserved (and so it feels smooth and doesn't reformat twice)
- If the new lambda argument names are in scope (`result` and `item`), it will add a number after the name until it's unique in that scope
- The refactoring doesn't present itself if there are 0 arguments passed in to `List.map`
- The refactoring works with 1 or 2 arguments (i.e. partially applied or not)


I considered doing something to do a live rename, like rename refactorings, but it seems unnecessary since you can rename it using that refactoring if you'd like to. Overall, it's feeling like a nice little win!

I'm open to any feedback you have on the functionality or the code. This one is a lot simpler than the other two I've taken on, so hopefully this one will be easier to wrap up.