### PR TITLE
Add intention to convert record constructor function to record literal

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/RecordConstructorToLiteralIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/RecordConstructorToLiteralIntention.kt
@@ -1,0 +1,90 @@
+package org.elm.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.elm.lang.core.psi.ElmPsiFactory
+import org.elm.lang.core.psi.ElmTypes.UPPER_CASE_IDENTIFIER
+import org.elm.lang.core.psi.elements.*
+
+/**
+ * An intention action that transforms a usage of record constructor to the corresponding record literal, i.e. converts
+ * this:
+ * ```
+ * type alias MyTypeAlias = { foo: String, bar: Int }
+ *
+ * baz = MyTypeAlias "a" 1
+ * ```
+ * to this:
+ * ```
+ * type alias MyTypeAlias = { foo: String, bar: Int }
+ *
+ * baz = { foo = "a", bar = 1 }
+ * ```
+ */
+class RecordConstructorToLiteralIntention :
+    ElmAtCaretIntentionActionBase<RecordConstructorToLiteralIntention.Context>() {
+
+    /**
+     * @param functionCall The current record constructor function call, to be replaced with a record literal.
+     * @param arguments The arguments to the record literal. Each entry in the list is a pair of strings: the first is
+     * the argument name, the second is the argument's text.
+     */
+    data class Context(val functionCall: ElmFunctionCallExpr, val arguments: List<Pair<String, String>>)
+
+    override fun getText() = "Use record literal"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        // This intention is valid in a situation like this:
+        //      foo = MyRecord "a" 1
+        // In order to be valid the caret must be in the text "MyRecord". If the caret is inside this word (or just
+        // before the M) then the PSI structure is as follows:
+        //      ElmFunctionCallExpr  (this is the record constructor function)
+        //          ElmValueExpr
+        //              ElmUpperCaseQID
+        //                  LeafPsiElement (the current element, elementType = UPPER_CASE_IDENTIFIER)
+        // But if the caret is just after the last "d" of "MyRecord" the structure is as follows:
+        //      ElmFunctionCallExpr  (this is the record constructor function)
+        //          ElmValueExpr
+        //          PsiWhiteSpace    (the current element, sibling of the ElmValueExpr above)
+        val functionCall = when {
+            element is LeafPsiElement &&
+                    element.elementType == UPPER_CASE_IDENTIFIER &&
+                    element.parent is ElmUpperCaseQID &&
+                    element.parent.parent is ElmValueExpr &&
+                    element.parent.parent.parent is ElmFunctionCallExpr -> element.parent.parent.parent as ElmFunctionCallExpr
+            element is PsiWhiteSpace &&
+                    element.prevSibling is ElmValueExpr &&
+                    element.parent is ElmFunctionCallExpr -> element.parent as ElmFunctionCallExpr
+            else -> return null
+        }
+
+        // If we get here, we are in a function call. Check if that function resolves to a record type alias.
+        val recordArgNames = ((functionCall.target.reference?.resolve() as? ElmTypeAliasDeclaration)
+            // The logic in the next three lines is what's in ElmTypeAliasDeclaration.isRecordAlias, but we duplicate it
+            // here to get at the actual ElmRecordType object.
+            ?.typeExpression
+            ?.allSegments
+            ?.firstOrNull() as? ElmRecordType)
+            ?.fieldTypeList
+            ?.map { field -> field.lowerCaseIdentifier.text }
+            ?: return null
+
+        // Check the number of args to the function match the number of args expected by the type alias.
+        val args = functionCall.arguments.toList()
+            .takeIf { it.size == recordArgNames.size }
+            ?.mapIndexed { index, elmAtomTag -> recordArgNames[index] to elmAtomTag.text }
+            ?: return null
+
+        return Context(functionCall, args)
+    }
+
+    override fun invoke(project: Project, editor: Editor, context: Context) {
+        context.functionCall.replace(
+            ElmPsiFactory(project).createRecordExpr(context.arguments)
+        )
+    }
+}

