### PR TITLE
Add intentions for converting between regular and triple-quoted strings.

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/RegularToTripleQuotedStringIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RegularToTripleQuotedStringIntention.kt
@@ -1,0 +1,38 @@
+package org.elm.ide.intentions
+
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+import org.elm.lang.core.psi.elements.TRIPLE_QUOTE_STRING_DELIMITER
+
+/**
+ * An intention which converts regular strings to triple-quoted strings, e.g. replaces this:
+ * ```
+ *     example =
+ *         "foo\nbar"
+ * ```
+ * with this:
+ * ```
+ *     example =
+ *         """foo
+ *     bar"""
+ * ```
+ */
+class RegularToTripleQuotedStringIntention : StringDelimiterIntention(TRIPLE_QUOTE_STRING_DELIMITER) {
+
+    override fun getText() = "Convert to triple-quoted string"
+
+    override val ElmStringConstantExpr.isValidForReplacement: Boolean
+        get() = !isTripleQuoted
+
+    override fun getReplacement(source: String): String {
+        val replacement = source
+            // Replace \n with an actual line separator as they don't need to be escaped in triple-quoted strings.
+            .replace(SLASH_N, System.lineSeparator())
+            // Replace \" with double-quotes without the backslash as they don't need to be escaped either.
+            .replace(ESCAPED_DOUBLE_QUOTE, DOUBLE_QUOTE)
+
+        // There is one exception to the comment above: if a string ends in a double-quote, the last double-quotes need
+        // to be escaped.
+        return if (replacement.endsWith(DOUBLE_QUOTE)) replacement.removeSuffix(DOUBLE_QUOTE) + ESCAPED_DOUBLE_QUOTE
+        else replacement
+    }
+}

--- a/src/main/kotlin/org/elm/ide/intentions/StringDelimiterIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/StringDelimiterIntention.kt
@@ -1,0 +1,55 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.ancestors
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+
+/**
+ * Abstract base class for intentions which handle conversions between triple-quoted and regular strings.
+ *
+ * @param targetDelimiter The delimiter to use in the new string literal created by this intention.
+ */
+abstract class StringDelimiterIntention(private val targetDelimiter: String) :
+    ElmAtCaretIntentionActionBase<StringDelimiterIntention.Context>() {
+
+    data class Context(val stringConstant: ElmStringConstantExpr)
+
+    override fun getFamilyName() = text
+
+    /**
+     * Indicates whether `this` [ElmStringConstantExpr] is valid for replacement using this intention.
+     */
+    protected abstract val ElmStringConstantExpr.isValidForReplacement: Boolean
+
+    /**
+     * Gets the string to use to replace `source`, where `source` is the content of the [ElmStringConstantExpr] (i.e.
+     * the text inside its delimiters/quotes).
+     */
+    abstract fun getReplacement(source: String): String
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement) =
+        element.ancestors.filterIsInstance<ElmStringConstantExpr>()
+            .firstOrNull()
+            ?.takeIf { it.isValidForReplacement }
+            ?.let { Context(it) }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        val newString =
+            ElmPsiFactory(project).createStringConstant(
+                "$targetDelimiter${getReplacement(context.stringConstant.textContent)}$targetDelimiter"
+            )
+        context.stringConstant.replace(newString)
+    }
+
+    companion object {
+        @JvmStatic
+        protected val DOUBLE_QUOTE = "\""
+        @JvmStatic
+        protected val ESCAPED_DOUBLE_QUOTE = "\\\""
+        @JvmStatic
+        protected val SLASH_N = "\\n"
+    }
+}

--- a/src/main/kotlin/org/elm/ide/intentions/TripleQuotedToRegularStringIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/TripleQuotedToRegularStringIntention.kt
@@ -1,0 +1,41 @@
+package org.elm.ide.intentions
+
+import org.elm.lang.core.psi.elements.ElmStringConstantExpr
+import org.elm.lang.core.psi.elements.REGULAR_STRING_DELIMITER
+
+/**
+ * An intention which converts triple-quoted string to regular strings, e.g. replaces this:
+ * ```
+ *     example =
+ *         """foo
+ *     bar"""
+ * ```
+ * with this:
+ * ```
+ *     example =
+ *         "foo\nbar"
+ * ```
+ */
+class TripleQuotedToRegularStringIntention : StringDelimiterIntention(REGULAR_STRING_DELIMITER) {
+
+    override fun getText() = "Convert to regular string"
+
+    override val ElmStringConstantExpr.isValidForReplacement: Boolean
+        get() = isTripleQuoted
+
+    override fun getReplacement(source: String): String {
+        // In triple-quoted strings, double-quotes don't need to be escaped, unless this is the last character.
+        // So if this ends with an escaped double-quote, replace it with a unescaped double-quote so it's the same
+        // as the rest of the double quotes which we'll escape soon.
+        return source
+            .unescapeLastDoubleQuote()
+            // Replace line separators with "\n" as they need to be escaped in regular strings
+            .replace(System.lineSeparator(), SLASH_N)
+            // Escape double-quotes.
+            .replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)
+    }
+
+    private fun String.unescapeLastDoubleQuote() =
+        if (endsWith(ESCAPED_DOUBLE_QUOTE)) removeSuffix(ESCAPED_DOUBLE_QUOTE) + DOUBLE_QUOTE
+        else this
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmStringConstantExpr.kt
@@ -4,6 +4,37 @@ import com.intellij.lang.ASTNode
 import org.elm.lang.core.psi.ElmConstantTag
 import org.elm.lang.core.psi.ElmPsiElementImpl
 
