### PR TITLE
Use mutation API for changing a project's exclude patterns

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.startup.StartupManager
 import com.intellij.openapi.util.EmptyRunnable
@@ -453,12 +454,14 @@ class ElmWorkspaceService(
                     if (rawProjects.isNotEmpty()) {
                         // Exclude `elm-stuff` directories to prevent pollution of open-by-filename, etc.
                         ApplicationManager.getApplication().invokeLater {
-                            intellijProject.modules.asSequence()
-                                    .flatMap { ModuleRootManager.getInstance(it).contentEntries.asSequence() }
-                                    .forEach {
+                            for (module in intellijProject.modules.asSequence()) {
+                                ModuleRootModificationUtil.updateModel(module) { model ->
+                                    model.contentEntries.forEach {
                                         if ("elm-stuff" !in it.excludePatterns)
                                             it.addExcludePattern("elm-stuff")
                                     }
+                                }
+                            }
                         }
                     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -305,9 +305,10 @@
 
     <!--
     See http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
-    Note that the range is half-open: [since-build, until-build)
+    Note that the range is half-open: [since-build, until-build), but if you use a wildcard in `until`,
+    it will be inclusive (i.e. 203.* is inclusive for 2020.3.x)
      -->
-    <idea-version since-build="191.4212.41" until-build="202.*"/>
+    <idea-version since-build="191.4212.41" until-build="203.*"/>
 
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
This was necessary to make it work properly in IntelliJ 2020.3, which is stricter.