### PR TITLE
Fix error about ElmTestConfigurationFactory.getId()

### DIFF
--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestConfigurationFactory.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestConfigurationFactory.kt
@@ -10,6 +10,8 @@ class ElmTestConfigurationFactory internal constructor(type: ConfigurationType) 
     override fun createTemplateConfiguration(project: Project) =
             ElmTestRunConfiguration(project, this, "Elm Test")
 
+    override fun getId() = "Elm Test configuration factory"
+
     override fun getName() = "Elm Test configuration factory"
 
     override fun getIcon() = RUN_ICON


### PR DESCRIPTION
Use hardcoded string instead of falling back on getName().
Closes issue #776.