--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -260,6 +260,15 @@ class ElmPsiFactory(private val project: Project) {
         createFromText("module Foo exposing ($typeName(..))")
             ?: error("Failed to create type exposure")
 
+    /**
+     * Creates a record expression with the passed in `args`, which is a list of the arguments to use to construct the
+     * record. Each entry in the list is a pair of strings: the first is the argument name, the second is the argument's
+     * text.
+     */
+    fun createRecordExpr(args: List<Pair<String, String>>): ElmRecordExpr =
+        createFromText("foo = { ${args.joinToString(", "){ (name, value) -> "$name = $value" }} }")
+            ?: error("Failed to create record expression")
+
     private inline fun <reified T : PsiElement> createFromText(code: String): T? =
             PsiFileFactory.getInstance(project)
                     .createFileFromText("DUMMY.elm", ElmFileType, code)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -466,6 +466,10 @@
             <className>org.elm.ide.intentions.MakeEncoderIntention</className>
             <category>Elm</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.elm.ide.intentions.RecordConstructorToLiteralIntention</className>
+            <category>Elm</category>
+        </intentionAction>
 
         <!-- ELM PROJECTS, PACKAGES AND DEPENDENCIES -->
         <projectService serviceImplementation="org.elm.workspace.ElmWorkspaceService"/>

--- a/src/main/resources/intentionDescriptions/RecordConstructorToLiteralIntention/after.elm.template
+++ b/src/main/resources/intentionDescriptions/RecordConstructorToLiteralIntention/after.elm.template
@@ -1,0 +1,5 @@
+type alias MyTypeAlias =
+    { foo : String, bar : Int }
+
+baz =
+    <spot>{ foo = "a", bar = 1 }</spot>

--- a/src/main/resources/intentionDescriptions/RecordConstructorToLiteralIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/RecordConstructorToLiteralIntention/before.elm.template
@@ -1,0 +1,5 @@
+type alias MyTypeAlias =
+    { foo : String, bar : Int }
+
+baz =
+    <spot>MyTypeAlias "a" 1</spot>

--- a/src/main/resources/intentionDescriptions/RecordConstructorToLiteralIntention/description.html
+++ b/src/main/resources/intentionDescriptions/RecordConstructorToLiteralIntention/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Turn a usage of a type alias constructor function into a record literal.
+</body>
+</html>

--- a/src/test/kotlin/org/elm/ide/intentions/RecordConstructorToLiteralIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/RecordConstructorToLiteralIntentionTest.kt
@@ -1,0 +1,213 @@
+package org.elm.ide.intentions
+
+class RecordConstructorToLiteralIntentionTest : ElmIntentionTestBase(RecordConstructorToLiteralIntention()) {
+
+    fun `test record type alias with two fields (caret inside type name)`() = doAvailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+foo =
+    MyType{-caret-}Alias "A" 1
+""", """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+foo =
+    { a = "A", b = 1 }
+"""
+    )
+
+    fun `test record type alias with two fields (caret at end of type name)`() = doAvailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+foo =
+    MyTypeAlias{-caret-} "A" 1
+""", """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+foo =
+    { a = "A", b = 1 }
+"""
+    )
+
+    fun `test record type alias with nested record`() = doAvailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int, c : { x : String, y : String} }
+
+foo =
+    MyType{-caret-}Alias "A" 1 { x = "X", y = "Y" }
+""", """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int, c : { x : String, y : String} }
+
+foo =
+    { a = "A", b = 1, c = { x = "X", y = "Y" } }
+"""
+    )
+
+
+    fun `test record type alias with nested record type alias (using constructor function)`() = doAvailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyNestedTypeAlias =
+    { x : String, y : String}
+
+type alias MyTypeAlias =
+    { a : String, b : Int, c : MyNestedTypeAlias }
+
+foo =
+    MyType{-caret-}Alias "A" 1 (MyNestedTypeAlias "X" "Y")
+""", """
+module Foo exposing (..)
+
+type alias MyNestedTypeAlias =
+    { x : String, y : String}
+
+type alias MyTypeAlias =
+    { a : String, b : Int, c : MyNestedTypeAlias }
+
+foo =
+    { a = "A", b = 1, c = (MyNestedTypeAlias "X" "Y") }
+"""
+    )
+
+    fun `test record type alias with nested record type alias (using record literal)`() = doAvailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyNestedTypeAlias =
+    { x : String, y : String}
+
+type alias MyTypeAlias =
+    { a : String, b : Int, c : MyNestedTypeAlias }
+
+foo =
+    MyType{-caret-}Alias "A" 1 { x = "X", y = "Y", c = { x = "X", y = "Y" } }
+""", """
+module Foo exposing (..)
+
+type alias MyNestedTypeAlias =
+    { x : String, y : String}
+
+type alias MyTypeAlias =
+    { a : String, b : Int, c : MyNestedTypeAlias }
+
+foo =
+    { a = "A", b = 1, c = { x = "X", y = "Y", c = { x = "X", y = "Y" } } }
+"""
+    )
+
+    fun `test record type alias with non-trivial values`() = doAvailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+foo =
+    MyType{-caret-}Alias ("A" ++ "B" ++ missingFunction) (1 * 2 * (String.length "bar"))
+""", """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+foo =
+    { a = ("A" ++ "B" ++ missingFunction), b = (1 * 2 * (String.length "bar")) }
+"""
+    )
+
+    fun `test record type alias imported from another module (unqualified)`() = doAvailableTestWithFileTree(
+        """
+--@ main.elm
+module Main exposing (..)
+
+import Foo exposing (..)
+
+foo =
+    MyType{-caret-}Alias "A" 1
+--@ Foo.elm
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+""", """
+module Main exposing (..)
+
+import Foo exposing (..)
+
+foo =
+    { a = "A", b = 1 }
+"""
+    )
+
+    fun `test record type alias imported from another module (qualified)`() = doAvailableTestWithFileTree(
+        """
+--@ main.elm
+module Main exposing (..)
+
+import Foo
+
+foo =
+    Foo.MyType{-caret-}Alias "A" 1
+--@ Foo.elm
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+""", """
+module Main exposing (..)
+
+import Foo
+
+foo =
+    { a = "A", b = 1 }
+"""
+    )
+
+    fun `test not available for custom type`() = doUnavailableTest(
+        """
+module Foo exposing (..)
+
+type MyType
+    = MyType String Int
+
+foo =
+    My{-caret-}Type "a" 1
+"""
+    )
+
+    fun `test not available for function which creates record`() = doUnavailableTest(
+        """
+module Foo exposing (..)
+
+type alias MyTypeAlias =
+    { a : String, b : Int }
+
+constructMyTypeAlias : String -> Int -> MyTypeAlias
+constructMyTypeAlias string int =
+    MyTypeAlias string int
+
+foo =
+    constructMyType{-caret-}Alias "A" 1
+"""
+    )
+}


### PR DESCRIPTION
Hi Keith. As discussed on Discord, here's the PR for this next refactoring intention. Some stuff to consider:
* The logic around the PSI structure in `RecordConstructorToLiteralIntention.findApplicableContext`: I'm possibly being overly defensive/specific here? Do you think there's a better approach, maybe using some of the extension functions in `PsiElement.kt` (e.g. all the stuff related to `ancestors`)?
* I'm not handling piped operations (e.g. `1 |> MyTypeAlias "a"`). In those situations the intention isn't available. I think that's OK, but let me know if you disagree.
* I'm not currently removing brackets which become redundant when the intention is applied. For example `MyTypeAlias "a" (1 + 2)` becomes `{ foo = "a", bar = (1 + 2) }` - the brackets around `1 + 2` are no longer required. Again, I think that's OK, but let me know if you want me to revisit that.
* I'm not checking the types passed into the constructor function are valid. The intention is available even if you're passing the wrong data types into the existing function. Obviously it'll generate code that doesn't compile (as the current code won't) but I think that's OK.
