### PR TITLE
Rewrite project/dependency loader

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
@@ -130,7 +130,7 @@ private fun buildSearchScope(includeTests: Boolean, p: ElmProject, intellijProje
      *        you must take that into account when retrieving the cached value.
      */
     val (srcDirPaths, dependencies) = when {
-        includeTests -> p.allSourceDirs to p.allResolvedDependencies
+        includeTests -> p.allSourceDirs to p.allDirectDeps
         else -> p.absoluteSourceDirectories.asSequence() to p.dependencies.asSequence()
     }
 

--- a/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
+++ b/src/main/kotlin/org/elm/lang/core/lookup/ElmLookup.kt
@@ -11,8 +11,8 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import org.elm.lang.core.psi.ElmFile
 import org.elm.lang.core.psi.ElmNamedElement
-import org.elm.lang.core.stubs.index.ElmNamedElementIndex
 import org.elm.lang.core.psi.moduleName
+import org.elm.lang.core.stubs.index.ElmNamedElementIndex
 import org.elm.openapiext.findFileByPathTestAware
 import org.elm.workspace.ElmPackageProject
 import org.elm.workspace.ElmProject
@@ -131,7 +131,7 @@ private fun buildSearchScope(includeTests: Boolean, p: ElmProject, intellijProje
      */
     val (srcDirPaths, dependencies) = when {
         includeTests -> p.allSourceDirs to p.allResolvedDependencies
-        else -> p.absoluteSourceDirectories.asSequence() to p.dependencies.direct.asSequence()
+        else -> p.absoluteSourceDirectories.asSequence() to p.dependencies.asSequence()
     }
 
     val srcDirs = srcDirPaths.mapNotNull { findFileByPathTestAware(it) }.toList()

--- a/src/main/kotlin/org/elm/workspace/ElmAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAdditionalLibraryRootsProvider.kt
@@ -13,13 +13,11 @@ import javax.swing.Icon
 
 class ElmAdditionalLibraryRootsProvider : AdditionalLibraryRootsProvider() {
 
-    override fun getAdditionalProjectLibraries(project: Project): Collection<ElmLibrary> {
-        return project.elmWorkspace.allProjects.asSequence()
-                .flatMap { it.allResolvedDependencies }
-                .mapNotNull { ElmLibrary.fromPackage(it) }
-                .toList()
-    }
-
+    override fun getAdditionalProjectLibraries(project: Project): Collection<ElmLibrary> =
+            project.elmWorkspace.allProjects
+                    .flatMap { it.deepDeps() }
+                    .mapNotNull { ElmLibrary.fromPackage(it) }
+                    .toList()
 
     override fun getRootsToWatch(project: Project) =
             getAdditionalProjectLibraries(project).map { it.root }

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -1,46 +1,29 @@
 package org.elm.workspace
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.JsonNodeType
 import com.intellij.openapi.util.UserDataHolderBase
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.indexing.LightDirectoryIndex
-import org.elm.workspace.ElmToolchain.Companion.ELM_INTELLIJ_JSON
-import java.io.InputStream
 import java.nio.file.Path
 import java.nio.file.Paths
 
-
-private val objectMapper = ObjectMapper()
 
 /**
  * The logical representation of an Elm project. An Elm project can be an application
  * or a package, and it specifies its dependencies.
  *
  * @param manifestPath The location of the manifest file (e.g. `elm.json`). Uniquely identifies a project.
- * @param dependencies Additional Elm packages that this project depends on
- * @param testDependencies Additional Elm packages that this project's **tests** depends on
+ * @param dependencies Additional Elm packages that this project depends on directly
+ * @param testDependencies Additional Elm packages that this project's **tests** depends on directly
  * @param sourceDirectories The relative paths to one-or-more directories containing Elm source files belonging to this project.
  * @param testsRelativeDirPath The path to the directory containing unit tests, relative to the [projectDirPath].
  * Typically this will be "tests": see [testsDirPath] for more info.
  */
 sealed class ElmProject(
         val manifestPath: Path,
-        val dependencies: Dependencies,
-        val testDependencies: Dependencies,
+        val dependencies: List<ElmPackageProject>,
+        val testDependencies: List<ElmPackageProject>,
         val sourceDirectories: List<Path>,
         testsRelativeDirPath: String
 ) : UserDataHolderBase() {
-    data class Dependencies(val direct: List<ElmPackageProject>, val indirect: List<ElmPackageProject>) {
-        companion object {
-            val EMPTY = Dependencies(emptyList(), emptyList())
-        }
-        val all get() = direct + indirect
-    }
 
     /**
      * The path to the directory containing the Elm project JSON file.
@@ -99,7 +82,7 @@ sealed class ElmProject(
      * production code or for tests.
      */
     val allResolvedDependencies: Sequence<ElmPackageProject> =
-            sequenceOf(dependencies.direct, testDependencies.direct).flatten()
+            sequenceOf(dependencies, testDependencies).flatten()
 
     /**
      * Returns true if this project is compatible with Elm compiler [version].
@@ -117,93 +100,6 @@ sealed class ElmProject(
      * Return `true` iff this package is the core package for the current version of Elm.
      */
     open fun isCore(): Boolean = false
-
-    companion object {
-
-        fun parse(manifestPath: Path, repo: ElmPackageRepository, ignoreTestDeps: Boolean = false): ElmProject {
-            val manifestStream = LocalFileSystem.getInstance().refreshAndFindFileByPath(manifestPath.toString())?.inputStream
-                    ?: throw ProjectLoadException("Could not find file $manifestPath. Is the package installed?")
-            val sidecarManifestStream = LocalFileSystem.getInstance().refreshAndFindFileByPath(
-                    manifestPath.resolveSibling(ELM_INTELLIJ_JSON).toString())?.inputStream
-            return parse(manifestStream, manifestPath, repo, ignoreTestDeps, sidecarManifestStream)
-        }
-
-        /**
-         * Attempts to parse an `elm.json` file and, if it exists, the sibling `elm.intellij.json` file (see
-         * [ElmToolchain.ELM_INTELLIJ_JSON]).
-         *
-         * @param sidecarManifestStream The stream to the `elm.intellij.json` file, if one exists. This is only used for
-         * Elm 19+ projects. Currently it is only read for projects which are marked in `elm.json` as an _application_
-         * (i.e. not for _packages_) as it is only applications which allow a custom test directory to be set (and that's
-         * the only thing we currently store in `elm.intellij.json`). In future this maybe change if more data is added
-         * into the sidecar manifest.
-         * @throws ProjectLoadException if the JSON cannot be parsed
-         */
-        fun parse(manifestStream: InputStream,
-                  manifestPath: Path,
-                  repo: ElmPackageRepository,
-                  ignoreTestDeps: Boolean = false,
-                  sidecarManifestStream: InputStream? = null
-        ): ElmProject {
-            val node = try {
-                objectMapper.readTree(manifestStream)
-            } catch (e: JsonProcessingException) {
-                throw ProjectLoadException("Bad JSON: ${e.message}")
-            }
-
-            val type = node.get("type")?.textValue()
-            return when (type) {
-                "application" -> {
-                    val manifestDto = try {
-                        objectMapper.treeToValue(node, ElmApplicationProjectDTO::class.java)
-                    } catch (e: JsonProcessingException) {
-                        throw ProjectLoadException("Invalid elm.json: ${e.message}")
-                    }
-
-                    // If specified, read the custom manfiest (elm.intellij.json)
-                    val sidecarManifestDto = sidecarManifestStream?.let {
-                        try {
-                            objectMapper.readValue(it, ElmSidecarManifestDTO::class.java)
-                        } catch (e: JsonProcessingException) {
-                            throw ProjectLoadException("Invalid elm.intellij.json: ${e.message}")
-                        }
-                    }
-
-                    ElmApplicationProject(
-                            manifestPath = manifestPath,
-                            elmVersion = manifestDto.elmVersion,
-                            dependencies = manifestDto.dependencies.depsToPackages(repo),
-                            testDependencies = if (ignoreTestDeps) Dependencies.EMPTY else manifestDto.testDependencies.depsToPackages(repo),
-                            sourceDirectories = manifestDto.sourceDirectories,
-                            testsRelativeDirPath = sidecarManifestDto?.testDirectory ?: DEFAULT_TESTS_DIR_NAME
-                    )
-                }
-                "package" -> {
-                    val dto = try {
-                        objectMapper.treeToValue(node, ElmPackageProjectDTO::class.java)
-                    } catch (e: JsonProcessingException) {
-                        throw ProjectLoadException("Invalid elm.json: ${e.message}")
-                    }
-                    // TODO [kl] resolve dependency constraints to determine package version numbers
-                    // [x] use whichever version number is available in the Elm package cache (~/.elm)
-                    // [ ] include transitive dependencies
-                    // [ ] resolve versions such that all constraints are satisfied
-                    //     (necessary for correctness sake, but low priority)
-                    ElmPackageProject(
-                            manifestPath = manifestPath,
-                            elmVersion = dto.elmVersion,
-                            dependencies = dto.dependencies.constraintDepsToPackages(repo),
-                            testDependencies = if (ignoreTestDeps) emptyList() else dto.testDependencies.constraintDepsToPackages(repo),
-                            sourceDirectories = listOf(Paths.get("src")),
-                            name = dto.name,
-                            version = dto.version,
-                            exposedModules = dto.exposedModulesNode.toExposedModuleMap())
-                }
-                else -> throw ProjectLoadException("The 'type' field is '$type', "
-                        + "but expected either 'application' or 'package'")
-            }
-        }
-    }
 }
 
 
@@ -213,8 +109,8 @@ sealed class ElmProject(
 class ElmApplicationProject(
         manifestPath: Path,
         val elmVersion: Version,
-        dependencies: Dependencies,
-        testDependencies: Dependencies,
+        dependencies: List<ElmPackageProject>,
+        testDependencies: List<ElmPackageProject>,
         sourceDirectories: List<Path>,
         testsRelativeDirPath: String = DEFAULT_TESTS_DIR_NAME
 ) : ElmProject(manifestPath, dependencies, testDependencies, sourceDirectories, testsRelativeDirPath)
@@ -234,46 +130,13 @@ class ElmPackageProject(
         val exposedModules: List<String>
 ) : ElmProject(
         manifestPath = manifestPath,
-        dependencies = Dependencies(dependencies, emptyList()),
-        testDependencies = Dependencies(testDependencies, emptyList()),
+        dependencies = dependencies,
+        testDependencies = testDependencies,
         sourceDirectories = sourceDirectories,
         testsRelativeDirPath = DEFAULT_TESTS_DIR_NAME
 ) {
     override fun isCore(): Boolean =
             name == "elm/core"
-}
-
-
-private fun ExactDependenciesDTO.depsToPackages(repo: ElmPackageRepository) =
-        ElmProject.Dependencies(direct.depsToPackages(repo), indirect.depsToPackages(repo))
-
-
-private fun Map<String, Version>.depsToPackages(repo: ElmPackageRepository) =
-        map { (name, version) ->
-            loadDependency(repo, name, version)
-        }
-
-private fun Map<String, Constraint>.constraintDepsToPackages(repo: ElmPackageRepository) =
-        map { (name, constraint) ->
-            val version = repo.availableVersionsForPackage(name)
-                    .filter { constraint.contains(it) }
-                    .min()
-                    ?: throw ProjectLoadException("Could not load $name ($constraint). Is it installed?")
-
-            loadDependency(repo, name, version)
-        }
-
-private fun loadDependency(repo: ElmPackageRepository, name: String, version: Version): ElmPackageProject {
-    val manifestPath = repo.findPackageManifest(name, version)
-            ?: throw ProjectLoadException("Could not load $name ($version): manifest not found")
-    // TODO [kl] guard against circular dependencies
-    // NOTE: we ignore the test dependencies of our dependencies because it is highly unlikely
-    // that they have been installed by Elm in the local package cache (the user would have
-    // to actually run the package's tests from within the package cache, which no one is going to do).
-    val elmProject = ElmProject.parse(manifestPath, repo, ignoreTestDeps = true) as? ElmPackageProject
-            ?: throw ProjectLoadException("Could not load $name ($version): expected a package!")
-
-    return elmProject
 }
 
 /**
@@ -282,75 +145,11 @@ private fun loadDependency(repo: ElmPackageRepository, name: String, version: Ve
 val noProjectSentinel = ElmApplicationProject(
         manifestPath = Paths.get("/elm.json"),
         elmVersion = Version(0, 0, 0),
-        dependencies = ElmProject.Dependencies.EMPTY,
-        testDependencies = ElmProject.Dependencies.EMPTY,
+        dependencies = emptyList(),
+        testDependencies = emptyList(),
         sourceDirectories = emptyList()
 )
 
-
-// JSON Decoding
-
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-private interface ElmProjectDTO
-
-
-private class ElmApplicationProjectDTO(
-        @JsonProperty("elm-version") val elmVersion: Version,
-        @JsonProperty("source-directories") val sourceDirectories: List<Path>,
-        @JsonProperty("dependencies") val dependencies: ExactDependenciesDTO,
-        @JsonProperty("test-dependencies") val testDependencies: ExactDependenciesDTO
-) : ElmProjectDTO
-
-
-/**
- * DTO used to wrap the data in `elm.intellij.json`.
- *
- * @see [ElmToolchain.ELM_INTELLIJ_JSON]
- */
-private class ElmSidecarManifestDTO(
-        /**
-         * The path to the directory containing the unit tests, relative to the root of the Elm project.
-         */
-        @JsonProperty("test-directory") val testDirectory: String
-)
-
-
-private class ExactDependenciesDTO(
-        @JsonProperty("direct") val direct: Map<String, Version>,
-        @JsonProperty("indirect") val indirect: Map<String, Version>
-)
-
-
-private class ElmPackageProjectDTO(
-        @JsonProperty("elm-version") val elmVersion: Constraint,
-        @JsonProperty("dependencies") val dependencies: Map<String, Constraint>,
-        @JsonProperty("test-dependencies") val testDependencies: Map<String, Constraint>,
-        @JsonProperty("name") val name: String,
-        @JsonProperty("version") val version: Version,
-        @JsonProperty("exposed-modules") val exposedModulesNode: JsonNode
-) : ElmProjectDTO
-
-
-private fun JsonNode.toExposedModuleMap(): List<String> {
-    // Normalize the 2 exposed-modules formats into a single format.
-    // format 1: a list of strings, where each string is the name of an exposed module
-    // format 2: a map where the keys are categories and the values are the names of the modules
-    //           exposed in that category. We discard the categories because they are not useful.
-    return when (this.nodeType) {
-        JsonNodeType.ARRAY -> {
-            this.elements().asSequence().map { it.textValue() }.toList()
-        }
-        JsonNodeType.OBJECT -> {
-            this.fields().asSequence().flatMap { (_, nameNodes) ->
-                nameNodes.asSequence().map { it.textValue() }
-            }.toList()
-        }
-        else -> {
-            throw RuntimeException("exposed-modules JSON must be either an array or an object")
-        }
-    }
-}
 
 /**
  * The default name of the directory which contains unit tests.

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -81,8 +81,22 @@ sealed class ElmProject(
      * Returns all packages which this project depends on directly, whether it be for normal,
      * production code or for tests.
      */
-    val allResolvedDependencies: Sequence<ElmPackageProject> =
+    val allDirectDeps: Sequence<ElmPackageProject> =
             sequenceOf(dependencies, testDependencies).flatten()
+
+    /**
+     * Returns the direct and indirect dependencies of the receiver, recursively.
+     */
+    fun deepDeps(): List<ElmPackageProject> {
+        val stack = allDirectDeps.toMutableList()
+        val acc = mutableListOf<ElmPackageProject>()
+        while (stack.isNotEmpty()) {
+            val p = stack.removeAt(0)
+            acc.add(p)
+            stack.addAll(p.allDirectDeps)
+        }
+        return acc.distinctBy { it.manifestPath }
+    }
 
     /**
      * Returns true if this project is compatible with Elm compiler [version].

--- a/src/main/kotlin/org/elm/workspace/ElmProjectWatcher.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProjectWatcher.kt
@@ -3,8 +3,8 @@ package org.elm.workspace
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent
-import org.elm.workspace.ElmToolchain.Companion.ELM_INTELLIJ_JSON
 import org.elm.workspace.ElmToolchain.Companion.ELM_JSON
+import org.elm.workspace.ElmToolchain.Companion.SIDECAR_FILENAME
 
 
 /**
@@ -22,7 +22,7 @@ class ElmProjectWatcher(val onChange: () -> Unit) : BulkFileListener {
 
 private fun isInterestingEvent(event: VFileEvent) =
         event.pathEndsWith(ELM_JSON)
-                || event.pathEndsWith(ELM_INTELLIJ_JSON)
+                || event.pathEndsWith(SIDECAR_FILENAME)
 
 
 private fun VFileEvent.pathEndsWith(suffix: String) =

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -53,12 +53,13 @@ data class ElmToolchain(
         /**
          * The name of the file that contains information specific to an Elm project, but which is _not_ in `elm.json`.
          * Here we put extra information which isn't in the normal `elm.json`, but which this plugin requires, such as
-         * the path to the directory containing tests.
+         * a custom path to the directory containing tests.
          *
          * The `elm.json` file is referred to elsewhere as the _manifest_. This `elm.intellij.json` file is referred to
          * as the _sidecar manifest_.
          */
-        const val ELM_INTELLIJ_JSON = "elm.intellij.json"
+        const val SIDECAR_FILENAME = "elm.intellij.json"
+
         const val DEFAULT_FORMAT_ON_SAVE = false
 
         /**

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -1,13 +1,9 @@
 package org.elm.workspace
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
-import com.intellij.openapi.util.io.FileUtil
-import com.intellij.util.io.exists
 import org.elm.workspace.commandLineTools.ElmCLI
 import org.elm.workspace.commandLineTools.ElmFormatCLI
 import org.elm.workspace.commandLineTools.ElmTestCLI
-import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -53,6 +49,7 @@ data class ElmToolchain(
 
     companion object {
         const val ELM_JSON = "elm.json"
+
         /**
          * The name of the file that contains information specific to an Elm project, but which is _not_ in `elm.json`.
          * Here we put extra information which isn't in the normal `elm.json`, but which this plugin requires, such as
@@ -83,68 +80,4 @@ data class ElmToolchain(
         fun suggest(project: Project): ElmToolchain =
                 BLANK.autoDiscoverAll(project)
     }
-}
-
-
-data class ElmPackageRepository(val elmCompilerVersion: Version) {
-
-    val elmHomePath: String
-        get() {
-            /*
-            The Elm compiler first checks the ELM_HOME environment variable. If not found,
-            it will fallback to the path returned by Haskell's `System.Directory.getAppUserDataDirectory`
-            function. That function behaves as follows:
-
-            - On Unix-like systems, the path is ~/.<app>.
-            - On Windows, the path is %APPDATA%/<app> (e.g. C:/Users/<user>/AppData/Roaming/<app>)
-
-            IntelliJ's FileUtil.expandUserHome() uses the JVM's `user.home` system property to
-            determine the home directory.
-
-            - On Unix-like systems, the path is /Users/<user>
-            - on Windows, the path is C:/Users/<user>
-
-            Note that the Haskell and Java functions do slightly different things.
-            */
-            val elmHomeVar = System.getenv("ELM_HOME")
-            if (elmHomeVar != null && Paths.get(elmHomeVar).exists())
-                return elmHomeVar
-
-            return when {
-                SystemInfo.isUnix -> FileUtil.expandUserHome("~/.elm")
-                SystemInfo.isMac -> FileUtil.expandUserHome("~/.elm")
-                SystemInfo.isWindows -> FileUtil.expandUserHome("~/AppData/Roaming/elm")
-                else -> error("Unsupported platform")
-            }
-        }
-
-    /**
-     * Path to Elm's global package cache directory
-     */
-    private val globalPackageCacheDir: Path
-        get() {
-            // In 0.19.0, the directory name was singular, but beginning in 0.19.1 it is now plural
-            val subDirName = when (elmCompilerVersion) {
-                Version(0, 19, 0) -> "package"
-                else -> "packages"
-            }
-            return Paths.get("$elmHomePath/$elmCompilerVersion/$subDirName/")
-        }
-
-    /**
-     * Path to the manifest file for the Elm package [name] at version [version]
-     */
-    fun findPackageManifest(name: String, version: Version): Path? {
-        return globalPackageCacheDir.resolve("$name/$version/${ElmToolchain.ELM_JSON}")
-    }
-
-    /**
-     * Path to directory for a package, containing one or more versions
-     */
-    fun availableVersionsForPackage(name: String): List<Version> {
-        val files = File("$globalPackageCacheDir/$name/").listFiles()
-                ?: return emptyList()
-        return files.mapNotNull { Version.parseOrNull(it.name) }
-    }
-
 }

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -308,7 +308,7 @@ class ElmWorkspaceService(
                         log.debug("Registering source directory $sourceDir for $project")
                         put(sourceDir, project)
                     }
-                    for (pkg in project.allResolvedDependencies) {
+                    for (pkg in project.deepDeps()) {
                         log.debug("Registering dependency directory ${pkg.projectDirPath} for $pkg")
                         put(pkg.projectDirPath, pkg)
                     }

--- a/src/main/kotlin/org/elm/workspace/VersionUtil.kt
+++ b/src/main/kotlin/org/elm/workspace/VersionUtil.kt
@@ -150,7 +150,7 @@ data class Constraint(
     /**
      * Returns true if the constraint is satisfied solely by comparing x.y.z (so "1.0-beta" == "1.0")
      */
-    fun contains(version: Version): Boolean =
+    operator fun contains(version: Version): Boolean =
             copy(low = low.xyz, high = high.xyz).semVerContains(version.xyz)
 
     /**

--- a/src/main/kotlin/org/elm/workspace/VersionUtil.kt
+++ b/src/main/kotlin/org/elm/workspace/VersionUtil.kt
@@ -153,6 +153,31 @@ data class Constraint(
     fun contains(version: Version): Boolean =
             copy(low = low.xyz, high = high.xyz).semVerContains(version.xyz)
 
+    /**
+     * Returns the intersection with [other] or null if the intersection is empty.
+     */
+    infix fun intersect(other: Constraint): Constraint? {
+        fun merge(op1: Op, op2: Op) =
+                if (Op.LESS_THAN in listOf(op1, op2)) Op.LESS_THAN else Op.LESS_THAN_OR_EQUAL
+
+        val (newLo, newLop) = when (low.compareTo(other.low)) {
+            -1 -> other.low to other.lowOp
+            0 -> low to merge(lowOp, other.lowOp)
+            1 -> low to lowOp
+            else -> error("unexpected compare result")
+        }
+
+        val (newHi, newHop) = when (high.compareTo(other.high)) {
+            -1 -> high to highOp
+            0 -> high to merge(highOp, other.highOp)
+            1 -> other.high to other.highOp
+            else -> error("unexpected compare result")
+        }
+
+        if (newLo >= newHi) return null
+        return Constraint(newLo, newHi, newLop, newHop)
+    }
+
     override fun toString() =
             "$low $lowOp v $highOp $high"
 

--- a/src/main/kotlin/org/elm/workspace/projectLoader.kt
+++ b/src/main/kotlin/org/elm/workspace/projectLoader.kt
@@ -1,0 +1,229 @@
+package org.elm.workspace
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeType
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.util.io.exists
+import org.elm.openapiext.findFileByPathTestAware
+import org.elm.workspace.solver.Pkg
+import org.elm.workspace.solver.PkgName
+import org.elm.workspace.solver.Repository
+import org.elm.workspace.solver.solve
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+private val objectMapper = ObjectMapper()
+
+class ElmPackageRepository(val elmCompilerVersion: Version) : Repository {
+
+    private val inMemCache: MutableMap<String, List<Pkg>> = mutableMapOf()
+
+    val elmHomePath: String
+        get() {
+            /*
+            The Elm compiler first checks the ELM_HOME environment variable. If not found,
+            it will fallback to the path returned by Haskell's `System.Directory.getAppUserDataDirectory`
+            function. That function behaves as follows:
+
+            - On Unix-like systems, the path is ~/.<app>.
+            - On Windows, the path is %APPDATA%/<app> (e.g. C:/Users/<user>/AppData/Roaming/<app>)
+
+            IntelliJ's FileUtil.expandUserHome() uses the JVM's `user.home` system property to
+            determine the home directory.
+
+            - On Unix-like systems, the path is /Users/<user>
+            - on Windows, the path is C:/Users/<user>
+
+            Note that the Haskell and Java functions do slightly different things.
+            */
+            val elmHomeVar = System.getenv("ELM_HOME")
+            if (elmHomeVar != null && Paths.get(elmHomeVar).exists())
+                return elmHomeVar
+
+            return when {
+                SystemInfo.isUnix -> FileUtil.expandUserHome("~/.elm")
+                SystemInfo.isMac -> FileUtil.expandUserHome("~/.elm")
+                SystemInfo.isWindows -> FileUtil.expandUserHome("~/AppData/Roaming/elm")
+                else -> error("Unsupported platform")
+            }
+        }
+
+    /**
+     * Path to Elm's global package cache directory
+     */
+    private val globalPackageCacheDir: Path
+        get() {
+            // In 0.19.0, the directory name was singular, but beginning in 0.19.1 it is now plural
+            val subDirName = when (elmCompilerVersion) {
+                Version(0, 19, 0) -> "package"
+                else -> "packages"
+            }
+            return Paths.get("$elmHomePath/$elmCompilerVersion/$subDirName/")
+        }
+
+    /**
+     * Path to the manifest file for the Elm package [name] at version [version]
+     */
+    fun findPackageManifest(name: String, version: Version): Path {
+        return globalPackageCacheDir.resolve("$name/$version/${ElmToolchain.ELM_JSON}")
+    }
+
+    override fun get(name: PkgName): List<Pkg> =
+            inMemCache.getOrPut(name) {
+                (File("$globalPackageCacheDir/$name/").listFiles() ?: emptyArray())
+                        .mapNotNull { dir ->
+                            val version = Version.parseOrNull(dir.name) ?: return@mapNotNull null
+                            val proj = parseDTO(dir.toPath().resolve("elm.json")) as ElmPackageProjectDTO
+                            object : Pkg {
+                                override val name: PkgName = name
+                                override val version: Version = version
+                                override val elmVersion: Constraint = proj.elmVersion
+                                override val dependencies: Map<PkgName, Constraint> = proj.dependencies
+                            }
+                        }
+            }
+}
+
+
+class ElmProjectLoader(
+        private val repo: ElmPackageRepository,
+        private val versionsByPackage: Map<String, Version>
+) {
+    private fun load(packageName: String): ElmPackageProject {
+        val version = versionsByPackage[packageName]
+                ?: throw ProjectLoadException("Could not find suitable version of $packageName")
+        val manifestPath = repo.findPackageManifest(packageName, version)
+        return when (val dto = parseDTO(manifestPath)) {
+            is ElmPackageProjectDTO ->
+                ElmPackageProject(
+                        manifestPath = manifestPath,
+                        elmVersion = dto.elmVersion,
+                        dependencies = dto.dependencies.keys.map { load(it) },
+                        testDependencies = dto.testDependencies.keys.map { load(it) },
+                        sourceDirectories = listOf(Paths.get("src")),
+                        name = dto.name,
+                        version = dto.version,
+                        exposedModules = dto.exposedModulesNode.toExposedModuleMap())
+            else -> error("should never happen")
+        }
+    }
+
+    companion object {
+        fun topLevelLoad(manifestPath: Path, repo: ElmPackageRepository): ElmProject {
+            return when (val dto = parseDTO(manifestPath)) {
+                is ElmApplicationProjectDTO -> {
+                    val deps = dto.dependencies.direct + dto.dependencies.indirect +
+                            dto.testDependencies.direct + dto.testDependencies.indirect
+                    val loader = ElmProjectLoader(repo, deps)
+                    ElmApplicationProject(
+                            manifestPath = manifestPath,
+                            elmVersion = dto.elmVersion,
+                            dependencies = dto.dependencies.direct.keys.map { loader.load(it) },
+                            testDependencies = dto.testDependencies.direct.keys.map { loader.load(it) },
+                            sourceDirectories = dto.sourceDirectories,
+                            testsRelativeDirPath = DEFAULT_TESTS_DIR_NAME
+                    )
+                }
+                is ElmPackageProjectDTO -> {
+                    val deps = solve(dto.dependencies + dto.testDependencies, repo)
+                            ?: throw ProjectLoadException("unsolvable constraints")
+                    val loader = ElmProjectLoader(repo, deps)
+                    ElmPackageProject(
+                            manifestPath = manifestPath,
+                            elmVersion = dto.elmVersion,
+                            dependencies = dto.dependencies.keys.map { loader.load(it) },
+                            testDependencies = dto.testDependencies.keys.map { loader.load(it) },
+                            sourceDirectories = listOf(Paths.get("src")),
+                            name = dto.name,
+                            version = dto.version,
+                            exposedModules = dto.exposedModulesNode.toExposedModuleMap())
+                }
+            }
+        }
+    }
+}
+
+
+private fun parseDTO(manifestPath: Path): ElmProjectDTO {
+    val manifestStream = findFileByPathTestAware(manifestPath)?.inputStream
+            ?: throw ProjectLoadException("Manifest file not found: $manifestPath")
+    return try {
+        val node = objectMapper.readTree(manifestStream)
+        when (val type = node.get("type")?.textValue()) {
+            "application" -> objectMapper.treeToValue(node, ElmApplicationProjectDTO::class.java)
+            "package" -> objectMapper.treeToValue(node, ElmPackageProjectDTO::class.java)
+            else -> throw ProjectLoadException("Invalid elm.json: unexpected type '$type'")
+        }
+    } catch (e: JsonProcessingException) {
+        throw ProjectLoadException("Invalid elm.json: ${e.message}")
+    }
+}
+
+// DTOs for JSON Decoding
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+private sealed class ElmProjectDTO
+
+
+private class ElmApplicationProjectDTO(
+        @JsonProperty("elm-version") val elmVersion: Version,
+        @JsonProperty("source-directories") val sourceDirectories: List<Path>,
+        @JsonProperty("dependencies") val dependencies: ExactDependenciesDTO,
+        @JsonProperty("test-dependencies") val testDependencies: ExactDependenciesDTO
+) : ElmProjectDTO()
+
+
+/**
+ * DTO used to wrap the data in `elm.intellij.json`.
+ *
+ * @see [ElmToolchain.ELM_INTELLIJ_JSON]
+ */
+private class ElmSidecarManifestDTO(
+        /**
+         * The path to the directory containing the unit tests, relative to the root of the Elm project.
+         */
+        @JsonProperty("test-directory") val testDirectory: String
+)
+
+
+private class ExactDependenciesDTO(
+        @JsonProperty("direct") val direct: Map<String, Version>,
+        @JsonProperty("indirect") val indirect: Map<String, Version>
+)
+
+
+private class ElmPackageProjectDTO(
+        @JsonProperty("elm-version") val elmVersion: Constraint,
+        @JsonProperty("dependencies") val dependencies: Map<String, Constraint>,
+        @JsonProperty("test-dependencies") val testDependencies: Map<String, Constraint>,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("version") val version: Version,
+        @JsonProperty("exposed-modules") val exposedModulesNode: JsonNode
+) : ElmProjectDTO()
+
+
+private fun JsonNode.toExposedModuleMap(): List<String> {
+    // Normalize the 2 exposed-modules formats into a single format.
+    // format 1: a list of strings, where each string is the name of an exposed module
+    // format 2: a map where the keys are categories and the values are the names of the modules
+    //           exposed in that category. We discard the categories because they are not useful.
+    return when (this.nodeType) {
+        JsonNodeType.ARRAY -> {
+            this.elements().asSequence().map { it.textValue() }.toList()
+        }
+        JsonNodeType.OBJECT -> {
+            this.fields().asSequence().flatMap { (_, nameNodes) ->
+                nameNodes.asSequence().map { it.textValue() }
+            }.toList()
+        }
+        else -> {
+            throw RuntimeException("exposed-modules JSON must be either an array or an object")
+        }
+    }
+}

--- a/src/main/kotlin/org/elm/workspace/projectLoader.kt
+++ b/src/main/kotlin/org/elm/workspace/projectLoader.kt
@@ -35,7 +35,7 @@ class ElmProjectLoader(
                         manifestPath = manifestPath,
                         elmVersion = dto.elmVersion,
                         dependencies = dto.deps.keys.map { load(it) },
-                        testDependencies = dto.testDeps.keys.map { load(it) },
+                        testDependencies = emptyList(), // we only use this for top-level packages
                         sourceDirectories = listOf(Paths.get("src")),
                         name = dto.name,
                         version = dto.version,

--- a/src/main/kotlin/org/elm/workspace/projectLoader.kt
+++ b/src/main/kotlin/org/elm/workspace/projectLoader.kt
@@ -84,7 +84,7 @@ class ElmProjectLoader(
 /**
  * Provides access to the Elm packages stored on-disk by the Elm compiler in `~/.elm`
  */
-class ElmPackageRepository(val elmCompilerVersion: Version) : Repository {
+class ElmPackageRepository(override val elmCompilerVersion: Version) : Repository {
 
     private val inMemCache: MutableMap<String, List<Pkg>> = mutableMapOf()
 
@@ -136,7 +136,7 @@ class ElmPackageRepository(val elmCompilerVersion: Version) : Repository {
                             object : Pkg {
                                 override val name: PkgName = name
                                 override val version: Version = version
-                                override val elmVersion: Constraint = proj.elmVersion
+                                override val elmConstraint: Constraint = proj.elmVersion
                                 override val dependencies: Map<PkgName, Constraint> = proj.deps
                             }
                         }

--- a/src/main/kotlin/org/elm/workspace/solver/Solver.kt
+++ b/src/main/kotlin/org/elm/workspace/solver/Solver.kt
@@ -22,6 +22,10 @@ interface Repository {
     operator fun get(name: PkgName): List<Pkg>
 }
 
+/**
+ * Attempt to find a solution for the constraints given by [deps] using the Elm packages
+ * that we know about in [repo].
+ */
 fun solve(deps: Map<PkgName, Constraint>, repo: Repository): Map<PkgName, Version>? {
     val solutions = mapOf<PkgName, Version>()
     return when (val res = Solver(repo).solve(deps, solutions)) {

--- a/src/main/kotlin/org/elm/workspace/solver/Solver.kt
+++ b/src/main/kotlin/org/elm/workspace/solver/Solver.kt
@@ -1,0 +1,72 @@
+package org.elm.workspace.solver
+
+import org.elm.workspace.Constraint
+import org.elm.workspace.Version
+import org.elm.workspace.solver.SolverResult.DeadEnd
+import org.elm.workspace.solver.SolverResult.Proceed
+
+typealias PkgName = String
+
+data class Pkg(
+        val name: PkgName,
+        val version: Version,
+        val elmVersion: Constraint = elm19, // TODO: get rid of the default outside of test cases
+        val dependencies: Map<PkgName, Constraint>
+)
+
+fun Version.satisfies(constraint: Constraint): Boolean = constraint.contains(this)
+
+private val elm19 = Constraint.parse("0.19.0 <= v < 0.20.0")
+
+data class Repository(private val packagesByName: Map<PkgName, List<Pkg>>) {
+    constructor(vararg packages: Pkg) : this(packages.groupBy { it.name })
+
+    operator fun get(name: String): List<Pkg> {
+        return packagesByName[name] ?: emptyList()
+    }
+}
+
+sealed class SolverResult {
+    object DeadEnd : SolverResult()
+    data class Proceed(
+            val pending: Map<PkgName, Constraint>,
+            val solutions: Map<PkgName, Version>
+    ) : SolverResult()
+}
+
+fun solve(deps: Map<PkgName, Constraint>, repo: Repository): Map<PkgName, Version>? {
+    val solutions = mapOf<PkgName, Version>()
+    return when (val res = Solver(repo).solve(deps, solutions)) {
+        DeadEnd -> null
+        is Proceed -> res.solutions
+    }
+}
+
+class Solver(private val repo: Repository) {
+    fun solve(deps: Map<PkgName, Constraint>, solutions: Map<PkgName, Version>): SolverResult {
+        // Pick a dep/constraint (Elm compiler picks by names in lexicographically ascending order)
+        val dep = deps.minBy { it.key }
+        if (dep == null) {
+            // no more dependencies left to explore
+            return Proceed(deps, solutions)
+        }
+
+        val (pkgName, constraint) = dep
+
+        // Figure out which versions of the dep actually exist
+        val candidates = repo[pkgName].filter { it.version.satisfies(constraint) }
+        println("$pkgName has candidates ${candidates.map { it.version }}")
+
+        if (candidates.isEmpty()) {
+            return DeadEnd
+        }
+
+        for (candidate in candidates) {
+        }
+
+        return DeadEnd
+    }
+}
+
+
+

--- a/src/main/kotlin/org/elm/workspace/solver/Solver.kt
+++ b/src/main/kotlin/org/elm/workspace/solver/Solver.kt
@@ -7,23 +7,19 @@ import org.elm.workspace.solver.SolverResult.Proceed
 
 typealias PkgName = String
 
-data class Pkg(
-        val name: PkgName,
-        val version: Version,
-        val elmVersion: Constraint = elm19, // TODO: get rid of the default outside of test cases
-        val dependencies: Map<PkgName, Constraint>
-)
+// TODO [kl] consider getting rid of the interface and just unifying it with the rest of the ElmProject system
+
+interface Pkg {
+    val name: PkgName
+    val version: Version
+    val elmVersion: Constraint
+    val dependencies: Map<PkgName, Constraint>
+}
 
 fun Version.satisfies(constraint: Constraint): Boolean = constraint.contains(this)
 
-private val elm19 = Constraint.parse("0.19.0 <= v < 0.20.0")
-
-data class Repository(private val packagesByName: Map<PkgName, List<Pkg>>) {
-    constructor(vararg packages: Pkg) : this(packages.groupBy { it.name })
-
-    operator fun get(name: String): List<Pkg> {
-        return packagesByName[name] ?: emptyList()
-    }
+interface Repository {
+    operator fun get(name: PkgName): List<Pkg>
 }
 
 fun solve(deps: Map<PkgName, Constraint>, repo: Repository): Map<PkgName, Version>? {

--- a/src/main/kotlin/org/elm/workspace/solver/Solver.kt
+++ b/src/main/kotlin/org/elm/workspace/solver/Solver.kt
@@ -7,18 +7,17 @@ import org.elm.workspace.solver.SolverResult.Proceed
 
 typealias PkgName = String
 
-// TODO [kl] consider getting rid of the interface and just unifying it with the rest of the ElmProject system
-
 interface Pkg {
     val name: PkgName
     val version: Version
-    val elmVersion: Constraint
+    val elmConstraint: Constraint
     val dependencies: Map<PkgName, Constraint>
 }
 
 fun Version.satisfies(constraint: Constraint): Boolean = constraint.contains(this)
 
 interface Repository {
+    val elmCompilerVersion: Version
     operator fun get(name: PkgName): List<Pkg>
 }
 
@@ -60,6 +59,7 @@ private class Solver(private val repo: Repository) {
 
         // Speculatively try each candidate version to see if it is a partial solution
         loop@ for (candidate in candidates) {
+            if (repo.elmCompilerVersion !in candidate.elmConstraint) continue@loop
             val tentativeDeps = restDeps.combine(candidate.dependencies) ?: continue@loop
             val tentativeSolutions = solutions + (dep.name to candidate.version)
 

--- a/src/main/kotlin/org/elm/workspace/solver/Solver.kt
+++ b/src/main/kotlin/org/elm/workspace/solver/Solver.kt
@@ -26,14 +26,6 @@ data class Repository(private val packagesByName: Map<PkgName, List<Pkg>>) {
     }
 }
 
-sealed class SolverResult {
-    object DeadEnd : SolverResult()
-    data class Proceed(
-            val pending: Map<PkgName, Constraint>,
-            val solutions: Map<PkgName, Version>
-    ) : SolverResult()
-}
-
 fun solve(deps: Map<PkgName, Constraint>, repo: Repository): Map<PkgName, Version>? {
     val solutions = mapOf<PkgName, Version>()
     return when (val res = Solver(repo).solve(deps, solutions)) {
@@ -42,26 +34,56 @@ fun solve(deps: Map<PkgName, Constraint>, repo: Repository): Map<PkgName, Versio
     }
 }
 
-class Solver(private val repo: Repository) {
+private sealed class SolverResult {
+    object DeadEnd : SolverResult()
+    data class Proceed(
+            val pending: Map<PkgName, Constraint>,
+            val solutions: Map<PkgName, Version>
+    ) : SolverResult()
+}
+
+private class Solver(private val repo: Repository) {
     fun solve(deps: Map<PkgName, Constraint>, solutions: Map<PkgName, Version>): SolverResult {
-        // Pick a dep/constraint (Elm compiler picks by names in lexicographically ascending order)
-        val dep = deps.minBy { it.key }
+        // Pick a dep to solve
+        val (dep, restDeps) = deps.pick()
         if (dep == null) {
-            // no more dependencies left to explore
+            // Base case: no more dependencies left to explore
             return Proceed(deps, solutions)
         }
 
-        val (pkgName, constraint) = dep
-
         // Figure out which versions of the dep actually exist
-        val candidates = repo[pkgName].filter { it.version.satisfies(constraint) }
-        println("$pkgName has candidates ${candidates.map { it.version }}")
+        var candidates = repo[dep.name]
+                .filter { it.version.satisfies(dep.constraint) }
+                .sortedByDescending { it.version }
+        println("${dep.name} has candidates ${candidates.map { it.version }}")
+
+        // Further restrict the candidates if a pending solution has already bound the version of this dep.
+        val solvedVersion = solutions[dep.name]
+        if (solvedVersion != null) {
+            if (candidates.any { it.version == solvedVersion }) {
+                // TODO [kl] shouldn't this never happen? or if it does, we should be able to immediately move on.
+                println("Already solved ${dep.name} as $solvedVersion")
+            }
+            candidates = candidates.filter { it.version == solvedVersion }
+        }
 
         if (candidates.isEmpty()) {
             return DeadEnd
         }
 
-        for (candidate in candidates) {
+        // Speculatively try each candidate version to see if it is a partial solution
+        loop@ for (candidate in candidates) {
+            // TODO [kl] check that constraints for the same key are compatible when combining
+            val tentativeDeps = restDeps + candidate.dependencies
+
+            // TODO [kl] check that solutions for the same key are equal when combining
+            val tentativeSolutions = solutions + (dep.name to candidate.version)
+
+            // TODO [kl] are we going to overflow the stack when recursing?
+            when (val res = solve(tentativeDeps, tentativeSolutions)) {
+                DeadEnd -> continue@loop
+                is Proceed -> return solve(res.pending, res.solutions)
+            }
         }
 
         return DeadEnd
@@ -69,4 +91,10 @@ class Solver(private val repo: Repository) {
 }
 
 
+private data class Dep(val name: PkgName, val constraint: Constraint)
 
+private fun Map<PkgName, Constraint>.pick(): Pair<Dep?, Map<PkgName, Constraint>> {
+    // Pick a dep/constraint (Elm compiler picks by pkg name in lexicographically ascending order)
+    val dep = minBy { it.key } ?: return (null to this)
+    return Dep(dep.key, dep.value) to minus(dep.key)
+}

--- a/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
@@ -73,6 +73,8 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
                 "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0",
                         "elm/parser": "1.0.0"
                     },
                     "indirect": {}

--- a/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ConstraintTest.kt
@@ -2,6 +2,7 @@ package org.elm.workspace
 
 import org.junit.Assert.*
 import org.junit.Test
+import kotlin.test.assertNull
 
 class ConstraintTest {
 
@@ -72,7 +73,29 @@ class ConstraintTest {
     fun `toString emits a readable string`() {
         assertEquals("1.0.0 <= v < 2.0.0", Constraint.parse("1.0.0 <= v < 2.0.0").toString())
     }
+
+    @Test
+    fun `empty intersection`() {
+        assertNull(c("1.0.0 <= v < 1.0.1") intersect c("1.0.1 <= v < 2.0.0"))
+        assertNull(c("1.0.0 <= v < 1.1.0") intersect c("1.1.0 <= v < 2.0.0"))
+        assertNull(c("1.0.0 <= v < 2.0.0") intersect c("2.0.0 <= v < 3.0.0"))
+    }
+
+    @Test
+    fun `non-empty intersections`() {
+        assertEquals(c("1.0.0 <= v < 2.0.0"), c("1.0.0 <= v < 2.0.0") intersect c("1.0.0 <= v < 3.0.0"))
+        assertEquals(c("2.0.0 <= v < 3.0.0"), c("1.0.0 <= v < 3.0.0") intersect c("2.0.0 <= v < 3.0.0"))
+        assertEquals(c("2.0.0 <= v < 3.0.0"), c("1.0.0 <= v < 3.0.0") intersect c("2.0.0 <= v < 4.0.0"))
+
+        assertEquals(c("1.0.0 <= v < 1.1.0"), c("1.0.0 <= v < 2.0.0") intersect c("1.0.0 <= v < 1.1.0"))
+        assertEquals(c("1.2.0 <= v < 1.3.0"), c("1.0.0 <= v < 1.3.0") intersect c("1.2.0 <= v < 1.4.0"))
+
+        assertEquals(c("1.2.3 <= v < 1.3.0"), c("1.2.3 <= v < 2.0.0") intersect c("1.1.1 <= v < 1.3.0"))
+    }
 }
+
+private fun c(str: String) =
+        Constraint.parse(str)
 
 private fun v(x: Int, y: Int, z: Int) =
         Version(x, y, z)

--- a/src/test/kotlin/org/elm/workspace/ElmProjectWatcherTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmProjectWatcherTest.kt
@@ -34,7 +34,7 @@ class ElmProjectWatcherTest : ElmTestBase() {
 
 
     fun `test detects a change involving elm intellij json project manifest file`() =
-            testVFileWatching(ElmToolchain.ELM_INTELLIJ_JSON)
+            testVFileWatching(ElmToolchain.SIDECAR_FILENAME)
 
 
     fun `test ignores files other than elm json`() =

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -175,7 +175,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
-                        "elm/time": "1.0.0"
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0"
                     },
                     "indirect": {}
                 },
@@ -187,11 +188,11 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             """)
             dir("src") {
                 elm("Main.elm", """
-                    import Time
+                    import Json.Decode
                            --^
                 """.trimIndent())
             }
-        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", toPackage = "elm/time 1.0.0")
+        }.checkReferenceIsResolved<ElmImportClause>("src/Main.elm", toPackage = "elm/json 1.0.0")
     }
 
 
@@ -209,6 +210,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 "elm-version": "0.19.1",
                 "dependencies": {
                     "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0",
                         "elm/parser": "1.0.0"
                     },
                     "indirect": {}
@@ -246,6 +249,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                         "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
+                                "elm/core": "1.0.0",
+                                "elm/json": "1.0.0",
                                 "elm/parser": "1.0.0"
                             },
                             "indirect": {}
@@ -273,6 +278,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                         "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
+                                "elm/core": "1.0.0",
+                                "elm/json": "1.0.0",
                                 "elm/parser": "1.1.0"
                             },
                             "indirect": {}
@@ -344,7 +351,12 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0",
+                        "elm/random": "1.0.0",
+                        "elm/time": "1.0.0"
+                    },
                     "indirect": {}
                 },
                 "test-dependencies": {
@@ -380,7 +392,12 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0",
+                        "elm/random": "1.0.0",
+                        "elm/time": "1.0.0"
+                    },
                     "indirect": {}
                 },
                 "test-dependencies": {
@@ -425,7 +442,12 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0",
+                        "elm/random": "1.0.0",
+                        "elm/time": "1.0.0"
+                    },
                     "indirect": {}
                 },
                 "test-dependencies": {

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -47,17 +47,23 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                 project("elm.json", """
                     {
                         "type": "application",
-                        "source-directories": [ "src", "vendor" ],
+                        "source-directories": [
+                            "src", "vendor"
+                        ],
                         "elm-version": "0.19.1",
                         "dependencies": {
                             "direct": {
-                                "elm/core": "1.0.0",
+                                "elm/browser": "1.0.2",
+                                "elm/core": "1.0.5",
                                 "elm/html": "1.0.0"
                             },
                             "indirect": {
+                                "elm/json": "1.1.3",
+                                "elm/time": "1.0.0",
+                                "elm/url": "1.0.0",
                                 "elm/virtual-dom": "1.0.2"
                             }
-                         },
+                        },
                         "test-dependencies": {
                             "direct": {
                                 "elm-explorations/test": "1.0.0"
@@ -97,23 +103,17 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         checkEquals(setOf(Paths.get("src"), Paths.get("vendor")), elmProject.sourceDirectories.toSet())
 
         checkDependencies(elmProject.dependencies,
-                direct = mapOf(
-                        "elm/core" to Version(1, 0, 0),
+                mapOf(
+                        "elm/browser" to Version(1, 0, 2),
+                        "elm/core" to Version(1, 0, 5),
                         "elm/html" to Version(1, 0, 0)
-                ),
-                indirect = mapOf(
-                        "elm/virtual-dom" to Version(1, 0, 2)
                 )
         )
 
         checkDependencies(elmProject.testDependencies,
-                direct = mapOf(
+                mapOf(
                         "elm-explorations/test" to Version(1, 0, 0)
-                ),
-                indirect = mapOf(
-                        "elm/random" to Version(1, 0, 0)
                 )
-
         )
     }
 
@@ -133,10 +133,10 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                         ],
                         "elm-version": "0.19.0 <= v < 0.20.0",
                         "dependencies": {
-                            "elm/core": "1.0.0 <= v < 2.0.0"
+                            "elm/core": "1.0.0 <= v < 1.0.1"
                         },
                         "test-dependencies": {
-                            "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+                            "elm-explorations/test": "1.0.0 <= v < 1.0.1"
                         }
                     }
                     """)
@@ -166,13 +166,8 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         // The source directory for Elm 0.19 packages is implicitly "src". It cannot be changed.
         checkEquals(setOf(Paths.get("src")), elmProject.sourceDirectories.toSet())
 
-        checkDependencies(elmProject.dependencies,
-                direct = mapOf("elm/core" to Version(1, 0, 0))
-        )
-
-        checkDependencies(elmProject.testDependencies,
-                direct = mapOf("elm-explorations/test" to Version(1, 0, 0))
-        )
+        checkDependencies(elmProject.dependencies, mapOf("elm/core" to Version(1, 0, 0)))
+        checkDependencies(elmProject.testDependencies, mapOf("elm-explorations/test" to Version(1, 0, 0)))
 
         checkEquals(setOf("Json.Decode", "Json.Encode"),
                 elmProject.exposedModules.toSet())
@@ -355,9 +350,8 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
     // END OF TESTS RELATED TO SIDECAR MANIFEST (elm.intellij.json)
 
-    private fun checkDependencies(actual: ElmProject.Dependencies, direct: Map<String, Version>, indirect: Map<String, Version> = emptyMap()) {
-        checkEquals(actual.direct.associate { it.name to it.version }, direct)
-        checkEquals(actual.indirect.associate { it.name to it.version }, indirect)
+    private fun checkDependencies(actual: List<ElmPackageProject>, expected: Map<String, Version>) {
+        checkEquals(actual.associate { it.name to it.version }, expected)
     }
 }
 

--- a/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
+++ b/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
@@ -1,0 +1,88 @@
+package org.elm.workspace.solver
+
+import org.elm.workspace.Constraint
+import org.elm.workspace.Version
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+typealias PkgName = String
+
+data class Pkg(
+        val name: PkgName,
+        val version: Version,
+        val elmVersion: Constraint = elm19, // TODO: get rid of the default outside of test cases
+        val dependencies: Map<PkgName, Constraint>
+)
+
+data class Repository(val packagesByName: Map<PkgName, List<Pkg>>) {
+    constructor(vararg packages: Pkg) : this(packages.groupBy { it.name })
+}
+
+fun solve(dependencies: Map<PkgName, Constraint>, repository: Repository): Map<PkgName, Version> {
+    return dependencies.mapValues { (name, constraint) ->
+        (repository.packagesByName[name] ?: error("package $name not found in repository"))
+                .map { it.version }
+                .filter { constraint.contains(it) }
+                .max()
+                ?: error("package $name does not have a version in repo that satisfies constraint $constraint")
+    }
+}
+
+private val elm19 = Constraint.parse("0.19.0 <= v < 0.20.0")
+
+private val repo = Repository(
+        Pkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
+        Pkg(name = "B", version = v(1, 0, 1), dependencies = emptyMap()),
+        Pkg(name = "B", version = v(1, 0, 2), dependencies = emptyMap()),
+        Pkg(name = "B", version = v(1, 0, 3), dependencies = emptyMap()),
+        Pkg(
+                name = "C",
+                version = v(1, 0, 0),
+                dependencies = mapOf(
+                        "B" to r("1.0.1 <= v < 1.0.3")
+                )
+        )
+)
+
+class SolverTest {
+
+    @Test
+    fun `trivial resolve`() {
+        val input = mapOf(
+                "C" to r("1.0.0 <= v < 2.0.0")
+        )
+
+        assertEquals(solve(input, repo), mapOf(
+                "C" to v(1, 0, 0)
+        ))
+    }
+
+    @Test
+    fun `picks highest available version`() {
+        val input = mapOf(
+                "B" to r("1.0.0 <= v < 2.0.0")
+        )
+
+        assertEquals(solve(input, repo), mapOf(
+                "B" to v(1, 0, 3)
+        ))
+    }
+
+    @Test
+    fun `resolve mutual constraints`() {
+        val input = mapOf(
+                "B" to r("1.0.0 <= v < 1.0.4"),
+                "C" to r("1.0.0 <= v < 2.0.0")
+        )
+
+        assertEquals(solve(input, repo), mapOf(
+                "B" to v(1, 0, 2),
+                "C" to v(1, 0, 0)
+        ))
+    }
+}
+
+private fun r(str: String) = Constraint.parse(str)
+
+private fun v(x: Int, y: Int, z: Int) =
+        Version(x, y, z)

--- a/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
+++ b/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
@@ -16,15 +16,33 @@ private val repo = Repository(
                 dependencies = mapOf(
                         "B" to r("1.0.1 <= v < 1.0.3")
                 )
+        ),
+        Pkg(
+                name = "D",
+                version = v(1, 0, 0),
+                dependencies = mapOf(
+                        "B" to r("1.0.1 <= v < 1.0.2"),
+                        "C" to r("1.0.0 <= v < 2.0.0")
+                )
         )
 )
 
 class SolverTest {
 
     @Test
+    fun `handles empty input`() = doTest(
+            deps = emptyMap(),
+            expect = emptyMap()
+    )
+
+    @Test
     fun `trivial resolve`() = doTest(
             deps = mapOf("C" to r("1.0.0 <= v < 2.0.0")),
-            expect = mapOf("C" to v(1, 0, 0)))
+            expect = mapOf(
+                    "B" to v(1, 0, 2),
+                    "C" to v(1, 0, 0)
+            )
+    )
 
     @Test
     fun `picks highest available version`() = doTest(
@@ -42,6 +60,24 @@ class SolverTest {
                     "B" to v(1, 0, 2),
                     "C" to v(1, 0, 0)
             ))
+
+    @Test
+    fun `resolve mutual constraints - multiple levels`() = doTest(
+            deps = mapOf(
+                    "B" to r("1.0.0 <= v < 1.0.4"),
+                    "C" to r("1.0.0 <= v < 2.0.0"),
+                    "D" to r("1.0.0 <= v < 2.0.0")
+            ),
+            expect = mapOf(
+                    "B" to v(1, 0, 1),
+                    "C" to v(1, 0, 0),
+                    "D" to v(1, 0, 0)
+            ))
+
+    @Test
+    fun `no solution because version constraint is lower than lowest version in repo`() = doTest(
+            deps = mapOf("C" to r("0.0.0 <= v < 1.0.0")),
+            expect = null)
 
     @Test
     fun `no solution because version constraint is higher than max version in repo`() = doTest(

--- a/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
+++ b/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
@@ -5,19 +5,34 @@ import org.elm.workspace.Version
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-private val fixture = Repository(
-        Pkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
-        Pkg(name = "B", version = v(1, 0, 1), dependencies = emptyMap()),
-        Pkg(name = "B", version = v(1, 0, 2), dependencies = emptyMap()),
-        Pkg(name = "B", version = v(1, 0, 3), dependencies = emptyMap()),
-        Pkg(
+data class SimplePkg(
+        override val name: PkgName,
+        override val version: Version,
+        override val elmVersion: Constraint = Constraint.parse("0.19.0 <= v < 0.20.0"),
+        override val dependencies: Map<PkgName, Constraint>
+) : Pkg
+
+data class SimpleRepository(private val packagesByName: Map<PkgName, List<Pkg>>) : Repository {
+    constructor(vararg packages: Pkg) : this(packages.groupBy { it.name })
+
+    override operator fun get(name: String): List<Pkg> {
+        return packagesByName[name] ?: emptyList()
+    }
+}
+
+private val fixture = SimpleRepository(
+        SimplePkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
+        SimplePkg(name = "B", version = v(1, 0, 1), dependencies = emptyMap()),
+        SimplePkg(name = "B", version = v(1, 0, 2), dependencies = emptyMap()),
+        SimplePkg(name = "B", version = v(1, 0, 3), dependencies = emptyMap()),
+        SimplePkg(
                 name = "C",
                 version = v(1, 0, 0),
                 dependencies = mapOf(
                         "B" to r("1.0.1 <= v < 1.0.3")
                 )
         ),
-        Pkg(
+        SimplePkg(
                 name = "D",
                 version = v(1, 0, 0),
                 dependencies = mapOf(
@@ -84,15 +99,15 @@ class SolverTest {
                     "A" to v(1, 0, 0),
                     "B" to v(2, 0, 0)
             ),
-            repo = Repository(
-                    Pkg(
+            repo = SimpleRepository(
+                    SimplePkg(
                             name = "A",
                             version = v(1, 0, 0),
                             dependencies = mapOf("B" to r("1.0.0 <= v < 3.0.0"))
                     ),
-                    Pkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
-                    Pkg(name = "B", version = v(2, 0, 0), dependencies = emptyMap()),
-                    Pkg(name = "B", version = v(2, 1, 0), dependencies = emptyMap())
+                    SimplePkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
+                    SimplePkg(name = "B", version = v(2, 0, 0), dependencies = emptyMap()),
+                    SimplePkg(name = "B", version = v(2, 1, 0), dependencies = emptyMap())
             )
     )
 
@@ -103,14 +118,14 @@ class SolverTest {
                     "B" to r("1.0.0 <= v < 2.0.0")
             ),
             expect = null,
-            repo = Repository(
-                    Pkg(
+            repo = SimpleRepository(
+                    SimplePkg(
                             name = "A",
                             version = v(1, 0, 0),
                             dependencies = mapOf("B" to r("2.0.0 <= v < 3.0.0"))
                     ),
-                    Pkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
-                    Pkg(name = "B", version = v(2, 0, 0), dependencies = emptyMap())
+                    SimplePkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
+                    SimplePkg(name = "B", version = v(2, 0, 0), dependencies = emptyMap())
             )
     )
 

--- a/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
+++ b/src/test/kotlin/org/elm/workspace/solver/SolverTest.kt
@@ -5,31 +5,6 @@ import org.elm.workspace.Version
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-typealias PkgName = String
-
-data class Pkg(
-        val name: PkgName,
-        val version: Version,
-        val elmVersion: Constraint = elm19, // TODO: get rid of the default outside of test cases
-        val dependencies: Map<PkgName, Constraint>
-)
-
-data class Repository(val packagesByName: Map<PkgName, List<Pkg>>) {
-    constructor(vararg packages: Pkg) : this(packages.groupBy { it.name })
-}
-
-fun solve(dependencies: Map<PkgName, Constraint>, repository: Repository): Map<PkgName, Version> {
-    return dependencies.mapValues { (name, constraint) ->
-        (repository.packagesByName[name] ?: error("package $name not found in repository"))
-                .map { it.version }
-                .filter { constraint.contains(it) }
-                .max()
-                ?: error("package $name does not have a version in repo that satisfies constraint $constraint")
-    }
-}
-
-private val elm19 = Constraint.parse("0.19.0 <= v < 0.20.0")
-
 private val repo = Repository(
         Pkg(name = "B", version = v(1, 0, 0), dependencies = emptyMap()),
         Pkg(name = "B", version = v(1, 0, 1), dependencies = emptyMap()),
@@ -47,39 +22,43 @@ private val repo = Repository(
 class SolverTest {
 
     @Test
-    fun `trivial resolve`() {
-        val input = mapOf(
-                "C" to r("1.0.0 <= v < 2.0.0")
-        )
-
-        assertEquals(solve(input, repo), mapOf(
-                "C" to v(1, 0, 0)
-        ))
-    }
+    fun `trivial resolve`() = doTest(
+            deps = mapOf("C" to r("1.0.0 <= v < 2.0.0")),
+            expect = mapOf("C" to v(1, 0, 0)))
 
     @Test
-    fun `picks highest available version`() {
-        val input = mapOf(
-                "B" to r("1.0.0 <= v < 2.0.0")
-        )
-
-        assertEquals(solve(input, repo), mapOf(
-                "B" to v(1, 0, 3)
-        ))
-    }
+    fun `picks highest available version`() = doTest(
+            deps = mapOf("B" to r("1.0.0 <= v < 2.0.0")),
+            expect = mapOf("B" to v(1, 0, 3))
+    )
 
     @Test
-    fun `resolve mutual constraints`() {
-        val input = mapOf(
-                "B" to r("1.0.0 <= v < 1.0.4"),
-                "C" to r("1.0.0 <= v < 2.0.0")
-        )
+    fun `resolve mutual constraints`() = doTest(
+            deps = mapOf(
+                    "B" to r("1.0.0 <= v < 1.0.4"),
+                    "C" to r("1.0.0 <= v < 2.0.0")
+            ),
+            expect = mapOf(
+                    "B" to v(1, 0, 2),
+                    "C" to v(1, 0, 0)
+            ))
 
-        assertEquals(solve(input, repo), mapOf(
-                "B" to v(1, 0, 2),
-                "C" to v(1, 0, 0)
-        ))
-    }
+    @Test
+    fun `no solution because version constraint is higher than max version in repo`() = doTest(
+            deps = mapOf("C" to r("9.0.0 <= v < 10.0.0")),
+            expect = null)
+
+    @Test
+    fun `no solution because mutual constraints conflict with each other`() = doTest(
+            deps = mapOf(
+                    "B" to r("1.0.3 <= v < 1.0.4"),
+                    "C" to r("1.0.0 <= v < 2.0.0")
+            ),
+            expect = null)
+}
+
+fun doTest(deps: Map<PkgName, Constraint>, expect: Map<PkgName, Version>?) {
+    assertEquals(expect, solve(deps, repo))
 }
 
 private fun r(str: String) = Constraint.parse(str)


### PR DESCRIPTION
One of the most important things in this plugin is the logic for reading an `elm.json` file and determining the layout of source directories, the location of dependencies, and which modules are visible for a given scope. This is relatively easy to do for Elm applications because the `elm.json` file contains the concrete version numbers of each dependency, direct and indirect, whereas package projects only list _constraints_ on versions.

Early on in the project I punted on properly resolving "package project" constraints because I was hopeful that the Elm compiler would eventually be able to export information about how it resolved the constraints. That never happened, and I never got around to doing it myself.

But as it turns out, there was a deep bug in my code even for application projects which resulted in the plugin potentially using the wrong version of a package.

This PR does several things:
1. fixes the bug that caused application projects to sometimes use the wrong version of a dependency
2. implements constraint-based version resolution for package projects
3. cleans-up the code to make it easier to understand
4. gets rid of some lame hacks related to how integration tests load `elm.json` files
5. fixes go-to-declaration for indirect dependencies

Fixes #669 
Fixes #681
Fixes #497