### PR TITLE
Complete fields in record expressions

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionContributor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionContributor.kt
@@ -4,10 +4,12 @@ import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionInitializationContext
 import com.intellij.codeInsight.completion.CompletionType.BASIC
 import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.ElmLanguage
 import org.elm.lang.core.psi.ElmFile
-import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.ElmTypes.*
 import org.elm.lang.core.psi.elementType
+import org.elm.lang.core.psi.elements.ElmRecordExpr
 
 class ElmCompletionContributor : CompletionContributor() {
 
@@ -26,15 +28,27 @@ class ElmCompletionContributor : CompletionContributor() {
         for languages like Elm where many parse rules require a lower-case identifier.
         */
 
-        if (pre.elementType == ElmTypes.DOT) {
+        if (pre.elementType == DOT) {
             // Assume that after a dot, a lower-case identifier should follow.
             // This works well for functions qualified by their module name (e.g. `String.length`)
             // but it does NOT work for qualified types (e.g. `Task.Task`)
 
             // TODO use additional context to determine whether it should be upper- vs lower-case.
             context.dummyIdentifier = LOWER_DUMMY_IDENTIFIER
+        } else if (pre.parent is ElmRecordExpr) {
+            // For records, we need to make sure the field expression is complete
+            val nextElement = PsiTreeUtil.nextVisibleLeaf(pre)?.elementType
+            var dummy = when (nextElement) {
+                EQ -> LOWER_DUMMY_IDENTIFIER
+                else -> "$EMPTY_RECORD_FIELD_DUMMY_IDENTIFIER = ()"
+            }
+            if (nextElement == LOWER_CASE_IDENTIFIER) {
+                dummy = "$dummy,"
+            }
+            context.dummyIdentifier = dummy
         }
     }
 }
 
 private const val LOWER_DUMMY_IDENTIFIER = "elm_code_completion_dummy"
+const val EMPTY_RECORD_FIELD_DUMMY_IDENTIFIER = "elm_empty_record_field_dummy_identifier"

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionProvider.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmCompletionProvider.kt
@@ -3,6 +3,7 @@ package org.elm.lang.core.completion
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.psi.PsiReference
 import com.intellij.util.ProcessingContext
 
 interface Suggestor {
@@ -18,7 +19,7 @@ interface Suggestor {
  */
 class ElmCompletionProvider : CompletionProvider<CompletionParameters>() {
 
-    val suggestors = listOf(ElmQualifiableRefSuggestor, ElmRecordFieldSuggestor, ElmKeywordSuggestor)
+    val suggestors = listOf(ElmQualifiableRefSuggestor, ElmRecordFieldSuggestor, ElmRecordExprSuggestor, ElmKeywordSuggestor)
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         suggestors.forEach { it.addCompletions(parameters, result) }

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmKeywordSuggestions.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmKeywordSuggestions.kt
@@ -10,10 +10,7 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.lang.core.psi.ElmTypes.*
 import org.elm.lang.core.psi.elementType
-import org.elm.lang.core.psi.elements.ElmCaseOfExpr
-import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
-import org.elm.lang.core.psi.elements.ElmIfElseExpr
-import org.elm.lang.core.psi.elements.ElmLetInExpr
+import org.elm.lang.core.psi.elements.*
 import org.elm.lang.core.psi.prevLeaves
 import org.elm.lang.core.psi.withoutErrors
 
@@ -26,6 +23,9 @@ object ElmKeywordSuggestor : Suggestor {
         val pos = parameters.position
         val parent = pos.parent
         val grandParent = pos.parent?.parent
+
+        // Don't suggest keywords for record expression field names
+        if (grandParent is ElmRecordExpr) return
 
         if (pos.elementType == LOWER_CASE_IDENTIFIER) {
             // NOTE TO SELF:

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordExprSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordExprSuggestor.kt
@@ -14,7 +14,8 @@ object ElmRecordExprSuggestor : Suggestor {
         val pos = parameters.position
         val field = pos.parent as? ElmField ?: return
         val record = field.parent as? ElmRecordExpr ?: return
-        val diff = record.findInference()?.recordDiffs?.get(record) ?: return
+        val findInference = record.findInference()
+        val diff = findInference?.recordDiffs?.get(record) ?: return
 
         val needsEquals = field.lowerCaseIdentifier.text.endsWith(EMPTY_RECORD_FIELD_DUMMY_IDENTIFIER)
 

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordExprSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordExprSuggestor.kt
@@ -1,0 +1,31 @@
+package org.elm.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import org.elm.lang.core.psi.elements.ElmField
+import org.elm.lang.core.psi.elements.ElmRecordExpr
+import org.elm.lang.core.types.Ty
+import org.elm.lang.core.types.findInference
+import org.elm.lang.core.types.renderedText
+
+object ElmRecordExprSuggestor : Suggestor {
+    override fun addCompletions(parameters: CompletionParameters, result: CompletionResultSet) {
+        val pos = parameters.position
+        val field = pos.parent as? ElmField ?: return
+        val record = field.parent as? ElmRecordExpr ?: return
+        val diff = record.findInference()?.recordDiffs?.get(record) ?: return
+
+        val needsEquals = field.lowerCaseIdentifier.text.endsWith(EMPTY_RECORD_FIELD_DUMMY_IDENTIFIER)
+
+        for ((f, t) in diff.missing) {
+            result.add(needsEquals, f, t)
+        }
+    }
+}
+
+private fun CompletionResultSet.add(needsEquals: Boolean, str: String, field: Ty) {
+    val s = if (needsEquals) "$str = " else str
+    addElement(LookupElementBuilder.create(s)
+            .withTypeText(field.renderedText()))
+}

--- a/src/main/kotlin/org/elm/lang/core/completion/ElmRecordExprSuggestor.kt
+++ b/src/main/kotlin/org/elm/lang/core/completion/ElmRecordExprSuggestor.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import org.elm.lang.core.psi.elements.ElmField
 import org.elm.lang.core.psi.elements.ElmRecordExpr
+import org.elm.lang.core.psi.outermostDeclaration
 import org.elm.lang.core.types.Ty
 import org.elm.lang.core.types.findInference
 import org.elm.lang.core.types.renderedText
@@ -15,6 +16,13 @@ object ElmRecordExprSuggestor : Suggestor {
         val field = pos.parent as? ElmField ?: return
         val record = field.parent as? ElmRecordExpr ?: return
         val diff = record.findInference()?.recordDiffs?.get(record) ?: return
+
+        // HACK: for some reason, subsequent completions can return stale results if you edit a
+        // record after triggering completion. This forces the results to update. Note that even
+        // without this, type errors and hints update as expected, which means the inference _is_
+        // being invalidated correctly. The stale completion results probably have something to do
+        // with the fact that completion runs on a shadow copy of the actual file.
+        record.outermostDeclaration(strict = true)?.modificationTracker?.incModificationCount()
 
         val needsEquals = field.lowerCaseIdentifier.text.endsWith(EMPTY_RECORD_FIELD_DUMMY_IDENTIFIER)
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeExpressionInference.kt
@@ -149,7 +149,7 @@ class TypeExpression(
 
     fun beginTypeRefInference(typeExpr: ElmTypeExpression): InferenceResult {
         val ty = typeExpressionType(typeExpr)
-        return InferenceResult(expressionTypes, diagnostics, ty)
+        return InferenceResult(expressionTypes, diagnostics, emptyMap(), ty)
     }
 
     fun beginTypeDeclarationInference(typeDeclaration: ElmTypeDeclaration): ParameterizedInferenceResult<TyUnion> {

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -85,10 +85,16 @@ private class InferenceScope(
      */
     private val resolvedDeclarations: MutableMap<ElmValueDeclaration, Ty> = parent?.resolvedDeclarations
             ?: mutableMapOf()
+
     /** names declared in parameters and patterns */
     private val bindings: MutableMap<ElmNamedElement, Ty> = mutableMapOf()
+
     /** errors encountered during inference */
     private val diagnostics: MutableList<ElmDiagnostic> = mutableListOf()
+
+    /** Record diffs for elements that have a type error */
+    private val recordDiffs: MutableMap<ElmPsiElement, RecordDiff> = mutableMapOf()
+
     /**
      * If this scope is a let-in, this set contains declarations that are direct children of this scope.
      *
@@ -96,6 +102,7 @@ private class InferenceScope(
      * so that we can find which ancestor to start inference from.
      */
     private val childDeclarations: MutableSet<ElmValueDeclaration> = mutableSetOf()
+
     /** The inferred types of elements that should be exposed through documentation. */
     private val expressionTypes: MutableMap<ElmPsiElement, Ty> = mutableMapOf()
 
@@ -178,7 +185,7 @@ private class InferenceScope(
         val bodyTy = inferExpression(expr)
         checkToplevelCaseBranches(expr, bodyTy)
 
-        return InferenceResult(expressionTypes, diagnostics, TyFunction(paramVars, bodyTy).uncurry())
+        return InferenceResult(expressionTypes, diagnostics, recordDiffs, TyFunction(paramVars, bodyTy).uncurry())
     }
 
     private fun beginLetInInference(letIn: ElmLetInExpr): InferenceResult {
@@ -197,7 +204,7 @@ private class InferenceScope(
         val exprTy = inferExpression(expr)
         checkToplevelCaseBranches(expr, exprTy)
 
-        return InferenceResult(expressionTypes, diagnostics, exprTy)
+        return InferenceResult(expressionTypes, diagnostics, recordDiffs, exprTy)
     }
 
     private fun beginCaseBranchInference(
@@ -207,7 +214,7 @@ private class InferenceScope(
     ): InferenceResult {
         bindPattern(pattern, caseTy, false)
         val ty = inferExpression(branchExpression)
-        return InferenceResult(expressionTypes, diagnostics, ty)
+        return InferenceResult(expressionTypes, diagnostics, recordDiffs, ty)
     }
 
     private inline fun inferChild(
@@ -217,6 +224,7 @@ private class InferenceScope(
     ): InferenceResult {
         val result = InferenceScope(shadowableNames.toMutableSet(), activeScopes, recursionAllowed, this).block()
         diagnostics += result.diagnostics
+        recordDiffs += result.recordDiffs
         expressionTypes += result.expressionTypes
         return result
     }
@@ -282,7 +290,7 @@ private class InferenceScope(
         val outerVars = ancestors.drop(1).flatMap { it.annotationVars.asSequence() }.toList()
         val ret = TypeReplacement.replace(ty, replacements, outerVars)
         if (replaceExpressionTypes) freeze(ret)
-        return InferenceResult(exprs, diagnostics, ret)
+        return InferenceResult(exprs, diagnostics, recordDiffs, ret)
     }
 
     //</editor-fold>
@@ -585,7 +593,10 @@ private class InferenceScope(
             val expected = baseFields[name.text]
             if (expected == null) {
                 if (baseTy is TyRecord) {
-                    if (!baseTy.isSubset) diagnostics += RecordFieldError(name, name.text)
+                    if (!baseTy.isSubset) {
+                        diagnostics += RecordFieldError(name, name.text)
+                        recordDiffs[record] = calcRecordDiff(TyRecord(fields.mapKeys { (k, _) -> k.text }), baseTy)
+                    }
                 } else if (baseTy is MutableTyRecord) {
                     baseTy.fields[name.text] = ty
                 }
@@ -987,6 +998,7 @@ private class InferenceScope(
                 // For pattern declarations, the elm compiler issues diagnostics on the expression
                 // rather than the pattern, but it's easier for us to issue them on the pattern instead.
                 diagnostics += TypeMismatchError(pat, actualTy, ty, patternBinding = true, recordDiff = recordDiff)
+                recordDiff?.let { recordDiffs[pat] = it }
             }
 
             for (f in fields) {
@@ -1036,6 +1048,9 @@ private class InferenceScope(
             // rather than the whole thing.
             val errorElement = (element as? ElmLetInExpr)?.expression ?: element
             diagnostics += TypeMismatchError(errorElement, t1, t2, endElement, patternBinding, diff)
+            if (diff != null && element is ElmRecordExpr) {
+                recordDiffs[element] = diff
+            }
         }
         return assignable
     }
@@ -1323,11 +1338,15 @@ private class InferenceScope(
 /**
  * @property expressionTypes the types for any psi elements inferred that should be available to inspections
  * @property diagnostics any errors encountered during inference
+ * @property recordDiffs record diffs for elements that have a type error
  * @property ty the return type of the function or expression being inferred
  */
-data class InferenceResult(val expressionTypes: Map<ElmPsiElement, Ty>,
-                           val diagnostics: List<ElmDiagnostic>,
-                           val ty: Ty) {
+data class InferenceResult(
+        val expressionTypes: Map<ElmPsiElement, Ty>,
+        val diagnostics: List<ElmDiagnostic>,
+        val recordDiffs: Map<ElmPsiElement, RecordDiff>,
+        val ty: Ty
+) {
     fun elementType(element: ElmPsiElement): Ty = expressionTypes[element] ?: TyUnknown()
 }
 

--- a/src/test/kotlin/org/elm/ide/inspections/inference/InferenceCacheInvalidationTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/InferenceCacheInvalidationTest.kt
@@ -1,0 +1,68 @@
+package org.elm.ide.inspections.inference
+
+import com.intellij.psi.PsiDocumentManager
+import org.elm.lang.ElmTestBase
+import org.elm.lang.core.psi.directChildrenOfType
+import org.elm.lang.core.psi.elements.ElmValueDeclaration
+import org.elm.lang.core.types.InferenceResult
+import org.elm.lang.core.types.findInference
+import org.intellij.lang.annotations.Language
+
+class InferenceCacheInvalidationTest : ElmTestBase() {
+    override fun getProjectDescriptor() = ElmWithStdlibDescriptor
+
+    fun `test reinferred only current function after insert in annotated function`() = doTest("1", """
+foo: List Int
+foo = [ {-caret-} ]
+bar = ()
+""", "foo")
+
+    fun `test reinferred only current function after remove in annotated function`() = doTest("\b", """
+foo: List Int
+foo = [ 2{-caret-} ]
+bar = ()
+""", "foo")
+
+    fun `test reinferred only current function after replace in annotated function`() = doTest("\b3", """
+foo: List Int
+foo = [ 2{-caret-} ]
+bar = ()
+""", "foo")
+
+    fun `test reinferred everything on insert in unannotated function`() = doTest("1", """
+foo = [ {-caret-} ]
+bar = ()
+""", "foo", "bar")
+
+    fun `test reinferred everything on type change`() = doTest("a", """
+type Foo a = Bar {-caret-}
+foo = ()
+bar = ()
+""", "foo", "bar")
+
+    fun `test reinferred everything on type alias change`() = doTest(", baz: a", """
+type alias Foo a = { bar: a{-caret-} }
+foo = ()
+bar = ()
+""", "foo", "bar")
+
+    private fun doTest(type: String, @Language("Elm") code: String, vararg expected: String) {
+        InlineFile(code).withCaret()
+        val before = collectInference()
+
+        myFixture.type(type)
+        PsiDocumentManager.getInstance(project).commitAllDocuments() // process PSI modification events
+
+        val changed = collectInference()
+                .filter { before[it.key] !== it.value }
+                .keys.toList()
+
+        assertEquals(expected.asList(), changed)
+    }
+
+    private fun collectInference(): Map<String, InferenceResult> {
+        val directChildrenOfType = myFixture.file.directChildrenOfType<ElmValueDeclaration>()
+        return directChildrenOfType
+                .associate { it.functionDeclarationLeft!!.name to it.findInference()!! }
+    }
+}

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
@@ -83,7 +83,7 @@ main = <error descr="Type mismatch.Required: ((), (), ())Found: ((), ())">((), (
 
     fun `test mismatched tuple value type from wrong field type`() = checkByText("""
 main : ((), ())
-main = <error descr="Type mismatch.Required: ((), ())Found: (Float, ())">(1.0, ())</error>
+main = (<error descr="Type mismatch.Required: ()Found: Float">1.0</error>, ())
 """)
 
     fun `test mismatched tuple value type from extra field`() = checkByText("""

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordExprCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordExprCompletionTest.kt
@@ -190,4 +190,14 @@ f =
     { second = { third = Baz { foo = {-caret-} } } }
 """
     )
+
+    fun `test inside tuple`() = doSingleCompletion("""
+f : ({ foo : () }, ())
+f =
+    ({ f{-caret-} }, ())
+""", """
+f : ({ foo : () }, ())
+f =
+    ({ foo = {-caret-} }, ())
+""")
 }

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordExprCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordExprCompletionTest.kt
@@ -80,13 +80,6 @@ f =
     { foo = {-caret-} }
 """)
 
-    fun `test leaf of nested record`() = checkNoCompletion(
-            """
-f : { foo : { bar: () } }
-f =
-    { foo = { s{-caret-} } }
-""")
-
     fun `test custom type declaration`() = doSingleCompletion(
             """
 type Bar = Baz { foo : () }

--- a/src/test/kotlin/org/elm/lang/core/completion/ElmRecordExprCompletionTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/completion/ElmRecordExprCompletionTest.kt
@@ -1,0 +1,193 @@
+package org.elm.lang.core.completion
+
+class ElmRecordExprCompletionTest : ElmCompletionTestBase() {
+
+    fun `test blank`() = doSingleCompletion(
+            """
+f : { foo : () }
+f =
+    { {-caret-} }
+""", """
+f : { foo : () }
+f =
+    { foo = {-caret-} }
+""")
+
+    fun `test one letter`() = doSingleCompletion(
+            """
+f : { foo : (), other: () }
+f =
+    { f{-caret-} }
+""", """
+f : { foo : (), other: () }
+f =
+    { foo = {-caret-} }
+""")
+
+    fun `test no completions when all fields already defined`() = checkNoCompletion(
+            """
+f : { foo : () }
+f =
+    { foo = "", f{-caret-} }
+""")
+
+    fun `test no completions when type cannot be inferred`() = checkNoCompletion(
+            """
+f =
+    { foo = "", f{-caret-} }
+""")
+
+    fun `test middle of record missing trailing comma`() = doSingleCompletion(
+            """
+f : { foo : (), bar : (), baz : () }
+f =
+    { foo = ()
+    , b{-caret-}
+      baz = ()
+    }
+""", """
+f : { foo : (), bar : (), baz : () }
+f =
+    { foo = ()
+    , bar = {-caret-}
+      baz = ()
+    }
+""")
+
+    fun `test record update`() = doSingleCompletion(
+            """
+type alias Foo = { foo : () }
+
+f : Foo -> Foo
+f foo =
+    { foo | f{-caret-} }
+""", """
+type alias Foo = { foo : () }
+
+f : Foo -> Foo
+f foo =
+    { foo | foo = {-caret-} }
+""")
+
+    fun `test root of nested record`() = doSingleCompletion(
+            """
+f : { foo : { bar: () } }
+f =
+    { f{-caret-} }
+""", """
+f : { foo : { bar: () } }
+f =
+    { foo = {-caret-} }
+""")
+
+    fun `test leaf of nested record`() = checkNoCompletion(
+            """
+f : { foo : { bar: () } }
+f =
+    { foo = { s{-caret-} } }
+""")
+
+    fun `test custom type declaration`() = doSingleCompletion(
+            """
+type Bar = Baz { foo : () }
+type alias Foo = { bar : Bar }
+
+f : () -> Foo
+f str =
+    { bar = Baz { {-caret-} } }
+""", """
+type Bar = Baz { foo : () }
+type alias Foo = { bar : Bar }
+
+f : () -> Foo
+f str =
+    { bar = Baz { foo = {-caret-} } }
+""")
+
+    fun `test let block`() = doSingleCompletion(
+            """
+f =
+  let
+    f2 : { foo : () }
+    f2 =
+        { f{-caret-} }
+  in
+  f2
+""", """
+f =
+  let
+    f2 : { foo : () }
+    f2 =
+        { foo = {-caret-} }
+  in
+  f2
+""")
+
+    fun `test case expression without type annotation`() = doSingleCompletion(
+            """
+f b =
+  case b of 
+    () ->
+        { foo = "foo" }
+    _ ->
+        { f{-caret-} }
+""", """
+f b =
+  case b of 
+    () ->
+        { foo = "foo" }
+    _ ->
+        { foo = {-caret-} }
+""")
+
+    fun `test blank with field value set`() = doSingleCompletion(
+            """
+f : { foo : () }
+f =
+    { {-caret-} = "" }
+""", """
+f : { foo : () }
+f =
+    { foo{-caret-} = "" }
+""")
+
+    fun `test one letter with field value set`() = doSingleCompletion(
+            """
+f : { foo : () }
+f =
+    { f{-caret-} = "" }
+""", """
+f : { foo : () }
+f =
+    { foo{-caret-} = "" }
+""")
+
+    fun `test extensible record`() = doSingleCompletion(
+            """
+f : { a | foo : () }
+f =
+    { f{-caret-} }
+""", """
+f : { a | foo : () }
+f =
+    { foo = {-caret-} }
+""")
+
+    fun `test custom type declaration nested in incomplete record`() = doSingleCompletion(
+            """
+type Bar = Baz { foo : () }
+type alias Foo = { first : (), second : { third : Bar } }
+
+f : Foo
+f =
+    { second = { third = Baz { {-caret-} } } }
+""", """
+type Bar = Baz { foo : () }
+type alias Foo = { first : (), second : { third : Bar } }
+
+f : Foo
+f =
+    { second = { third = Baz { foo = {-caret-} } } }
+"""
+    )
+}


### PR DESCRIPTION
Rather than trying to infer partial programs, this PR instead uses the normal completion mechanisms to fix up the PSI so it parses correctly before finding suggestions.

A situation where I didn't add completion is like this: `{foo: a b{-caret-}}`. It's not possible to tell whether `b` is supposed to be a function call or a field name, so I left that case alone.

Fixes #680