### PR TITLE
Optimize 'Find Usages' so that it only looks at `*.elm` files

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiElementImpl.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiElementImpl.kt
@@ -5,8 +5,11 @@ import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
+import org.elm.lang.core.ElmFileType
 import org.elm.lang.core.resolve.reference.ElmReference
 import org.elm.workspace.ElmProject
 import org.elm.workspace.elmWorkspace
@@ -70,6 +73,12 @@ abstract class ElmStubbedElement<StubT : StubElement<*>>
     override fun getReferences(): Array<ElmReference> {
         val ref = getReference() as? ElmReference ?: return EMPTY_REFERENCE_ARRAY
         return arrayOf(ref)
+    }
+
+    override fun getUseScope(): SearchScope {
+        // Restrict find-usages to only look at `*.elm` files in the current IntelliJ project.
+        val baseScope = GlobalSearchScope.projectScope(project)
+        return GlobalSearchScope.getScopeRestrictedByFileTypes(baseScope, ElmFileType)
     }
 
     // this is needed to match how [ASTWrapperPsiElement] implements `toString()`


### PR DESCRIPTION
Previously, if you did 'Find Usages' on a function named `view`,
it would open/read/parse all files which contain the word "view".
Now, this wasn't wrong--since the actual reference would never
resolve when say a Markdown file contains the word "view"--but it
was needlessly inefficient.

Fixes #336 