### PR TITLE
Enable ElmIncompletePatternInspection inspection on the of keyword

### DIFF
--- a/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspection.kt
@@ -7,6 +7,9 @@ import com.intellij.psi.PsiElement
 import org.elm.ide.inspections.MissingCaseBranchAdder.Result.MissingVariants
 import org.elm.ide.inspections.MissingCaseBranchAdder.Result.NoMissing
 import org.elm.lang.core.psi.ElmPsiElement
+import org.elm.lang.core.psi.ElmTypes
+import org.elm.lang.core.psi.directChildren
+import org.elm.lang.core.psi.elementType
 import org.elm.lang.core.psi.elements.ElmCaseOfExpr
 
 class ElmIncompletePatternInspection : ElmLocalInspection() {
@@ -21,7 +24,12 @@ class ElmIncompletePatternInspection : ElmLocalInspection() {
             else -> arrayOf(AddWildcardBranchFix())
         }
 
-        holder.registerProblem(element.firstChild, "Case expression is not exhaustive", *fixes)
+        val description = "Case expression is not exhaustive"
+        holder.registerProblem(element.firstChild, description, *fixes)
+        val ofKeyword = element.directChildren.find { it.elementType == ElmTypes.OF }
+        if (ofKeyword !== null) {
+            holder.registerProblem(ofKeyword, description, *fixes)
+        }
     }
 }
 


### PR DESCRIPTION
Very often I (and others) write a case expression like `case x of` and the plugin is able to infer that there are missing cases and which ones (or that you need a `_` branch).

When I finish to write the `of` keyword, to make use of the inspection and automatic fixes, I have to go back to the `case` keyword. Instead, I'd like to have fixes from the `of` keyword where my editor cursor is at that moment. The `of` keyword is also more accessible by mouse because you can click anywhere on the line after the `of` keyword, but having to go to `case` requires more precision.

This PR makes the inspections available on `case` available also on `of`.