+/**
+ * The double-quote character used to delimit regular (non-triple-quoted) strings.
+ */
+const val REGULAR_STRING_DELIMITER = "\""
+
+/**
+ * The three double-quote characters used to delimit triple-quoted strings. See [ElmStringConstantExpr.isTripleQuoted]
+ * for more info on this.
+ */
+const val TRIPLE_QUOTE_STRING_DELIMITER = "\"\"\""
 
 /** A literal string. e.g. `""` or `"""a"b"""` */
-class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmConstantTag
+class ElmStringConstantExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmConstantTag {
+
+    /**
+     * Indicates whether this is a "triple-quoted" string, i.e. a string with `"""` as its delimiters. Typically this is
+     * used for multi-line strings, but it doesn't have to be: it can be used for single line strings as the text within
+     * it can contain double-quotes without needing to escape them.
+     */
+    val isTripleQuoted: Boolean
+        get() = node.text.startsWith(TRIPLE_QUOTE_STRING_DELIMITER) &&
+                node.text.endsWith(TRIPLE_QUOTE_STRING_DELIMITER) &&
+                node.text.length >= 6
+
+    /**
+     * The content of this string constant, i.e. the text inside its delimiters/quotes.
+     */
+    val textContent: String
+        get() {
+            val delimiter = if (isTripleQuoted) TRIPLE_QUOTE_STRING_DELIMITER else REGULAR_STRING_DELIMITER
+            val delimiterLength = delimiter.length
+            return node.text.substring(delimiterLength, node.text.length - delimiterLength)
+        }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -410,6 +410,14 @@
             <category>Elm</category>
         </intentionAction>
         <intentionAction>
+            <className>org.elm.ide.intentions.RegularToTripleQuotedStringIntention</className>
+            <category>Elm</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.elm.ide.intentions.TripleQuotedToRegularStringIntention</className>
+            <category>Elm</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.elm.ide.intentions.MakeAnnotationIntention</className>
             <category>Elm</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/RegularToTripleQuotedStringIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/RegularToTripleQuotedStringIntention/after.elm.template
@@ -1,0 +1,5 @@
+module Example exposing (example)
+
+example =
+    """foo
+bar"""

--- a/src/main/resources/intentionDescriptions/RegularToTripleQuotedStringIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/RegularToTripleQuotedStringIntention/before.elm.template
@@ -1,0 +1,4 @@
+module Example exposing (example)
+
+example =
+    "foo\nbar"

--- a/src/main/resources/intentionDescriptions/RegularToTripleQuotedStringIntention/description.html
+++ b/src/main/resources/intentionDescriptions/RegularToTripleQuotedStringIntention/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Turn a regular string into a triple-quoted string. This lets you create potentially multi-line strings with unescaped quotes and newlines.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/TripleQuotedToRegularStringIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/TripleQuotedToRegularStringIntention/after.elm.template
@@ -1,0 +1,4 @@
+module Example exposing (example)
+
+example =
+    "foo\nbar"

--- a/src/main/resources/intentionDescriptions/TripleQuotedToRegularStringIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/TripleQuotedToRegularStringIntention/before.elm.template
@@ -1,0 +1,5 @@
+module Example exposing (example)
+
+example =
+    """foo
+bar"""

--- a/src/main/resources/intentionDescriptions/TripleQuotedToRegularStringIntention/description.html
+++ b/src/main/resources/intentionDescriptions/TripleQuotedToRegularStringIntention/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Turn a triple-quoted string into a regular string. This will escape any quotes and newlines in the existing string.
+</body>
+</html>

--- a/src/test/kotlin/org/elm/ide/intentions/RegularToTripleQuotedStringIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/RegularToTripleQuotedStringIntentionTest.kt
@@ -1,0 +1,91 @@
+package org.elm.ide.intentions
+
+import org.elm.lang.core.psi.elements.TRIPLE_QUOTE_STRING_DELIMITER
+
+class RegularToTripleQuotedStringIntentionTest : ElmIntentionTestBase(RegularToTripleQuotedStringIntention()) {
+
+    // Note that because Kotlin and Elm both use """, we can't put """ in the embedded Elm code snippets below, as the
+    // Kotlin compiler assumes these terminate the Kotlin string literal. And raw Kotlin string literals can't have
+    // escape characters in them. So instead use the TRIPLE_QUOTE_STRING_DELIMITER constant.
+
+    fun `test converts non-empty regular string to triple-quoted string`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                "ab{-caret-}cd"
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                ${TRIPLE_QUOTE_STRING_DELIMITER}abcd$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent()
+    )
+
+    fun `test converts empty regular string to triple-quoted string`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                "{-caret-}"
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                ${TRIPLE_QUOTE_STRING_DELIMITER}$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent()
+    )
+
+    fun `test converts white-space only regular string to triple-quoted string`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                "  {-caret-}   "
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                $TRIPLE_QUOTE_STRING_DELIMITER     $TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent()
+    )
+
+    fun `test converts carriage returns and quotes`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                "foo\n\"bar\"{-caret-} baz"
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                ${TRIPLE_QUOTE_STRING_DELIMITER}foo
+            "bar" baz$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent()
+    )
+
+    // If string ends in quotes then when converted to triple-quoted string, the last quote should be escaped, but any
+    // other quotes shouldn't.
+    fun `test quotes in text`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                "\"fo{-caret-}\"o\""
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                $TRIPLE_QUOTE_STRING_DELIMITER"fo"o\"$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent()
+    )
+
+    fun `test unavailable for triple-quoted string`() = doUnavailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                ${TRIPLE_QUOTE_STRING_DELIMITER}ab{-caret-}cd$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent()
+    )
+}

