### PR TITLE
Only show New Elm File option inside Elm source directories

### DIFF
--- a/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmCreateFileAction.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import org.elm.lang.core.ElmFileType
@@ -66,16 +65,12 @@ class ElmCreateFileAction : CreateFileFromTemplateAction(CAPTION, "", ElmFileTyp
 
         val file = CommonDataKeys.VIRTUAL_FILE.getData(dataContext) ?: return false
         val project = PlatformDataKeys.PROJECT.getData(dataContext)!!
-        val sourceDirs = project.elmWorkspace.allProjects.asSequence()
-                .flatMap { it.allSourceDirVirtualFiles.asSequence() }
-        return sourceDirs.any {
-            VfsUtil.isAncestor(it, file, /*strict=*/ false)
-        }
+        return project.elmWorkspace.findProjectForFile(file) != null
     }
 
     private companion object {
-        private val CAPTION = "New Elm file"
-        private val ELM_MODULE_KIND = "Elm Module" // must match name of internal template stored in JAR resources
+        private const val CAPTION = "New Elm file"
+        private const val ELM_MODULE_KIND = "Elm Module" // must match name of internal template stored in JAR resources
     }
 }
 

--- a/src/main/kotlin/org/elm/workspace/ElmProject.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmProject.kt
@@ -1,12 +1,9 @@
 package org.elm.workspace
 
 import com.intellij.openapi.util.UserDataHolderBase
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.indexing.LightDirectoryIndex
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.concurrent.atomic.AtomicReference
 
 
 /**
@@ -86,20 +83,6 @@ sealed class ElmProject(
      */
     val allDirectDeps: Sequence<ElmPackageProject> =
             sequenceOf(dependencies, testDependencies).flatten()
-
-    private val sourceDirCache = AtomicReference<List<VirtualFile>>()
-
-    /**
-     * Returns [VirtualFile]s for each directory in [allSourceDirs].
-     */
-    val allSourceDirVirtualFiles: List<VirtualFile>
-        get() {
-            val cached = sourceDirCache.get()
-            if (cached?.all { it.isValid } == true) return cached
-            val dirs = allSourceDirs.mapNotNull { LocalFileSystem.getInstance().findFileByIoFile(it.toFile()) }.toList()
-            sourceDirCache.set(dirs)
-            return dirs
-        }
 
     /**
      * Returns the direct and indirect dependencies of the receiver, recursively.


### PR DESCRIPTION
It's a bit annoying to have the "New Elm File" action show up even in projects that don't use Elm at all. This PR changes that action so that it only appears inside Elm source directories.

[Kotlin](https://github.com/intellij-rust/intellij-rust/blob/3f4eb6e80c08ee8c987e321ea5abedab8f71e4f7/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt#L25) and [Rust](https://github.com/JetBrains/kotlin/blob/a7f57646bf55aff3dcfd8f2c313e1ced36c2e9a5/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt#L126) do something similar.