### PR TITLE
Remove until-build constraint and hope for the best

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -331,7 +331,7 @@
     Note that the range is half-open: [since-build, until-build), but if you use a wildcard in `until`,
     it will be inclusive (i.e. 203.* is inclusive for 2020.3.x)
      -->
-    <idea-version since-build="191.4212.41" until-build="211.*"/>
+    <idea-version since-build="191.4212.41"/>
 
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
Future versions of IntelliJ may break this plugin, but this is the easiest way forward given that I have not been a good steward of the project lately.