### PR TITLE
Elm Compiler panel: show how `elm make` was invoked

### DIFF
--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
@@ -249,12 +249,8 @@ class ElmCompilerPanel(
         if (compilerMessages.isEmpty()) return null
 
         val nextIndex = when (direction) {
-            is OccurenceDirection.Forward -> if (selectedCompilerMessage < compilerMessages.lastIndex)
-                selectedCompilerMessage + 1
-            else return null
-            is OccurenceDirection.Back -> if (selectedCompilerMessage > 0)
-                selectedCompilerMessage - 1
-            else return null
+            is OccurenceDirection.Forward -> selectedCompilerMessage + 1
+            is OccurenceDirection.Back -> selectedCompilerMessage - 1
         }
 
         val elmError = compilerMessages.getOrNull(nextIndex) ?: return null

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerPanel.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.util.text.StringUtil.pluralize
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -201,7 +202,8 @@ class ElmCompilerPanel(
                     selectedCompilerMessage = 0
                     tableUI.setRowSelectionInterval(0, 0)
 
-                    contentManager.getContent(0)?.displayName = "${compilerMessages.size} errors"
+                    val numErrors = compilerMessages.size
+                    contentManager.getContent(0)?.displayName = "$numErrors ${pluralize("error", numErrors)}"
 
                     entryPointLabel.text = "$baseDirPath: elm make"
                     entryPointLink.text = targetPath

--- a/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmBuildAction.kt
@@ -57,12 +57,23 @@ class ElmBuildAction : AnAction() {
         val (filePathToCompile, targetPath, offset) = when (elmProject) {
             is ElmApplicationProject -> {
                 val mainEntryPoint = findMainEntryPoint(project, elmProject)
-                mainEntryPoint?.containingFile?.virtualFile?.let { Triple(it.pathAsPath, VfsUtilCore.getRelativePath(it, projectDir), mainEntryPoint.textOffset) }
+                mainEntryPoint?.containingFile?.virtualFile
+                        ?.let {
+                            Triple(
+                                    it.pathAsPath,
+                                    VfsUtilCore.getRelativePath(it, projectDir),
+                                    mainEntryPoint.textOffset
+                            )
+                        }
                         ?: return showError(project, "Cannot find your Elm app's main entry point. Please make sure that it has a type annotation.")
             }
 
             is ElmPackageProject ->
-                Triple(activeFile.pathAsPath, VfsUtilCore.getRelativePath(activeFile, projectDir), 0)
+                Triple(
+                        activeFile.pathAsPath,
+                        VfsUtilCore.getRelativePath(activeFile, projectDir),
+                        0
+                )
         }
 
         val json = try {
@@ -81,7 +92,7 @@ class ElmBuildAction : AnAction() {
         }
 
         fun postErrors() = project.messageBus.syncPublisher(ERRORS_TOPIC)
-                .update(elmProject.projectDirPath, messages, targetPath, offset)
+                .update(elmProject.projectDirPath, messages, targetPath!!, offset)
 
         when {
             isUnitTestMode -> postErrors()
@@ -115,7 +126,7 @@ class ElmBuildAction : AnAction() {
     }
 
     interface ElmErrorsListener {
-        fun update(baseDirPath: Path, messages: List<ElmError>, targetPath: String?, offset: Int)
+        fun update(baseDirPath: Path, messages: List<ElmError>, targetPath: String, offset: Int)
     }
 
     companion object {

--- a/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
@@ -78,7 +78,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
         var succeeded = false
         with(project.messageBus.connect(testRootDisposable)) {
             subscribe(ElmBuildAction.ERRORS_TOPIC, object : ElmBuildAction.ElmErrorsListener {
-                override fun update(baseDirPath: Path, messages: List<ElmError>, targetPath: String?, offset: Int) {
+                override fun update(baseDirPath: Path, messages: List<ElmError>, targetPath: String, offset: Int) {
                     TestCase.assertEquals(expectedNumErrors, messages.size)
                     TestCase.assertEquals("src/Main.elm", targetPath)
                     TestCase.assertEquals(expectedOffset, offset)


### PR DESCRIPTION
This feature was partially implemented, but never finished.

### Changes
- shows the file which we passed to `elm make`, even if there are 0 errors
- shows the project directory in which we ran `elm make`
- re-wrote a lot of the code for clarity
- slight improvements to the UI