### PR TITLE
Update the default `elm.json` template

### DIFF
--- a/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
+++ b/src/main/kotlin/org/elm/ide/project/ElmModuleBuilder.kt
@@ -152,7 +152,7 @@ private class ElmProjectWizardStep(val context: WizardContext) : ModuleWizardSte
 }
 
 /**
- * As-of 2019-02-09, this is the standard `elm.json` file created by `elm init`.
+ * As-of 2020-08-25, this is the standard `elm.json` file created by `elm init`.
  * I would just run `elm init`, but it prompts the user for input, and there is
  * no flag to override that behavior.
  *
@@ -161,29 +161,30 @@ private class ElmProjectWizardStep(val context: WizardContext) : ModuleWizardSte
 @Language("JSON")
 val elmJson = """
     {
-        "type": "application",
-        "source-directories": [
-            "src"
-        ],
-        "elm-version": "0.19.1",
-        "dependencies": {
-            "direct": {
-                "elm/browser": "1.0.1",
-                "elm/core": "1.0.2",
-                "elm/html": "1.0.0"
-            },
-            "indirect": {
-                "elm/json": "1.1.2",
-                "elm/time": "1.0.0",
-                "elm/url": "1.0.0",
-                "elm/virtual-dom": "1.0.2"
-            }
+      "type": "application",
+      "source-directories": [
+        "src"
+      ],
+      "elm-version": "0.19.1",
+      "dependencies": {
+        "direct": {
+          "elm/browser": "1.0.2",
+          "elm/core": "1.0.5",
+          "elm/html": "1.0.0"
         },
-        "test-dependencies": {
-            "direct": {},
-            "indirect": {}
+        "indirect": {
+          "elm/json": "1.1.3",
+          "elm/time": "1.0.0",
+          "elm/url": "1.0.0",
+          "elm/virtual-dom": "1.0.2"
         }
-    }""".trimIndent()
+      },
+      "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+      }
+    }
+    """.trimIndent()
 
 
 /**


### PR DESCRIPTION
Temporary fix until we can delegate the creation of the `elm.json` to `elm init` CLI.

Fixes #609 