### PR TITLE
Allow elm-format to run on-save even if there are syntax errors

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -1,6 +1,5 @@
 package org.elm.ide.actions
 
-import com.intellij.execution.ExecutionException
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -9,19 +8,17 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.notifications.showBalloon
 import org.elm.lang.core.psi.isElmFile
 import org.elm.openapiext.isUnitTestMode
 import org.elm.workspace.Version
 import org.elm.workspace.commandLineTools.ElmFormatCLI
+import org.elm.workspace.commandLineTools.ElmFormatCLI.ElmFormatResult
 import org.elm.workspace.elmToolchain
 import org.elm.workspace.elmWorkspace
 
 
 class ElmExternalFormatAction : AnAction() {
-
 
     override fun update(e: AnActionEvent) {
         super.update(e)
@@ -35,24 +32,27 @@ class ElmExternalFormatAction : AnAction() {
             return
         }
 
-        val fixAction = "Fix" to { ctx.project.elmWorkspace.showConfigureToolchainUI() }
+        val project = ctx.project
+        val configureFixAction = "Configure" to { project.elmWorkspace.showConfigureToolchainUI() }
 
-        val elmFormat = ctx.project.elmToolchain.elmFormatCLI
+        val elmFormat = project.elmToolchain.elmFormatCLI
         if (elmFormat == null) {
-            ctx.project.showBalloon("Could not find elm-format", NotificationType.ERROR, fixAction)
+            project.showBalloon("Could not find elm-format", NotificationType.ERROR, configureFixAction)
             return
         }
 
-        try {
-            elmFormat.formatDocumentAndSetText(ctx.project, ctx.document, ctx.elmVersion, addToUndoStack = true)
-        } catch (ex: ExecutionException) {
-            if (isUnitTestMode) throw ex
-            val message = ex.message ?: "something went wrong running elm-format"
-            if (message.contains("SYNTAX PROBLEM", ignoreCase = true)) {
-                ctx.project.showBalloon("Please fix the syntax errors before running elm-format.", NotificationType.WARNING)
-            } else {
-                ctx.project.showBalloon(message, NotificationType.ERROR, fixAction)
-            }
+        when (val result = elmFormat.formatDocumentAndSetText(project, ctx.document, ctx.elmVersion, addToUndoStack = true)) {
+            is ElmFormatResult.BadSyntax ->
+                project.showBalloon(result.msg, NotificationType.WARNING)
+
+            is ElmFormatResult.FailedToStart ->
+                project.showBalloon(result.msg, NotificationType.ERROR, configureFixAction)
+
+            is ElmFormatResult.UnknownFailure ->
+                project.showBalloon(result.msg, NotificationType.ERROR)
+
+            is ElmFormatResult.Success ->
+                return
         }
     }
 

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -1,13 +1,17 @@
 package org.elm.ide.components
 
 import com.intellij.AppTopics
+import com.intellij.ide.DataManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.project.Project
+import org.elm.ide.notifications.executeAction
 import org.elm.ide.notifications.showBalloon
 import org.elm.lang.core.psi.isElmFile
 import org.elm.workspace.commandLineTools.ElmFormatCLI
@@ -32,11 +36,17 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                         val elmVersion = ElmFormatCLI.getElmVersion(project, vFile) ?: return
                         val elmFormat = project.elmToolchain.elmFormatCLI ?: return
 
+                        val editor = EditorFactory.getInstance().getEditors(document).first()
+
                         val result = elmFormat.formatDocumentAndSetText(project, document, elmVersion, addToUndoStack = false)
 
                         when (result) {
-                            is ElmFormatResult.BadSyntax ->
-                                project.showBalloon(result.msg, NotificationType.WARNING)
+                            is ElmFormatResult.BadSyntax -> {
+                                project.showBalloon(result.msg, NotificationType.WARNING, "Show Errors" to {
+                                    val action = ActionManager.getInstance().getAction("Elm.Build")!!
+                                    executeAction(action, "elm-format-notif", DataManager.getInstance().getDataContext(editor.component))
+                                })
+                            }
 
                             is ElmFormatResult.FailedToStart ->
                                 project.showBalloon(result.msg, NotificationType.ERROR, "Configure" to { project.elmWorkspace.showConfigureToolchainUI() })

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -1,8 +1,6 @@
 package org.elm.ide.components
 
 import com.intellij.AppTopics
-import com.intellij.execution.ExecutionException
-import com.intellij.execution.process.ProcessNotCreatedException
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ProjectComponent
@@ -10,12 +8,10 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.notifications.showBalloon
 import org.elm.lang.core.psi.isElmFile
-import org.elm.openapiext.isUnitTestMode
 import org.elm.workspace.commandLineTools.ElmFormatCLI
+import org.elm.workspace.commandLineTools.ElmFormatCLI.ElmFormatResult
 import org.elm.workspace.elmSettings
 import org.elm.workspace.elmToolchain
 import org.elm.workspace.elmWorkspace
@@ -30,29 +26,26 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                 AppTopics.FILE_DOCUMENT_SYNC,
                 object : FileDocumentManagerListener {
                     override fun beforeDocumentSaving(document: Document) {
-
                         if (!project.elmSettings.toolchain.isElmFormatOnSaveEnabled) return
-
-                        val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document) ?: return
-                        if (PsiTreeUtil.hasErrorElements(psiFile)) return
-
                         val vFile = FileDocumentManager.getInstance().getFile(document) ?: return
                         if (!vFile.isElmFile) return
-
                         val elmVersion = ElmFormatCLI.getElmVersion(project, vFile) ?: return
                         val elmFormat = project.elmToolchain.elmFormatCLI ?: return
 
-                        try {
-                            elmFormat.formatDocumentAndSetText(project, document, elmVersion, addToUndoStack = false)
-                        } catch (e: ExecutionException) {
-                            if (isUnitTestMode) throw e
-                            val message = e.message ?: "Something went wrong running elm-format"
-                            val actions = when (e) {
-                                is ProcessNotCreatedException ->
-                                    arrayOf("Fix Path" to { project.elmWorkspace.showConfigureToolchainUI() })
-                                else -> emptyArray()
-                            }
-                            project.showBalloon(message, NotificationType.ERROR, *actions)
+                        val result = elmFormat.formatDocumentAndSetText(project, document, elmVersion, addToUndoStack = false)
+
+                        when (result) {
+                            is ElmFormatResult.BadSyntax ->
+                                project.showBalloon(result.msg, NotificationType.WARNING)
+
+                            is ElmFormatResult.FailedToStart ->
+                                project.showBalloon(result.msg, NotificationType.ERROR, "Configure" to { project.elmWorkspace.showConfigureToolchainUI() })
+
+                            is ElmFormatResult.UnknownFailure ->
+                                project.showBalloon(result.msg, NotificationType.ERROR)
+
+                            is ElmFormatResult.Success ->
+                                return
                         }
                     }
                 }

--- a/src/main/kotlin/org/elm/ide/notifications/Utils.kt
+++ b/src/main/kotlin/org/elm/ide/notifications/Utils.kt
@@ -11,6 +11,10 @@ import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.project.Project
 
 private val pluginNotifications = NotificationGroup.balloonGroup("Elm Plugin")
@@ -30,14 +34,26 @@ fun Project.showBalloon(
         vararg actions: Pair<String, (() -> Unit)>
 ) {
     val notification = pluginNotifications.createNotification(content, type)
-    for ((actionTitle, actionCallback) in actions) {
+    actions.forEach { (title, fn) ->
         notification.addAction(
-                NotificationAction.create(actionTitle)
-                { _, notif ->
+                NotificationAction.create(title) { _, notif ->
                     notif.hideBalloon()
-                    actionCallback()
+                    fn()
                 }
         )
     }
     Notifications.Bus.notify(notification, this)
+}
+
+fun executeAction(action: AnAction, place: String, dataContext: DataContext) {
+    val event = AnActionEvent.createFromAnAction(action, null, place, dataContext)
+    action.beforeActionPerformedUpdate(event)
+    action.update(event)
+
+    if (event.presentation.isEnabled && event.presentation.isVisible) {
+        val actionManager = ActionManagerEx.getInstanceEx()
+        actionManager.fireBeforeActionPerformed(action, event.dataContext, event)
+        action.actionPerformed(event)
+        actionManager.fireAfterActionPerformed(action, event.dataContext, event)
+    }
 }

--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -35,9 +35,7 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.io.systemIndependentPath
-import java.io.BufferedWriter
 import java.io.OutputStreamWriter
-import java.nio.charset.Charset
 import java.nio.file.Path
 
 private val log = Logger.getInstance("org.elm.openapiext.Subprocesses")
@@ -130,3 +128,6 @@ private fun errorMessage(commandLine: GeneralCommandLine, output: ProcessOutput)
 
 val ProcessOutput.isSuccess: Boolean
     get() = !isTimeout && !isCancelled && exitCode == 0
+
+val ProcessOutput.isNotSuccess: Boolean
+    get() = !isSuccess

--- a/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
+++ b/src/test/kotlin/org/elm/ide/actions/ElmExternalFormatActionTest.kt
@@ -101,7 +101,8 @@ class ElmExternalFormatActionTest : ElmWorkspaceTestBase() {
     private fun makeTestAction(file: VirtualFile): Pair<ElmExternalFormatAction, TestActionEvent> {
         val dataContext = MapDataContext(mapOf(
                 CommonDataKeys.PROJECT to project,
-                CommonDataKeys.VIRTUAL_FILE to file
+                CommonDataKeys.VIRTUAL_FILE to file,
+                CommonDataKeys.EDITOR to editor
         ))
         val action = ElmExternalFormatAction()
         val event = TestActionEvent(dataContext, action)

--- a/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
+++ b/src/test/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponentTest.kt
@@ -101,28 +101,6 @@ class ElmFormatOnFileSaveComponentTest : ElmWorkspaceTestBase() {
         )
     }
 
-    fun `test ElmFormatOnFileSaveComponent should not touch a file syntax errors`() {
-        val brokenElmCode = """
-                    m0dule Main exposing (f)
-
-
-                    f x = x
-
-                """.trimIndent()
-        buildProject {
-            project("elm.json", manifestElm19)
-            dir("src") {
-                elm("Main.elm", brokenElmCode)
-            }
-        }
-
-        testCorrectFormatting(
-                "src/Main.elm",
-                brokenElmCode,
-                expected = brokenElmCode
-        )
-    }
-
     private fun testCorrectFormatting(fileWithCaret: String, unformatted: String, expected: String, activateOnSaveHook: Boolean = true) {
 
         project.elmWorkspace.useToolchain(toolchain.copy(isElmFormatOnSaveEnabled = activateOnSaveHook))


### PR DESCRIPTION
Fixes #628 