### PR TITLE
Change until-build to 212 to support IntelliJ 2021.2

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -331,7 +331,7 @@
     Note that the range is half-open: [since-build, until-build), but if you use a wildcard in `until`,
     it will be inclusive (i.e. 203.* is inclusive for 2020.3.x)
      -->
-    <idea-version since-build="191.4212.41" until-build="211.*"/>
+    <idea-version since-build="191.4212.41" until-build="212.*"/>
 
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
This is a lower-tech solution than #764, in case that PR is deemed too risky. This one simply increments the `until-build` number from 211 to 212. I can't currently test whether this builds successfully as the code won't compile for me locally for reasons outlined in #764. But I'm submitting this anyway in the hope that maybe it'll pass the CI/CD pipeline if all the artefacts are already cached somewhere on the build system. Whether this will pass the CI build remains to be seen, given the code still uses jcenter/bintray, which are now retired. If it does pass, this might be an easier fix to get the plugin working with IntelliJ 2021.2. Though the larger-scale upgrade of things in #764 is still something that should be done at some point.