### PR TITLE
Add parentheses around expression

### DIFF
--- a/src/main/kotlin/org/elm/ide/ElmTypedHandler.kt
+++ b/src/main/kotlin/org/elm/ide/ElmTypedHandler.kt
@@ -1,0 +1,29 @@
+package org.elm.ide
+
+import com.intellij.codeInsight.CodeInsightSettings
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import org.elm.lang.core.psi.ElmFile
+import org.elm.openapiext.runWriteCommandAction
+
+class ElmTypedHandler : TypedHandlerDelegate() {
+    override fun beforeSelectionRemoved(c: Char, project: Project, editor: Editor, psiFile: PsiFile): Result {
+        if (psiFile !is ElmFile) return super.charTyped(c, project, editor, psiFile)
+
+        val charMap = mapOf('(' to ')', '{' to '}', '[' to ']')
+
+        if (editor.selectionModel.hasSelection()
+            && charMap.contains(c)
+            && CodeInsightSettings.getInstance().AUTOINSERT_PAIR_BRACKET) {
+            project.runWriteCommandAction {
+                editor.document.insertString(editor.selectionModel.selectionStart, c.toString())
+                editor.document.insertString(editor.selectionModel.selectionEnd, charMap[c].toString())
+            }
+            return Result.STOP
+        }
+
+        return Result.CONTINUE
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -340,6 +340,7 @@
         <gotoSymbolContributor implementation="org.elm.ide.navigation.ElmGoToSymbolContributor"/>
         <lang.braceMatcher language="Elm" implementationClass="org.elm.ide.ElmPairedBraceMatcher"/>
         <lang.commenter language="Elm" implementationClass="org.elm.ide.commenter.ElmCommenter"/>
+        <typedHandler implementation="org.elm.ide.ElmTypedHandler" id="ElmFile"/>
         <completion.contributor language="Elm"
                                 implementationClass="org.elm.lang.core.completion.ElmCompletionContributor"/>
         <breadcrumbsInfoProvider implementation="org.elm.ide.structure.ElmBreadcrumbsProvider"/>

--- a/src/test/kotlin/org/elm/ide/typing/ElmOnBraceInsertHandlerTest.kt
+++ b/src/test/kotlin/org/elm/ide/typing/ElmOnBraceInsertHandlerTest.kt
@@ -1,0 +1,31 @@
+package org.elm.ide.typing
+
+import org.intellij.lang.annotations.Language
+
+
+class ElmOnBraceInsertHandlerTest : ElmTypingTestBase() {
+
+    fun `test add parentheses around selection`() = doTest("""
+f = <selection>4 + 3</selection>
+""", """
+f = (4 + 3)
+""")
+
+    fun `test add braces around selection`() = doTest("""
+f = <selection>name</selection>
+""", """
+f = {name}
+""", '{')
+
+    fun `test does not interfere with default brace behaviour`() = doTest("""
+f = {-caret-}
+""", """
+f = ()
+""")
+
+    fun doTest(@Language("Elm") before: String, @Language("Elm") after: String, c: Char = '(') {
+        checkByText(before, after) {
+            myFixture.type(c)
+        }
+    }
+}


### PR DESCRIPTION
I found this feature quite necessary, especially for languages like Elm and Haskell

**Before:**
https://user-images.githubusercontent.com/9882721/107880341-4bf98f80-6f08-11eb-886d-95beb6fdefcd.mov

**After:**
https://user-images.githubusercontent.com/9882721/107880232-bb22b400-6f07-11eb-846d-d14ebab57551.mov