--- a/src/test/kotlin/org/elm/ide/intentions/TripleQuotedToRegularStringIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/TripleQuotedToRegularStringIntentionTest.kt
@@ -1,0 +1,90 @@
+package org.elm.ide.intentions
+
+import org.elm.lang.core.psi.elements.TRIPLE_QUOTE_STRING_DELIMITER
+
+class TripleQuotedToRegularStringIntentionTest : ElmIntentionTestBase(TripleQuotedToRegularStringIntention()) {
+
+    // Note that because Kotlin and Elm both use """, we can't put """ in the embedded Elm code snippets below, as the
+    // Kotlin compiler assumes these terminate the Kotlin string literal. And raw Kotlin string literals can't have
+    // escape characters in them. So instead use the TRIPLE_QUOTE_STRING_DELIMITER constant.
+
+    fun `test converts non-empty triple-quoted string to regular string`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                ${TRIPLE_QUOTE_STRING_DELIMITER}ab{-caret-}cd$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                "abcd"
+        """.trimIndent()
+    )
+
+    fun `test converts empty triple-quoted string to regular string`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                $TRIPLE_QUOTE_STRING_DELIMITER{-caret-}$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                ""
+        """.trimIndent()
+    )
+
+    fun `test converts white-space only triple-quoted string to regular string`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                $TRIPLE_QUOTE_STRING_DELIMITER  {-caret-}   $TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                "     "
+        """.trimIndent()
+    )
+
+    fun `test converts carriage returns and quotes`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                ${TRIPLE_QUOTE_STRING_DELIMITER}foo
+            "bar"{-caret-} baz$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                "foo\n\"bar\" baz"
+        """.trimIndent()
+    )
+
+    // Last quote in a triple-quoted string is escaped, the rest aren't.
+    fun `test quotes in text`() = doAvailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                $TRIPLE_QUOTE_STRING_DELIMITER"fo{-caret-}"o\"$TRIPLE_QUOTE_STRING_DELIMITER
+        """.trimIndent(),
+
+        """
+            module Foo exposing (s0)
+            s0 =
+                "\"fo\"o\""
+        """.trimIndent()
+    )
+
+    fun `test unavailable for regular-quoted string`() = doUnavailableTest(
+        """
+            module Foo exposing (s0)
+            s0 =
+                "ab{-caret-}cd"
+        """.trimIndent()
+    )
+}


### PR DESCRIPTION
Closes #690.

Hi Keith. As discussed here's a PR for the refactoring intentions to convert between regular and triple-quoted strings. Some points for your consideration when reviewing:
* I haven't done anything with the caret position. If we decide this should be included here, it will add some complexity, particularly in multi-line strings, so we'll need to decide if that's worthwhile or not.
* In terms of terminology, I went with "regular string" and "triple-quoted string", but happy to change this to something else (e.g. "multi-line string") if you prefer. I decided against multi-line string as it doesn't necessarily have to have multiple lines, but I'm aware that generally this is the most common usage of triple-quotes.
* I added a couple of properties into `ElmStringConstantExpr` so this class now knows a bit about delimiters. If you prefer we can move these into the intention-related code (e.g. as extension properties there). From looking at some of the other classes it looked like it was OK for this type of class to have knowledge of such things, so I went with this approach, but happy to move if you have a different preference.
* I've used `System.lineSeparator` when building up mutli-line strings: is this right, or should we just use `\n`?

@dillonkearns, fyi. Any comments/suggestions welcome as always.