### PR TITLE
Autocomplete record field names using diagnostics

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionContributor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionContributor.kt
@@ -8,6 +8,7 @@ import org.elm.lang.core.ElmLanguage
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmTypes
 import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.ElmRecordExpr
 
 class ElmCompletionContributor : CompletionContributor() {
 
@@ -26,10 +27,11 @@ class ElmCompletionContributor : CompletionContributor() {
         for languages like Elm where many parse rules require a lower-case identifier.
         */
 
-        if (pre.elementType == ElmTypes.DOT) {
+        if (pre.elementType == ElmTypes.DOT || pre.parent is ElmRecordExpr) {
             // Assume that after a dot, a lower-case identifier should follow.
             // This works well for functions qualified by their module name (e.g. `String.length`)
             // but it does NOT work for qualified types (e.g. `Task.Task`)
+            // Also assume lower-case identifiers should be used inside of elm record expressions.
 
             // TODO use additional context to determine whether it should be upper- vs lower-case.
             context.dummyIdentifier = LOWER_DUMMY_IDENTIFIER

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionProvider.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionProvider.kt
@@ -18,7 +18,7 @@ interface Suggestor {
  */
 class ElmCompletionProvider : CompletionProvider<CompletionParameters>() {
 
-    val suggestors = listOf(ElmQualifiableRefSuggestor, ElmRecordFieldSuggestor, ElmKeywordSuggestor)
+    val suggestors = listOf(ElmQualifiableRefSuggestor, ElmRecordFieldSuggestor, ElmRecordLiteralFieldSuggestor, ElmKeywordSuggestor)
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         suggestors.forEach { it.addCompletions(parameters, result) }

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmKeywordSuggestions.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmKeywordSuggestions.kt
@@ -9,11 +9,11 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmTypes.*
-import org.elm.lang.core.psi.elementType
-import org.elm.lang.core.psi.elements.ElmCaseOfExpr
 import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
 import org.elm.lang.core.psi.elements.ElmIfElseExpr
 import org.elm.lang.core.psi.elements.ElmLetInExpr
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.*
 import org.elm.lang.core.psi.prevLeaves
 import org.elm.lang.core.psi.withoutErrors
 
@@ -63,8 +63,11 @@ object ElmKeywordSuggestor : Suggestor {
                 result.add("exposing")
             }
 
+            if(parent is ElmRecordExpr && prevVisibleLeaf?.elementType in listOf(COMMA, LEFT_SQUARE_BRACKET)) {
+                // When in a record field (e.g. `{n }` or `{ name = "", n }`) do not suggest keywords.
+            }
             // keywords that can appear at the beginning of an expression
-            if (prevVisibleLeaf?.elementType in listOf(EQ, ARROW, IN, COMMA, LEFT_SQUARE_BRACKET, LEFT_PARENTHESIS)) {
+            else if (prevVisibleLeaf?.elementType in listOf(EQ, ARROW, IN, COMMA, LEFT_SQUARE_BRACKET, LEFT_PARENTHESIS)) {
                 result.add("if")
                 result.add("case")
                 result.add("let")

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordLiteralFieldSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordLiteralFieldSuggestor.kt
@@ -1,0 +1,42 @@
+package org.elm.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import org.elm.lang.core.diagnostics.TypeMismatchError
+import org.elm.lang.core.psi.ELM_IDENTIFIERS
+import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.ElmField
+import org.elm.lang.core.psi.elements.ElmRecordExpr
+import org.elm.lang.core.types.*
+
+object ElmRecordLiteralFieldSuggestor : Suggestor {
+
+    override fun addCompletions(parameters: CompletionParameters, result: CompletionResultSet) {
+        val pos = parameters.position
+        val parent = pos.parent
+        val grandParent = parent?.parent
+        val recordExpr = parent as? ElmRecordExpr
+                ?: if (parent is ElmField) grandParent as? ElmRecordExpr else null
+
+        if (pos.elementType in ELM_IDENTIFIERS && recordExpr != null) {
+            recordExpr.findInference()
+                    ?.diagnostics
+                    ?.filterIsInstance<TypeMismatchError>()
+                    ?.filter { it.recordDiff != null }
+                    ?.firstOrNull { it.element === recordExpr }
+                    ?.recordDiff
+                    ?.missing
+                    ?.forEach { fieldName, fieldTy ->
+                        result.add(fieldName, fieldTy, parent is ElmField)
+                    }
+        }
+    }
+}
+
+private fun CompletionResultSet.add(fieldName: String, field: Ty, inElmField: Boolean) {
+    // Do not add equals after key in a field { {-caret-} = "hello" }
+    val str = if (inElmField) fieldName else "$fieldName = "
+    addElement(LookupElementBuilder.create(str)
+            .withTypeText(field.renderedText()))
+}

--- a/src/main/kotlin/org/elm/lang/core/diagnostics/ElmDiagnostic.kt
+++ b/src/main/kotlin/org/elm/lang/core/diagnostics/ElmDiagnostic.kt
@@ -112,7 +112,7 @@ class TypeMismatchError(
         private val expected: Ty,
         endElement: PsiElement? = null,
         private val patternBinding: Boolean = false,
-        private val recordDiff: RecordDiff? = null
+        val recordDiff: RecordDiff? = null
 ) : ElmDiagnostic(element, endElement) {
     override val message: String
         get() {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -436,6 +436,7 @@ private class InferenceScope(
             atom is ElmLetInExpr -> inferChild { beginLetInInference(atom) }.ty
             atom is ElmCaseOfExpr -> inferCase(atom)
             atom is ElmParenthesizedExpr -> inferExpression(atom.expression)
+            atom is ElmRecordExpr -> inferRecord(atom)
             atom.hasErrors -> TyUnknown()
             else -> when (atom) {
                 is ElmAnonymousFunctionExpr -> inferLambda(atom)
@@ -449,7 +450,6 @@ private class InferenceScope(
                 is ElmTupleExpr -> TyTuple(atom.expressionList.map { inferExpression(it) })
                 is ElmNumberConstantExpr -> if (atom.isFloat) TyFloat else TyVar("number")
                 is ElmOperatorAsFunctionExpr -> inferOperatorAsFunction(atom)
-                is ElmRecordExpr -> inferRecord(atom)
                 is ElmStringConstantExpr -> TyString
                 is ElmUnitExpr -> TyUnit()
                 is ElmValueExpr -> inferReferenceElement(atom)
@@ -535,8 +535,6 @@ private class InferenceScope(
 
         // TODO: check patterns cover possibilities
         for (branch in caseOf.branches) {
-            if (branch.hasErrors) break
-
             val pat = branch.pattern
             val branchExpression = branch.expression ?: break
             val result = inferChild { beginCaseBranchInference(pat, caseOfExprTy, branchExpression) }

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordLiteralCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordLiteralCompletionTest.kt
@@ -1,0 +1,226 @@
+package org.elm.lang.core.completion
+
+class ElmRecordLiteralCompletionTest : ElmCompletionTestBase() {
+    override fun getProjectDescriptor() = ElmWithStdlibDescriptor
+
+    fun `test complete field from blank`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { n{-caret-} }
+""", """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { name = {-caret-} }
+""")
+
+
+    fun `test complete field from one letter`() = doSingleCompletion(
+            """
+type alias Foo = { name : String, other: String }
+
+f : Foo
+f =
+    { n{-caret-} }
+""", """
+type alias Foo = { name : String, other: String }
+
+f : Foo
+f =
+    { name = {-caret-} }
+""")
+
+    fun `test complete single missing field from blank when record type contains two fields`() = doSingleCompletion(
+            """
+type alias Foo = { name : String, other:String }
+
+f : Foo
+f =
+    { name="", {-caret-}}
+""", """
+type alias Foo = { name : String, other:String }
+
+f : Foo
+f =
+    { name="", other = {-caret-}}
+""")
+
+    fun `test no completions when all fields already defined`() = checkNoCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { name = "", n{-caret-} }
+""")
+
+    fun `test no completions when no type annotation`() = checkNoCompletion(
+            """
+f =
+    { name = "", n{-caret-} }
+""")
+
+    fun `test complete field in record update`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo -> Foo
+f foo =
+    { foo | n{-caret-} }
+""", """
+type alias Foo = { name : String }
+
+f : Foo -> Foo
+f foo =
+    { foo | name = {-caret-} }
+""")
+
+
+    fun `test complete field in root of nested record`() = doSingleCompletion(
+            """
+type alias Foo = { first : { second: {third: String} } }
+
+f : Foo
+f =
+    { f{-caret-} }
+""", """
+type alias Foo = { first : { second: {third: String} } }
+
+f : Foo
+f =
+    { first = {-caret-} }
+""")
+
+    // TODO. Implemented this.
+    fun `test complete field in leaf of nested record`() = checkNoCompletion(
+            """
+type alias Foo = { first : { second: String } }
+
+f : Foo
+f =
+    { first = { s{-caret-} } }
+""")
+
+    fun `test complete field in custom type declaration`() = doSingleCompletion(
+            """
+type Bar = Baz {name:String}
+type alias Foo = { bar : Bar }
+
+f : String -> Foo
+f str =
+    { bar = Baz { {-caret-} } }
+""", """
+type Bar = Baz {name:String}
+type alias Foo = { bar : Bar }
+
+f : String -> Foo
+f str =
+    { bar = Baz { name = {-caret-} } }
+""")
+
+    fun `test complete field in let block`() = doSingleCompletion(
+            """
+f =
+  let
+    f2 : { name : String }
+    f2 =
+        { n{-caret-} }
+  in
+  f2
+""", """
+f =
+  let
+    f2 : { name : String }
+    f2 =
+        { name = {-caret-} }
+  in
+  f2
+""")
+
+
+    fun `test complete field in case expression without type annotation`() = doSingleCompletion(
+            """
+f b =
+  case b of 
+    True ->
+      { name = "foo" }
+    False ->
+       { n{-caret-} }
+""", """
+f b =
+  case b of 
+    True ->
+      { name = "foo" }
+    False ->
+       { name = {-caret-} }
+""")
+
+    fun `test complete missing field from blank with field value set`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { {-caret-} = "" }
+""", """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { name{-caret-} = "" }
+""")
+
+    fun `test complete field from one letter with field value set`() = doSingleCompletion(
+            """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { n{-caret-} = "" }
+""", """
+type alias Foo = { name : String }
+
+f : Foo
+f =
+    { name{-caret-} = "" }
+""")
+
+    fun `test complete field in extensible record`() = doSingleCompletion(
+            """
+type alias Named a = { a | name : String}
+
+f : Named a
+f =
+    { n{-caret-} }
+""", """
+type alias Named a = { a | name : String}
+
+f : Named a
+f =
+    { name = {-caret-} }
+""")
+
+
+    fun `test complete field in custom type declaration nested in incomplete record`() = doSingleCompletion(
+            """
+type Bar = Baz {name:String}
+type Foo = { first: String, second: {third: Bar} }
+
+f: Foo
+f =
+  { second = { third = Baz { {-caret-} } } }
+""", """
+type Bar = Baz {name:String}
+type Foo = { first: String, second: {third: Bar} }
+
+f: Foo
+f =
+  { second = { third = Baz { name = {-caret-} } } }
+"""
+    )
+
+}


### PR DESCRIPTION
Addresses #680

 Does not complete field names in nested records. See #680 for more details.

This PR stops the TypeInference from short circuiting in a few situations where there are errors in the AST. I think it is necessary because incomplete records (e.g `{name }`) contain errors such as `EQ, PIPE or RIGHT_BRACE expected got }`. To be honest I do not understand all the implications of making this change.