### PR TITLE
Fix bug where compiler panel always showed 0 errors first time

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalFormatAction.kt
@@ -2,7 +2,11 @@ package org.elm.ide.actions
 
 import com.intellij.ide.DataManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -13,6 +17,7 @@ import org.elm.openapiext.isUnitTestMode
 import org.elm.workspace.Version
 import org.elm.workspace.commandLineTools.ElmFormatCLI
 import org.elm.workspace.commandLineTools.ElmFormatCLI.ElmFormatResult
+import org.elm.workspace.compiler.ELM_BUILD_ACTION_ID
 import org.elm.workspace.elmToolchain
 import org.elm.workspace.elmWorkspace
 
@@ -47,7 +52,7 @@ class ElmExternalFormatAction : AnAction() {
         when (result) {
             is ElmFormatResult.BadSyntax -> {
                 project.showBalloon(result.msg, NotificationType.WARNING, "Show Errors" to {
-                    val action = ActionManager.getInstance().getAction("Elm.Build")!!
+                    val action = ActionManager.getInstance().getAction(ELM_BUILD_ACTION_ID)!!
                     executeAction(action, "elm-format-notif", DataManager.getInstance().getDataContext(editor.component))
                 })
             }

--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -16,6 +16,7 @@ import org.elm.ide.notifications.showBalloon
 import org.elm.lang.core.psi.isElmFile
 import org.elm.workspace.commandLineTools.ElmFormatCLI
 import org.elm.workspace.commandLineTools.ElmFormatCLI.ElmFormatResult
+import org.elm.workspace.compiler.ELM_BUILD_ACTION_ID
 import org.elm.workspace.elmSettings
 import org.elm.workspace.elmToolchain
 import org.elm.workspace.elmWorkspace
@@ -43,7 +44,7 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                         when (result) {
                             is ElmFormatResult.BadSyntax -> {
                                 project.showBalloon(result.msg, NotificationType.WARNING, "Show Errors" to {
-                                    val action = ActionManager.getInstance().getAction("Elm.Build")!!
+                                    val action = ActionManager.getInstance().getAction(ELM_BUILD_ACTION_ID)!!
                                     executeAction(action, "elm-format-notif", DataManager.getInstance().getDataContext(editor.component))
                                 })
                             }

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
@@ -5,7 +5,11 @@ import com.intellij.ide.OccurenceNavigator
 import com.intellij.ide.OccurenceNavigator.OccurenceInfo
 import com.intellij.ide.util.PsiNavigationSupport
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
@@ -26,6 +30,7 @@ import com.intellij.ui.table.JBTable
 import org.elm.openapiext.checkIsEventDispatchThread
 import org.elm.openapiext.findFileByPath
 import org.elm.openapiext.toPsiFile
+import org.elm.workspace.compiler.ELM_BUILD_ACTION_ID
 import org.elm.workspace.compiler.ElmBuildAction
 import org.elm.workspace.compiler.ElmError
 import org.elm.workspace.compiler.Region
@@ -36,8 +41,14 @@ import java.awt.Component
 import java.awt.Dimension
 import java.awt.font.TextAttribute
 import java.nio.file.Path
-import javax.swing.*
-import javax.swing.ScrollPaneConstants.*
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JTable
+import javax.swing.JTextPane
+import javax.swing.ListSelectionModel
+import javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED
+import javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+import javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED
 import javax.swing.border.EmptyBorder
 import javax.swing.table.DefaultTableCellRenderer
 import javax.swing.table.DefaultTableModel
@@ -174,7 +185,7 @@ class ElmCompilerPanel(
         val compilerPanel = this
         val toolbar = with(ActionManager.getInstance()) {
             val buttonGroup = DefaultActionGroup().apply {
-                add(getAction("Elm.Build"))
+                add(getAction(ELM_BUILD_ACTION_ID))
                 addSeparator()
                 add(CommonActionsManager.getInstance().createNextOccurenceAction(compilerPanel))
                 add(CommonActionsManager.getInstance().createPrevOccurenceAction(compilerPanel))


### PR DESCRIPTION
Tool windows are lazily initialized when shown. And since the compiler panel tool
window does not subscribe to the bus until initialized, we must be careful to
wait to post the notification until the subscription has occurred.