### PR TITLE
Create case of produces valid code

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/ElmPsiFactory.kt
@@ -222,7 +222,7 @@ class ElmPsiFactory(private val project: Project) {
 
     fun createCaseOfBranches(existingIndent: String, indent: String, patterns: List<String>): List<ElmCaseOfBranch> {
         val text = patterns.joinToString("\n\n$existingIndent$indent", prefix = "foo = case 1 of\n\n$existingIndent$indent") {
-            "$it ->\n$existingIndent$indent$indent"
+            "$it ->\n$existingIndent$indent$indent()"
         }
         return createFromText<ElmValueDeclaration>(text)
                 ?.descendantOfType<ElmCaseOfExpr>()?.branches


### PR DESCRIPTION
Since we don't have code formatter.
I want to format file after for example "Add missing branches" fix.
But I cannot since it will produce invalid code, this fixes that.