### PR TITLE
Fix an exception when elm-format runs on-save when Editor not found

### DIFF
--- a/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
+++ b/src/main/kotlin/org/elm/ide/components/ElmFormatOnFileSaveComponent.kt
@@ -37,20 +37,15 @@ class ElmFormatOnFileSaveComponent(val project: Project) : ProjectComponent {
                         val elmVersion = ElmFormatCLI.getElmVersion(project, vFile) ?: return
                         val elmFormat = project.elmToolchain.elmFormatCLI ?: return
 
-                        val editor = EditorFactory.getInstance().getEditors(document).first()
-
                         val result = elmFormat.formatDocumentAndSetText(project, document, elmVersion, addToUndoStack = false)
-
                         when (result) {
-                            is ElmFormatResult.BadSyntax -> {
-                                project.showBalloon(result.msg, NotificationType.WARNING, "Show Errors" to {
-                                    val action = ActionManager.getInstance().getAction(ELM_BUILD_ACTION_ID)!!
-                                    executeAction(action, "elm-format-notif", DataManager.getInstance().getDataContext(editor.component))
-                                })
-                            }
+                            is ElmFormatResult.BadSyntax ->
+                                project.showBalloon(result.msg, NotificationType.WARNING)
 
                             is ElmFormatResult.FailedToStart ->
-                                project.showBalloon(result.msg, NotificationType.ERROR, "Configure" to { project.elmWorkspace.showConfigureToolchainUI() })
+                                project.showBalloon(result.msg, NotificationType.ERROR,
+                                        "Configure" to { project.elmWorkspace.showConfigureToolchainUI() }
+                                )
 
                             is ElmFormatResult.UnknownFailure ->
                                 project.showBalloon(result.msg, NotificationType.ERROR)


### PR DESCRIPTION
I didn't realize that a `Document` does not always have an `Editor` when
the on-save hook runs. Consider the following:

1. modify the contents of a `.elm` file
2. close the editor tab for that file
3. change OS window manager focus from IntelliJ to another app
4. observe that the format-on-save hook runs but no `Editor` is available

The whole point of finding the editor was just to make it easier to show
all syntax errors using the `ElmBuildAction`. Since this is optional,
I decided to just get rid of the code path rather than try to find
a more robust solution.

Thanks @lydell for reporting the bug.