### PR TITLE
Install package dependencies when attaching/refreshing `elm.json`

### DIFF
--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
@@ -23,7 +24,7 @@ import com.intellij.ui.components.labels.ActionLink
 import com.intellij.ui.content.ContentManager
 import com.intellij.ui.table.JBTable
 import org.elm.openapiext.checkIsEventDispatchThread
-import org.elm.openapiext.findFileByPathTestAware
+import org.elm.openapiext.findFileByPath
 import org.elm.openapiext.toPsiFile
 import org.elm.workspace.compiler.ElmBuildAction
 import org.elm.workspace.compiler.ElmError
@@ -198,7 +199,9 @@ class ElmCompilerPanel(
     private fun startFromErrorMessage(): Triple<VirtualFile, Document, Start>? {
         val elmError = compilerMessages.getOrNull(selectedCompilerMessage) ?: return null
         val elmLocation = elmError.location ?: return null
-        val virtualFile = baseDirPath?.resolve(elmLocation.path)?.let { findFileByPathTestAware(it) } ?: return null
+        val virtualFile = baseDirPath?.resolve(elmLocation.path)?.let {
+            LocalFileSystem.getInstance().findFileByPath(it)
+        } ?: return null
         val psiFile = virtualFile.toPsiFile(project) ?: return null
         val document = PsiDocumentManager.getInstance(project).getDocument(psiFile) ?: return null
         val start = elmLocation.region?.start ?: return null

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.RecursionManager
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -78,12 +77,6 @@ fun checkIsBackgroundThread() {
 fun fullyRefreshDirectory(directory: VirtualFile) {
     VfsUtil.markDirtyAndRefresh(/* async = */ false, /* recursive = */ true, /* reloadChildren = */ true, directory)
 }
-
-fun VirtualFile.findFileByMaybeRelativePath(path: String): VirtualFile? =
-        if (FileUtil.isAbsolute(path))
-            fileSystem.findFileByPath(path)
-        else
-            findFileByRelativePath(path)
 
 fun VirtualFile.findFileBreadthFirst(predicate: (VirtualFile) -> Boolean): VirtualFile? {
     val queue = LinkedList<VirtualFile>().also { it.push(this) }
@@ -169,6 +162,17 @@ fun findFileByPathTestAware(path: Path): VirtualFile? {
     }
 
     return LocalFileSystem.getInstance().findFileByPath(path)
+}
+
+fun refreshAndFindFileByPathTestAware(path: Path): VirtualFile? {
+    if (isUnitTestMode) {
+        val vFile = TempFileSystem.getInstance().refreshAndFindFileByPath(path.toString())
+        if (vFile != null) {
+            return vFile
+        }
+    }
+
+    return LocalFileSystem.getInstance().refreshAndFindFileByPath(path.toString())
 }
 
 val isUnitTestMode: Boolean get() = ApplicationManager.getApplication().isUnitTestMode

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -164,6 +164,13 @@ fun findFileByPathTestAware(path: Path): VirtualFile? {
     return LocalFileSystem.getInstance().findFileByPath(path)
 }
 
+// TODO [kl] Rethink these "testAware" functions.
+//
+// These functions are a hack to workaround a mixed VFS environment. The crux of the problem
+// is that our ElmTestBase (non-workspace, non-"heavy" integration tests) use the in-mem,
+// light VFS. But the package dependencies exist in the real, LocalFileSystem VFS at `~/.elm`.
+// Maybe there's a better way?
+
 fun refreshAndFindFileByPathTestAware(path: Path): VirtualFile? {
     if (isUnitTestMode) {
         val vFile = TempFileSystem.getInstance().refreshAndFindFileByPath(path.toString())

--- a/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
@@ -1,15 +1,21 @@
 package org.elm.workspace
 
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
+import org.elm.ide.notifications.showBalloon
+import org.elm.openapiext.isSuccess
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.saveAllDocuments
 import org.elm.utils.handleError
 import org.elm.workspace.ElmToolchain.Companion.ELM_JSON
+import java.nio.file.Files
+import java.nio.file.Path
 
 
 class ElmAttachProjectAction : AnAction() {
@@ -23,7 +29,7 @@ class ElmAttachProjectAction : AnAction() {
         val descriptor = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
                 .withFileFilter { it.name == manifestName }
                 .withTitle("Select '$manifestName' file")
-        descriptor.isForcedToUseIdeaFileChooser = true
+                .apply { isForcedToUseIdeaFileChooser = true }
 
         val file = FileChooser.chooseFile(descriptor, project, null)
                 ?: return
@@ -33,13 +39,66 @@ class ElmAttachProjectAction : AnAction() {
             return
         }
 
-        project.elmWorkspace.asyncAttachElmProject(file.pathAsPath)
-                .handleError { showError(it) }
+        val manifestPath = file.pathAsPath
+        project.elmWorkspace.asyncAttachElmProject(manifestPath)
+                .handleError { showError(it.cause!!, project, manifestPath) }
     }
 
-    private fun showError(error: Throwable) {
+    private fun showError(error: Throwable, project: Project, manifestPath: Path) {
         ApplicationManager.getApplication().invokeLater {
-            Messages.showErrorDialog(error.message, "Failed to attach Elm project")
+            // TODO [kl] double-check threading
+            when (error) {
+                is ProjectLoadException.MissingDependencies -> {
+                    val answer = Messages.showYesNoDialog(
+                            "Run 'elm make' to install packages?",
+                            "Project dependencies may not be installed",
+                            null
+                    )
+                    if (answer == Messages.YES) {
+                        gracefullyRecover(project, error, manifestPath)
+                    }
+                }
+                else -> Messages.showErrorDialog(error.message, "Failed to attach Elm project")
+            }
         }
+    }
+
+    private fun gracefullyRecover(project: Project, error: ProjectLoadException.MissingDependencies, manifestPath: Path) {
+        val elmCLI = project.elmToolchain.elmCLI
+        if (elmCLI == null) {
+            showBalloon(project, "Please set the path to the 'elm' binary", includeFixAction = true)
+            return
+        }
+
+        // Install missing Elm package dependencies
+        //
+        // Unfortunately, there is no CLI command to install dependencies, so we instead
+        // pick an arbitrary `.elm` file in the `source-directories` and tell Elm to
+        // compile it. This will indirectly download and install the dependencies.
+
+        val arbitraryElmFilePath = error.sourceDirectories.asSequence()
+                .map { manifestPath.parent.resolve(it).normalize() }
+                .flatMap { Files.newDirectoryStream(it).asSequence() }
+                .firstOrNull()
+                ?: return showBalloon(project, "Could not find a `.elm` file to compile")
+
+        val output = elmCLI.make(project, workDir = manifestPath.parent, path = arbitraryElmFilePath)
+
+        when {
+            !output.isSuccess -> showBalloon(project, "Failed to compile $arbitraryElmFilePath")
+            else -> {
+                // Retry the original action. Hopefully this will work now!
+                project.elmWorkspace.asyncAttachElmProject(manifestPath)
+                        .handleError { showError(it.cause!!, project, manifestPath) }
+            }
+        }
+    }
+
+    private fun showBalloon(project: Project, message: String, includeFixAction: Boolean = false) {
+        val actions = when {
+            includeFixAction -> arrayOf("Fix" to { project.elmWorkspace.showConfigureToolchainUI() })
+            else -> emptyArray()
+        }
+        project.showBalloon(message, NotificationType.ERROR, *actions)
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
@@ -34,7 +34,7 @@ class ElmAttachProjectAction : AnAction() {
         }
 
         project.elmWorkspace.asyncAttachElmProject(file.pathAsPath)
-                .handleError { showError(it.cause!!) }
+                .handleError { showError(it) }
     }
 
     private fun showError(error: Throwable) {

--- a/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmAttachProjectAction.kt
@@ -1,21 +1,15 @@
 package org.elm.workspace
 
-import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
-import org.elm.ide.notifications.showBalloon
-import org.elm.openapiext.isSuccess
 import org.elm.openapiext.pathAsPath
 import org.elm.openapiext.saveAllDocuments
 import org.elm.utils.handleError
 import org.elm.workspace.ElmToolchain.Companion.ELM_JSON
-import java.nio.file.Files
-import java.nio.file.Path
 
 
 class ElmAttachProjectAction : AnAction() {
@@ -39,69 +33,13 @@ class ElmAttachProjectAction : AnAction() {
             return
         }
 
-        val manifestPath = file.pathAsPath
-        project.elmWorkspace.asyncAttachElmProject(manifestPath)
-                .handleError { showError(it.cause!!, project, manifestPath) }
+        project.elmWorkspace.asyncAttachElmProject(file.pathAsPath)
+                .handleError { showError(it.cause!!) }
     }
 
-    private fun showError(error: Throwable, project: Project, manifestPath: Path) {
+    private fun showError(error: Throwable) {
         ApplicationManager.getApplication().invokeLater {
-            when (error) {
-                is ProjectLoadException.StaleElmStuff -> {
-                    val answer = Messages.showYesNoDialog(
-                            "Run 'elm make' to install packages?",
-                            "Project dependencies may not be installed",
-                            null
-                    )
-                    if (answer == Messages.YES) {
-                        gracefullyRecover(project, error, manifestPath)
-                    }
-                }
-                else -> Messages.showErrorDialog(error.message, "Failed to attach Elm project")
-            }
+            Messages.showErrorDialog(error.message, "Failed to attach Elm project")
         }
-    }
-
-    private fun gracefullyRecover(project: Project, error: ProjectLoadException.StaleElmStuff, manifestPath: Path) {
-        val elmCLI = project.elmToolchain.elmCLI
-        if (elmCLI == null) {
-            showBalloon(project, "Please set the path to the 'elm' binary", includeFixAction = true)
-            return
-        }
-
-        // Install missing Elm package dependencies
-        //
-        // Unfortunately, there is no CLI command to install dependencies, so we instead
-        // pick an arbitrary `.elm` file in the `source-directories` and tell Elm to
-        // compile it. This will indirectly download and install the dependencies.
-
-        val arbitraryElmFilePath = error.sourceDirectories.asSequence()
-                .map { manifestPath.parent.resolve(it).normalize() }
-                .flatMap { Files.newDirectoryStream(it).asSequence() }
-                .firstOrNull()
-                ?: return showBalloon(project, "Could not find a `.elm` file to compile")
-
-        val app = ApplicationManager.getApplication()
-        app.executeOnPooledThread {
-            val output = elmCLI.make(project, workDir = manifestPath.parent, path = arbitraryElmFilePath)
-            app.invokeLater {
-                when {
-                    !output.isSuccess -> showBalloon(project, "Failed to compile $arbitraryElmFilePath")
-                    else -> {
-                        // Retry the original action. Hopefully this will work now!
-                        project.elmWorkspace.asyncAttachElmProject(manifestPath)
-                                .handleError { showError(it.cause!!, project, manifestPath) }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun showBalloon(project: Project, message: String, includeFixAction: Boolean = false) {
-        val actions = when {
-            includeFixAction -> arrayOf("Fix" to { project.elmWorkspace.showConfigureToolchainUI() })
-            else -> emptyArray()
-        }
-        project.showBalloon(message, NotificationType.ERROR, *actions)
     }
 }

--- a/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmRefreshProjectsAction.kt
@@ -17,7 +17,7 @@ class ElmRefreshProjectsAction : AnAction() {
         if (!(project.elmToolchain.looksLikeValidToolchain() && project.elmWorkspace.hasAtLeastOneValidProject())) {
             asyncAutoDiscoverWorkspace(project, explicitRequest = true)
         } else {
-            project.elmWorkspace.asyncRefreshAllProjects()
+            project.elmWorkspace.asyncRefreshAllProjects(installDeps = true)
         }.handleError {
             showError(it)
         }

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -448,11 +448,9 @@ sealed class ProjectLoadException(msg: String, cause: Exception? = null) : Runti
             cause: Exception? = null
     ) : ProjectLoadException(msg, cause)
 
-    class MissingDependencies(
-            msg: String,
-            cause: Exception? = null,
+    class StaleElmStuff(
             val sourceDirectories: List<Path>
-    ) : ProjectLoadException(msg, cause)
+    ) : ProjectLoadException("the elm.json file appears to have been modified without running 'elm make'")
 }
 
 

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -287,9 +287,9 @@ class ElmWorkspaceService(
     }
 
 
-    fun asyncRefreshAllProjects(): CompletableFuture<List<ElmProject>> =
+    fun asyncRefreshAllProjects(installDeps: Boolean = false): CompletableFuture<List<ElmProject>> =
             allProjects.map { elmProject ->
-                asyncLoadProject(elmProject.manifestPath)
+                asyncLoadProject(elmProject.manifestPath, installDeps = installDeps)
                         .exceptionally { null } // TODO [kl] capture info about projects that failed to load and show to user
             }.joinAll()
                     .thenApply { rawProjects ->

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -204,6 +204,11 @@ class ElmWorkspaceService(
                 // not thread-safe; do not reuse across threads!
                 val repo = ElmPackageRepository(compilerVersion)
 
+                // External files may have been created/modified by the Elm compiler. Refresh.
+                findFileByPathTestAware(Paths.get(repo.elmHomePath))?.also {
+                    fullyRefreshDirectory(it)
+                }
+
                 // Load the project
                 ElmProjectLoader.topLevelLoad(manifestPath, repo)
             }.whenComplete { _, error ->
@@ -247,6 +252,7 @@ class ElmWorkspaceService(
         // because some inputs can hang the compiler.
         if (!ElmProjectLoader.isValid(tempManifest.toPath())) {
             log.error("Failed to install deps: the elm.json file is invalid")
+            FileUtil.delete(dir)
             return false
         }
 

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -201,6 +201,7 @@ class ElmWorkspaceService(
                     // would provide some kind of `elm install` command, but for now we will
                     // work-around its absence.
                     val sourceDirectory = ElmProjectLoader.parseSourceDirs(manifestPath).firstOrNull()
+                            ?.let { manifestPath.parent.resolve(it).normalize() }
                             ?: throw ProjectLoadException.General("Need at least one source-directory in `elm.json`")
 
                     val tempFile = LocalFileSystem.getInstance()

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -192,10 +192,10 @@ class ElmWorkspaceService(
     private fun asyncLoadProject(manifestPath: Path, installDeps: Boolean = false): CompletableFuture<ElmProject> =
             runAsyncTask(intellijProject, "Loading Elm project '$manifestPath'") {
                 val elmCLI = settings.toolchain.elmCLI
-                        ?: throw ProjectLoadException.General("Must specify a valid path to Elm binary in Settings")
+                        ?: throw ProjectLoadException("Must specify a valid path to Elm binary in Settings")
 
                 val compilerVersion = elmCLI.queryVersion().orNull()
-                        ?: throw ProjectLoadException.General("Could not determine version of the Elm compiler")
+                        ?: throw ProjectLoadException("Could not determine version of the Elm compiler")
 
                 if (installDeps) {
                     installProjectDeps(manifestPath, elmCLI)
@@ -503,16 +503,7 @@ class ElmWorkspaceService(
 }
 
 
-sealed class ProjectLoadException(msg: String, cause: Exception? = null) : RuntimeException(msg, cause) {
-    class General(
-            msg: String,
-            cause: Exception? = null
-    ) : ProjectLoadException(msg, cause)
-
-    class StaleElmStuff(
-            val sourceDirectories: List<Path>
-    ) : ProjectLoadException("the elm.json file appears to have been modified without running 'elm make'")
-}
+class ProjectLoadException(msg: String, cause: Exception? = null) : RuntimeException(msg, cause)
 
 
 // AUTO-DISCOVER

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
@@ -18,7 +18,10 @@ import java.nio.file.Path
 class ElmCLI(private val elmExecutablePath: Path) {
 
     fun make(owner: Disposable, elmProject: ElmProject, path: Path): ProcessOutput {
-        val workDir = elmProject.manifestPath.parent
+        return make(owner, elmProject.manifestPath.parent, path)
+    }
+
+    fun make(owner: Disposable, workDir: Path, path: Path): ProcessOutput {
         return GeneralCommandLine(elmExecutablePath)
                 .withWorkDirectory(workDir)
                 .withParameters("make", path.toString(), "--output=/dev/null", "--report=json")

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
@@ -7,7 +7,6 @@ import org.elm.openapiext.GeneralCommandLine
 import org.elm.openapiext.Result
 import org.elm.openapiext.execute
 import org.elm.openapiext.withWorkDirectory
-import org.elm.workspace.ElmProject
 import org.elm.workspace.ParseException
 import org.elm.workspace.Version
 import java.nio.file.Path
@@ -17,14 +16,11 @@ import java.nio.file.Path
  */
 class ElmCLI(private val elmExecutablePath: Path) {
 
-    fun make(owner: Disposable, elmProject: ElmProject, path: Path): ProcessOutput {
-        return make(owner, elmProject.manifestPath.parent, path)
-    }
-
-    fun make(owner: Disposable, workDir: Path, path: Path): ProcessOutput {
+    fun make(owner: Disposable, workDir: Path, path: Path, jsonReport: Boolean = false): ProcessOutput {
         return GeneralCommandLine(elmExecutablePath)
                 .withWorkDirectory(workDir)
-                .withParameters("make", path.toString(), "--output=/dev/null", "--report=json")
+                .withParameters("make", path.toString(), "--output=/dev/null")
+                .apply { if (jsonReport) addParameter("--report=json") }
                 .execute(owner, ignoreExitCode = true)
     }
 

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
@@ -24,16 +24,6 @@ class ElmCLI(private val elmExecutablePath: Path) {
                 .execute(owner, ignoreExitCode = true)
     }
 
-    fun installDeps(owner: Disposable, elmProjectManifestPath: Path): ProcessOutput {
-        // Elm 0.19 does not have a way to install dependencies directly,
-        // so we have to compile an empty file to make it work.
-        val workDir = elmProjectManifestPath.parent
-        return GeneralCommandLine(elmExecutablePath)
-                .withWorkDirectory(workDir)
-                .withParameters("make", "./Main.elm", "--output=/dev/null")
-                .execute(owner, ignoreExitCode = false)
-    }
-
     fun queryVersion(): Result<Version> {
         // Output of `elm --version` is a single line containing the version number (e.g. `0.19.0\n`)
         val firstLine = try {

--- a/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
@@ -61,7 +61,7 @@ class ElmBuildAction : AnAction() {
         }
 
         val json = try {
-            elmCLI.make(project, elmProject, filePathToCompile).stderr
+            elmCLI.make(project, elmProject.projectDirPath, filePathToCompile, jsonReport = true).stderr
         } catch (e: ExecutionException) {
             return showError(project, "Failed to run the 'elm' executable. Is the path correct?", includeFixAction = true)
         }

--- a/src/main/kotlin/org/elm/workspace/projectLoader.kt
+++ b/src/main/kotlin/org/elm/workspace/projectLoader.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.io.exists
-import org.elm.openapiext.findFileByPathTestAware
+import org.elm.openapiext.refreshAndFindFileByPathTestAware
 import org.elm.workspace.ElmToolchain.Companion.SIDECAR_FILENAME
 import org.elm.workspace.solver.Pkg
 import org.elm.workspace.solver.PkgName
@@ -131,9 +131,6 @@ class ElmPackageRepository(override val elmCompilerVersion: Version) : Repositor
             return Paths.get("$elmHomePath/$elmCompilerVersion/$subDirName/")
         }
 
-    fun listPackages(): List<File> =
-            globalPackageCacheDir.toFile().listFiles()?.toList() ?: emptyList()
-
     /**
      * Path to the manifest file for the Elm package [name] at version [version]
      */
@@ -161,7 +158,7 @@ class ElmPackageRepository(override val elmCompilerVersion: Version) : Repositor
 // DTOs for JSON Decoding
 
 private fun parseDTO(manifestPath: Path): ElmProjectDTO {
-    val manifestStream = findFileByPathTestAware(manifestPath)?.inputStream
+    val manifestStream = refreshAndFindFileByPathTestAware(manifestPath)?.inputStream
             ?: throw ProjectLoadException.General("Manifest file not found: $manifestPath")
     return try {
         val node = objectMapper.readTree(manifestStream)

--- a/src/main/kotlin/org/elm/workspace/projectLoader.kt
+++ b/src/main/kotlin/org/elm/workspace/projectLoader.kt
@@ -57,7 +57,7 @@ class ElmProjectLoader(
                                 elmVersion = dto.elmVersion,
                                 dependencies = dto.deps.direct.keys.map { loader.load(it) },
                                 testDependencies = dto.testDeps.direct.keys.map { loader.load(it) },
-                                sourceDirectories = dto.sourceDirectories,
+                                sourceDirectories = dto.sourceDirectories.map { Paths.get(it) },
                                 testsRelativeDirPath = findAndParseSidecarFor(manifestPath)?.testDirectory
                                         ?: DEFAULT_TESTS_DIR_NAME
                         )
@@ -78,10 +78,12 @@ class ElmProjectLoader(
                     }
                 }
 
-        fun parseSourceDirs(manifestPath: Path): List<Path> =
-                when (val dto = parseDTO(manifestPath)) {
-                    is ElmApplicationProjectDTO -> dto.sourceDirectories
-                    is ElmPackageProjectDTO -> packageProjectSourceDirs
+        fun isValid(manifestPath: Path): Boolean =
+                try {
+                    parseDTO(manifestPath)
+                    true
+                } catch (e: Throwable) {
+                    false
                 }
 
         // Elm 0.19.x package projects have only a single source root and it is called "src"
@@ -181,7 +183,7 @@ private sealed class ElmProjectDTO
 
 private class ElmApplicationProjectDTO(
         @JsonProperty("elm-version") val elmVersion: Version,
-        @JsonProperty("source-directories") val sourceDirectories: List<Path>,
+        @JsonProperty("source-directories") val sourceDirectories: List<String>,
         @JsonProperty("dependencies") val deps: ExactDependenciesDTO,
         @JsonProperty("test-dependencies") val testDeps: ExactDependenciesDTO
 ) : ElmProjectDTO()

--- a/src/test/kotlin/org/elm/FileTree.kt
+++ b/src/test/kotlin/org/elm/FileTree.kt
@@ -79,6 +79,12 @@ interface FileTreeBuilder {
     /* Creates an Elm source file */
     fun elm(name: String, @Language("Elm") code: String) = file(name, code)
 
+    /* Creates an Elm source file where the content doesn't matter but it does compile */
+    fun elm(name: String) = file(name, """
+        module ${name.removeSuffix(".elm")} exposing (..)
+        placeholderValue = 0
+    """.trimIndent())
+
     /* Creates an `elm.json` project file */
     fun project(name: String, @Language("JSON") code: String) = file(name, code)
 }

--- a/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmCreateFileActionTest.kt
@@ -59,11 +59,18 @@ class ElmCreateFileActionTest : ElmWorkspaceTestBase() {
                         "./foo1"
                     ],
                     "elm-version": "0.19.1",
-                    "dependencies":      { "direct": {}, "indirect": {} },
+                    "dependencies": {
+                        "direct": {
+                            "elm/core": "1.0.0",
+                            "elm/json": "1.0.0"                        
+                        }, 
+                        "indirect": {}
+                    },
                     "test-dependencies": { "direct": {}, "indirect": {} }
                 }
                 """.trimIndent())
                 dir("src") {
+                    elm("Main.elm")
                     dir("Foo") {}
                     dir("Bar") {}
                 }

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -24,20 +24,20 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
 
 
     fun `test elm-format action with elm 19`() {
-        val fileWithCaret = buildProject {
+        buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", """
                     module Main exposing (f)
 
 
-                    f x = x{-caret-}
+                    f x = x
 
                 """.trimIndent())
             }
-        }.fileWithCaret
+        }
 
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val file = myFixture.configureFromTempProjectFile("src/Main.elm").virtualFile
         val document = FileDocumentManager.getInstance().getDocument(file)!!
         reformat(file)
         val expected = """
@@ -52,20 +52,15 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
     }
 
     fun `test elm-format action shouldn't be active on non-elm files`() {
-        val fileWithCaret = buildProject {
+        buildProject {
             project("elm.json", manifestElm19.trimIndent())
             dir("src") {
-                elm("Main.scala", """
-                    module Main exposing (f)
-
-
-                    f x = x{-caret-}
-
-                """.trimIndent())
+                elm("Main.elm")
+                file("foo.txt", "")
             }
-        }.fileWithCaret
+        }
 
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val file = myFixture.configureFromTempProjectFile("src/foo.txt").virtualFile
         val (_, e) = makeTestAction(file)
         check(!e.presentation.isEnabledAndVisible) {
             "The elm-format action shouldn't be enabled in this context"
@@ -73,20 +68,20 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
     }
 
     fun `test elm-format action should add to the undo stack`() {
-        val fileWithCaret = buildProject {
+        buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", """
                     module Main exposing (f)
 
 
-                    f x = x{-caret-}
+                    f x = x
 
                 """.trimIndent())
             }
-        }.fileWithCaret
+        }
 
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val file = myFixture.configureFromTempProjectFile("src/Main.elm").virtualFile
         reformat(file)
 
         val fileEditor = FileEditorManager.getInstance(project).getSelectedEditor(file)
@@ -126,7 +121,10 @@ private val manifestElm19 = """
             ],
             "elm-version": "0.19.1",
             "dependencies": {
-                "direct": {},
+                "direct": {
+                    "elm/core": "1.0.0",
+                    "elm/json": "1.0.0"                
+                },
                 "indirect": {}
             },
             "test-dependencies": {

--- a/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/lookup/ElmWorkspaceNameLookupTest.kt
@@ -4,9 +4,7 @@ import org.elm.TestClientLocation
 import org.elm.lang.core.psi.ElmNamedElement
 import org.elm.lang.core.psi.elements.ElmTypeAliasDeclaration
 import org.elm.lang.core.psi.moduleName
-import org.elm.workspace.CustomElmStdlibVariant
 import org.elm.workspace.ElmWorkspaceTestBase
-import org.elm.workspace.Version
 import org.elm.workspace.elmWorkspace
 import org.intellij.lang.annotations.Language
 
@@ -22,7 +20,10 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0"
+                    },
                     "indirect": {}
                 },
                 "test-dependencies": {
@@ -38,6 +39,7 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
             project("elm.json", standardElmAppProject)
             dir("src") {
                 elm("Foo.elm", """
+                    module Foo exposing (..)
                     type alias Foo = ()
                 """.trimIndent())
             }
@@ -49,8 +51,12 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
     fun `test find by name excludes things outside of the Elm project`() {
         buildProject {
             project("elm.json", standardElmAppProject)
+            dir("src") {
+                elm("Main.elm")
+            }
             dir("alien") {
                 elm("Bar.elm", """
+                    module Bar exposing (..)
                     type alias Bar = ()
                 """.trimIndent())
             }
@@ -60,9 +66,6 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
 
 
     fun `test find by name excludes things which are part of unexposed modules in a package`() {
-
-        ensureElmStdlibInstalled(CustomElmStdlibVariant(mapOf("elm/parser" to Version(1, 0, 0))))
-
         buildProject {
             project("elm.json", """
             {
@@ -85,7 +88,9 @@ class ElmWorkspaceNameLookupTest : ElmWorkspaceTestBase() {
                 }
             }
             """.trimIndent())
-            dir("src") {}
+            dir("src") {
+                elm("Main.elm")
+            }
         }
         /*
          * elm/parser v1.0.0 includes 2 modules: "Parser" and "Parser.Advanced". However,

--- a/src/test/kotlin/org/elm/workspace/ElmProjectHelperTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmProjectHelperTest.kt
@@ -56,7 +56,7 @@ class ElmProjectHelperTest : ElmWorkspaceTestBase() {
             dir("a") {
                 project("elm.json", elmJson)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
                 dir("tests") {
                 }
@@ -64,13 +64,13 @@ class ElmProjectHelperTest : ElmWorkspaceTestBase() {
             dir("without-tests") {
                 project("elm.json", elmJson)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
             }
             dir("b") {
                 project("elm.json", elmJson)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
                 dir("tests") {
                 }
@@ -93,15 +93,14 @@ class ElmProjectHelperTest : ElmWorkspaceTestBase() {
         "elm-version": "0.19.1",
         "dependencies": {
             "direct": {
+                "elm/core": "1.0.0",
+                "elm/json": "1.0.0"
             },
-            "indirect": {
-            }
+            "indirect": {}
          },
         "test-dependencies": {
-            "direct": {
-            },
-            "indirect": {
-            }
+            "direct": {},
+            "indirect": {}
         }
     }
     """

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -300,9 +300,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             asyncAttachElmProject(rootPath.resolve("b/elm.json")).get()
         }
 
-        val elmProjA = project.elmWorkspace.allProjects.find { it.presentableName == "a" }!!
-        val elmProjB = project.elmWorkspace.allProjects.find { it.presentableName == "b" }!!
-
         testProject.run {
             checkReferenceIsResolved<ElmImportClause>("a/src/Main.elm", toPackage = "elm/parser 1.0.0")
             checkReferenceIsResolved<ElmImportClause>("b/src/Main.elm", toPackage = "elm/parser 1.1.0")
@@ -348,6 +345,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             """)
             if (!useDefaultTestsLocation)
                 file("elm.intellij.json", """{"test-directory": "custom-tests"}""")
+            dir("src") {}
             dir(testsFolder) {
                 elm("MyTests.elm", """
                     import Test
@@ -433,6 +431,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             """)
             if (!useDefaultTestsLocation)
                 file("elm.intellij.json", """{"test-directory": "custom-tests"}""")
+            dir("src") {}
             dir(testsFolder) {
                 elm("MyTests.elm", """
                     import Helper
@@ -456,7 +455,11 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0",
+                        "elm/random": "1.0.0"
+                    },
                     "indirect": {
                         "elm/time": "1.0.0"
                     }

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceResolveTest.kt
@@ -1,9 +1,7 @@
 package org.elm.workspace
 
-import org.elm.TestClientLocation
 import org.elm.fileTree
 import org.elm.lang.core.psi.elements.ElmImportClause
-import org.elm.lang.core.stubs.index.ElmModulesIndex
 import org.elm.openapiext.pathAsPath
 
 class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
@@ -19,7 +17,10 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0"
+                    },
                     "indirect": {}
                 },
                 "test-dependencies": {
@@ -30,12 +31,15 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             """)
             dir("src") {
                 elm("Main.elm", """
+                    module Main exposing (..)
                     import Foo
                            --^
+                    x = 0
                 """.trimIndent())
 
                 elm("Foo.elm", """
                     module Foo exposing (..)
+                    y = 0
                 """.trimIndent())
 
             }
@@ -55,7 +59,10 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                         ],
                         "elm-version": "0.19.1",
                         "dependencies": {
-                            "direct": {},
+                            "direct": {
+                                "elm/core": "1.0.0",
+                                "elm/json": "1.0.0"
+                            },
                             "indirect": {}
                         },
                         "test-dependencies": {
@@ -69,6 +76,7 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     module Main exposing (..)
                     import FooBar
                            --^
+                    x = 0
                     """.trimIndent())
                 }
             }
@@ -80,7 +88,10 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     ],
                     "elm-version": "0.19.1",
                     "dependencies": {
-                        "direct": {},
+                        "direct": {
+                            "elm/core": "1.0.0",
+                            "elm/json": "1.0.0"
+                        },
                         "indirect": {}
                     },
                     "test-dependencies": {
@@ -91,8 +102,8 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 """)
             dir("src") {
                 elm("FooBar.elm", """
-                    module FooBar exposing (x)
-                    x = 42
+                    module FooBar exposing (y)
+                    y = 42
                     """.trimIndent())
             }
         }.create(project, elmWorkspaceDirectory)
@@ -102,22 +113,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             // it's critical for the test that they are attached in this order, sequentially
             asyncAttachElmProject(rootPath.resolve("example/elm.json")).get()
             asyncAttachElmProject(rootPath.resolve("elm.json")).get()
-        }
-
-        val elmProjA = project.elmWorkspace.allProjects[0]
-        val elmProjB = project.elmWorkspace.allProjects[1]
-
-        val debug = false
-        if (debug) {
-            println("A is $elmProjA, ${elmProjA.manifestPath}")
-            println("B is $elmProjB, ${elmProjB.manifestPath}")
-            val moduleDeclsForA = ElmModulesIndex.getAll(TestClientLocation(project, elmProjA))
-            val moduleDeclsForB = ElmModulesIndex.getAll(TestClientLocation(project, elmProjB))
-            println("module decls for A")
-            moduleDeclsForA.forEach { println(it.elmFile.virtualFile.path) }
-            println("\n\n")
-            println("module decls for B")
-            moduleDeclsForB.forEach { println(it.elmFile.virtualFile.path) }
         }
 
         testProject.run {
@@ -136,7 +131,10 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                 ],
                 "elm-version": "0.19.1",
                 "dependencies": {
-                    "direct": {},
+                    "direct": {
+                        "elm/core": "1.0.0",
+                        "elm/json": "1.0.0"
+                    },
                     "indirect": {}
                 },
                 "test-dependencies": {
@@ -147,13 +145,16 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
             """)
             dir("src") {
                 elm("Main.elm", """
+                    module Main exposing (..)
                     import Foo
                            --^
+                    x = 0
                     """.trimIndent())
             }
             dir("other") {
                 elm("Foo.elm", """
                     module Foo exposing (..)
+                    y = 0
                     """.trimIndent())
 
             }
@@ -162,9 +163,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
 
     fun `test resolves modules provided by packages which are direct dependencies`() {
-
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
-
         buildProject {
             project("elm.json", """
             {
@@ -197,9 +195,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
 
     fun `test does not resolve unexposed modules provided by direct packages dependencies`() {
-
-        ensureElmStdlibInstalled(CustomElmStdlibVariant(mapOf("elm/parser" to Version(1, 0, 0))))
-
         buildProject {
             project("elm.json", """
             {
@@ -233,10 +228,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
 
     fun `test resolves modules to correct version`() {
-
-        ensureElmStdlibInstalled(CustomElmStdlibVariant(mapOf("elm/parser" to Version(1, 0, 0))))
-        ensureElmStdlibInstalled(CustomElmStdlibVariant(mapOf("elm/parser" to Version(1, 1, 0))))
-
         // note that one depends on `elm/parser` 1.0.0 and the other on 1.1.0
         val testProject = fileTree {
             dir("a") {
@@ -263,8 +254,10 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     """)
                 dir("src") {
                     elm("Main.elm", """
-                    import Parser
-                           --^
+                        module Main exposing (..)
+                        import Parser
+                               --^
+                        x = 0
                     """.trimIndent())
                 }
             }
@@ -292,8 +285,10 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
                     """)
                 dir("src") {
                     elm("Main.elm", """
-                    import Parser
-                           --^
+                        module Main exposing (..)
+                        import Parser
+                               --^
+                        x = 0
                     """.trimIndent())
                 }
             }
@@ -307,19 +302,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
         val elmProjA = project.elmWorkspace.allProjects.find { it.presentableName == "a" }!!
         val elmProjB = project.elmWorkspace.allProjects.find { it.presentableName == "b" }!!
-
-        val debug = false
-        if (debug) {
-            println("A is $elmProjA, ${elmProjA.manifestPath}")
-            println("B is $elmProjB, ${elmProjB.manifestPath}")
-            val moduleDeclsForA = ElmModulesIndex.getAll(TestClientLocation(project, elmProjA))
-            val moduleDeclsForB = ElmModulesIndex.getAll(TestClientLocation(project, elmProjB))
-            println("module decls for A")
-            moduleDeclsForA.forEach { println(it.elmFile.virtualFile.path) }
-            println("\n\n")
-            println("module decls for B")
-            moduleDeclsForB.forEach { println(it.elmFile.virtualFile.path) }
-        }
 
         testProject.run {
             checkReferenceIsResolved<ElmImportClause>("a/src/Main.elm", toPackage = "elm/parser 1.0.0")
@@ -337,9 +319,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
 
     private fun testTestDependencyResolution(useDefaultTestsLocation: Boolean) {
-
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
-
         val testsFolder = if (useDefaultTestsLocation) "tests" else "custom-tests"
 
         buildProject {
@@ -380,9 +359,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
 
     fun `test does not resolve test dependencies when outside of the 'tests' directory`() {
-
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
-
         buildProject {
             project("elm.json", """
             {
@@ -428,9 +404,6 @@ class ElmWorkspaceResolveTest : ElmWorkspaceTestBase() {
 
 
     private fun testTestCompanionModulesResolution(useDefaultTestsLocation: Boolean) {
-
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
-
         val testsFolder = if (useDefaultTestsLocation) "tests" else "custom-tests"
 
         buildProject {

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -16,8 +16,8 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             dir("a") {
                 project("elm.json", BASIC_APPLICATION_MANIFEST)
                 dir("src") {
-                    elm("Main.elm", "")
-                    elm("Utils.elm", "")
+                    elm("Main.elm")
+                    elm("Utils.elm")
                 }
             }
         }.create(project, elmWorkspaceDirectory)
@@ -41,7 +41,6 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
 
     fun `test can attach application json files`() {
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
         val testProject = fileTree {
             dir("a") {
                 project("elm.json", """
@@ -75,10 +74,10 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                     }
                     """)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
                 dir("vendor") {
-                    elm("VendoredPackage.elm", "")
+                    elm("VendoredPackage.elm")
                 }
             }
         }.create(project, elmWorkspaceDirectory)
@@ -140,6 +139,9 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                         }
                     }
                     """)
+            dir("src") {
+                elm("Foo.elm")
+            }
         }.create(project, elmWorkspaceDirectory)
 
         val rootPath = testProject.root.pathAsPath
@@ -178,13 +180,13 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             dir("a") {
                 project("elm.json", BASIC_APPLICATION_MANIFEST)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
             }
             dir("b") {
                 project("elm.json", BASIC_APPLICATION_MANIFEST)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
             }
         }.create(project, elmWorkspaceDirectory)
@@ -212,7 +214,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         val testProject = fileTree {
             project("elm.json", BASIC_APPLICATION_MANIFEST)
             dir("src") {
-                elm("Main.elm", "")
+                elm("Main.elm")
             }
         }.create(project, elmWorkspaceDirectory)
 
@@ -226,7 +228,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
         fileTree {
             project("elm.json", """ { "BOGUS": "INVALID ELM.JSON" } """)
             dir("src") {
-                elm("Main.elm", "")
+                elm("Main.elm")
             }
         }.create(project, elmWorkspaceDirectory)
 
@@ -240,7 +242,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             dir("a") {
                 project("elm.json", BASIC_APPLICATION_MANIFEST)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
             }
         }.create(project, elmWorkspaceDirectory)
@@ -305,7 +307,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
             project("elm.json", BASIC_APPLICATION_MANIFEST)
             file("elm.intellij.json", """ { "BOGUS": "INVALID ELM.INTELLIJ.JSON" } """)
             dir("src") {
-                elm("Main.elm", "")
+                elm("Main.elm")
             }
         }.create(project, elmWorkspaceDirectory)
 
@@ -331,7 +333,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
                 if (sidecarManifestContent != null)
                     file("elm.intellij.json", sidecarManifestContent)
                 dir("src") {
-                    elm("Main.elm", "")
+                    elm("Main.elm")
                 }
             }
         }.create(project, elmWorkspaceDirectory)
@@ -366,8 +368,7 @@ private fun makeConstraint(low: Version, high: Version): Constraint {
 }
 
 /**
- * A basic minimal `elm.json` file for an application project, with no dependencies.
- * Used in tests which don't really care about the content of the file, just that it's a valid manifest.
+ * A minimal `elm.json` file for an application project.
  */
 private const val BASIC_APPLICATION_MANIFEST = """
 {
@@ -375,7 +376,10 @@ private const val BASIC_APPLICATION_MANIFEST = """
   "source-directories": [ "src" ],
   "elm-version": "0.19.1",
   "dependencies": {
-    "direct": {},
+    "direct": {
+        "elm/core": "1.0.0",
+        "elm/json": "1.0.0"
+    },
     "indirect": {}
   },
   "test-dependencies": {
@@ -386,19 +390,20 @@ private const val BASIC_APPLICATION_MANIFEST = """
 """
 
 /**
- * A basic minimal `elm.json` file for a package project, with no dependencies.
- * Used in tests which don't really care about the content of the file, just that it's a valid manifest.
+ * A minimal `elm.json` file for a package project.
  */
 private const val BASIC_PACKAGE_MANIFEST = """
 {
   "type": "package",
-  "name": "test",
-  "summary": "Test",
-  "license": "Test",
+  "name": "foo/bar",
+  "summary": "Example package",
+  "license": "MIT",
   "version": "1.2.3",
   "exposed-modules": [],
   "elm-version": "0.19.0 <= v < 0.20.0",
-  "dependencies": { },
+  "dependencies": {
+    "elm/core": "1.0.0 <= v < 2.0.0"
+  },
   "test-dependencies": { }
 }
 """

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -117,7 +117,6 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
     }
 
     fun `test can attach package json files`() {
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
         val testProject = fileTree {
             project("elm.json", """
                     {

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -37,12 +37,6 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
         return project.elmWorkspace.asyncDiscoverAndRefresh().thenApply { testProject }
     }
 
-    protected fun ensureElmStdlibInstalled(variant: ElmStdlibVariant) {
-        // IMPORTANT: do not use the returned `ElmProject` from [ensureElmStdlibInstalled] as it
-        // uses paths designed for IntelliJ's "light" tests (in-memory VFS).
-        variant.ensureElmStdlibInstalled(project, toolchain)
-    }
-
     override fun setUp() {
         super.setUp()
         originalToolchain = project.elmToolchain

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -24,26 +24,7 @@ interface ElmStdlibVariant {
     /**
      * Install Elm 0.19 stdlib in the default location ($HOME/.elm)
      */
-    fun ensureElmStdlibInstalled(project: Project, toolchain: ElmToolchain) {
-        val elmCLI = toolchain.elmCLI
-                ?: error("Must have a path to the Elm compiler to install Elm stdlib")
-
-        val compilerVersion = elmCLI.queryVersion().orNull()
-                ?: error("Could not query the Elm compiler version")
-        require(compilerVersion != Version(0, 18, 0))
-
-        // Create the dummy Elm project on-disk (real file system) and invoke the Elm compiler on it.
-        val onDiskTmpDir = LocalFileSystem.getInstance()
-                .refreshAndFindFileByIoFile(FileUtil.createTempDirectory("elm-stdlib-variant", null, true))
-                ?: error("Could not create on-disk temp dir for Elm stdlib installation")
-
-        fileTree {
-            project(ELM_JSON, jsonManifest)
-            file("Main.elm", elmHeadlessWorkerCode)
-        }.create(project, onDiskTmpDir)
-
-        elmCLI.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
-    }
+    fun ensureElmStdlibInstalled(project: Project, toolchain: ElmToolchain)
 }
 
 object EmptyElmStdlibVariant : ElmStdlibVariant {
@@ -102,95 +83,25 @@ object MinimalElmStdlibVariant : ElmStdlibVariant {
                 }
             }
             """.trimIndent()
+
+    override fun ensureElmStdlibInstalled(project: Project, toolchain: ElmToolchain) {
+        val elmCLI = toolchain.elmCLI
+                ?: error("Must have a path to the Elm compiler to install Elm stdlib")
+
+        val compilerVersion = elmCLI.queryVersion().orNull()
+                ?: error("Could not query the Elm compiler version")
+        require(compilerVersion != Version(0, 18, 0))
+
+        // Create the dummy Elm project on-disk (real file system) and invoke the Elm compiler on it.
+        val onDiskTmpDir = LocalFileSystem.getInstance()
+                .refreshAndFindFileByIoFile(FileUtil.createTempDirectory("elm-stdlib-variant", null, true))
+                ?: error("Could not create on-disk temp dir for Elm stdlib installation")
+
+        fileTree {
+            project(ELM_JSON, jsonManifest)
+            elm("Main.elm")
+        }.create(project, onDiskTmpDir)
+
+        elmCLI.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
+    }
 }
-
-
-/**
- * Allows for ad-hoc installation of Elm packages given by [extraDependencies]
- */
-class CustomElmStdlibVariant(val extraDependencies: Map<String, Version>) : ElmStdlibVariant {
-    override val jsonManifest: String
-        @Language("JSON")
-        get() {
-            val moreDirectDeps = extraDependencies
-                    .map { (pkgName, version) ->
-                        "\"${pkgName}\": \"${version}\""
-                    }.joinToString(",\n")
-            return """
-                    {
-                        "type": "application",
-                        "source-directories": [
-                            "."
-                        ],
-                        "elm-version": "0.19.1",
-                        "dependencies": {
-                            "direct": {
-                                "elm/core": "1.0.0",
-                                "elm/json": "1.0.0",
-                                ${moreDirectDeps}
-                            },
-                            "indirect": {}
-                        },
-                        "test-dependencies": {
-                            "direct": {},
-                            "indirect": {}
-                        }
-                    }
-                    """.trimIndent()
-        }
-}
-
-
-/**
- * Describes a "full" installation of the Elm stdlib, including all of the stuff that you need for a normal
- * Elm app including test dependencies.
- */
-object FullElmStdlibVariant : ElmStdlibVariant {
-    override val jsonManifest: String
-        @Language("JSON")
-        get() = """
-            {
-                "type": "application",
-                "source-directories": [
-                    "."
-                ],
-                "elm-version": "0.19.1",
-                "dependencies": {
-                    "direct": {
-                        "elm/core": "1.0.0",
-                        "elm/html": "1.0.0",
-                        "elm/json": "1.0.0",
-                        "elm/time": "1.0.0"
-                    },
-                    "indirect": {
-                        "elm/virtual-dom": "1.0.2"
-                    }
-                },
-                "test-dependencies": {
-                    "direct": {
-                        "elm-explorations/test": "1.0.0"
-                    },
-                    "indirect": {
-                        "elm/random": "1.0.0"
-                    }
-                }
-            }
-            """.trimIndent()
-}
-
-
-/**
- * A dummy Elm Main module necessary to get Elm to install the packages we want.
- */
-private val elmHeadlessWorkerCode = """
-        module Main exposing (..)
-        main =
-            Platform.worker { init = init , update = update , subscriptions = always Sub.none }
-
-        init : () -> ( Int, Cmd Msg )
-        init flags = ( 0, Cmd.none )
-
-        type Msg = Nop
-
-        update msg model = ( model, Cmd.none )
-        """.trimIndent()

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -7,6 +7,7 @@ import org.elm.fileTree
 import org.elm.openapiext.pathAsPath
 import org.elm.workspace.ElmToolchain.Companion.ELM_JSON
 import org.intellij.lang.annotations.Language
+import java.nio.file.Paths
 
 /*
 Some of the Elm tests depend on having certain Elm packages installed in the global location.
@@ -102,6 +103,6 @@ object MinimalElmStdlibVariant : ElmStdlibVariant {
             elm("Main.elm")
         }.create(project, onDiskTmpDir)
 
-        elmCLI.installDeps(project, onDiskTmpDir.pathAsPath.resolve("elm.json"))
+        elmCLI.make(project, onDiskTmpDir.pathAsPath, Paths.get("Main.elm"))
     }
 }

--- a/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
@@ -10,7 +10,6 @@ import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.TestActionEvent
 import junit.framework.TestCase
 import org.elm.workspace.ElmWorkspaceTestBase
-import org.elm.workspace.FullElmStdlibVariant
 import org.intellij.lang.annotations.Language
 import java.nio.file.Path
 
@@ -23,7 +22,6 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                     main = Html.text "hi"
                 """.trimIndent()
 
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
         buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
@@ -43,7 +41,6 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                     main = Html.text "hi"
                 """.trimIndent()
 
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
         buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
@@ -66,7 +63,6 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                         
                 """.trimIndent()
 
-        ensureElmStdlibInstalled(FullElmStdlibVariant)
         buildProject {
             project("elm.json", manifestElm19)
             dir("src") {

--- a/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
@@ -16,23 +16,21 @@ import java.nio.file.Path
 
 class ElmBuildActionTest : ElmWorkspaceTestBase() {
 
-    val caret = "{-caret-}"
-
     fun `test build Elm application project`() {
         val source = """
                     module Main exposing (..)
                     import Html
-                    main = Html.text "hi"$caret
+                    main = Html.text "hi"
                 """.trimIndent()
 
         ensureElmStdlibInstalled(FullElmStdlibVariant)
-        val fileWithCaret = buildProject {
+        buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", source)
             }
-        }.fileWithCaret
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        }
+        val file = myFixture.configureFromTempProjectFile("src/Main.elm").virtualFile
         doTest(file, expectedNumErrors = 0, expectedOffset = source.indexOf("main"))
     }
 
@@ -41,19 +39,19 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
         val source = """
                     module Main exposing (..)
                     import Html
-                    foo = bogus$caret
+                    foo = bogus
                     main = Html.text "hi"
                 """.trimIndent()
 
         ensureElmStdlibInstalled(FullElmStdlibVariant)
-        val fileWithCaret = buildProject {
+        buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
                 elm("Main.elm", source)
             }
-        }.fileWithCaret
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
-        doTest(file, expectedNumErrors = 1, expectedOffset = source.indexOf("main") - caret.length)
+        }
+        val file = myFixture.configureFromTempProjectFile("src/Main.elm").virtualFile
+        doTest(file, expectedNumErrors = 1, expectedOffset = source.indexOf("main"))
     }
 
     fun `test build Elm project ignores nested function named 'main'`() {
@@ -62,20 +60,20 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                     import Html
                     foo =
                         let
-                            main = Html.text "hi"$caret
+                            main = Html.text "hi"
                         in
                         main
                         
                 """.trimIndent()
 
         ensureElmStdlibInstalled(FullElmStdlibVariant)
-        val fileWithCaret = buildProject {
+        buildProject {
             project("elm.json", manifestElm19)
             dir("src") {
                 elm("Foo.elm", source)
             }
-        }.fileWithCaret
-        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        }
+        val file = myFixture.configureFromTempProjectFile("src/Foo.elm").virtualFile
         doTestShowsErrorBalloon(file, "Cannot find your Elm app's main entry point")
     }
 


### PR DESCRIPTION
Previously, the plugin assumed that you had already installed the dependencies in your `elm.json` file. Now we will automatically install any dependences in the `elm.json` when you attach it to the workspace *or* when you click the "Refresh" button in the Elm workspace panel.

This change also allowed me to significantly simplify how the integration tests can specify which packages they depend on and ensure that they are installed before the test runs.