### PR TITLE
Don't require Lamdera during project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ related information [here](docs/nvm.md).
 - [ ] Click the <kbd>Watch</kbd> button on the top of the [IntelliJ Platform Plugin Template][template] to be notified about releases containing new features and fixes.
 
 <!-- Plugin description -->
-Elm & Lamdera Plugin
+Elm Plugin
 <!-- Plugin description end -->
 
 ## Installation

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 5.0.0-beta21
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 213.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -270,18 +270,19 @@ class ElmWorkspaceService(
             0 // mainEntryPoint.textOffset
         )
 
-        val success =
-            if (dto.has("lamdera/core"))
-                elmCLI.make(intellijProject, workDir = dir.toPath(), null, listOf(tmpEntryPoint)) // path = tempMain.toPath()
-            else {
-                val lamderaCLI = settings.toolchain.lamderaCLI
+        val lamderaEnabled = settings.toolchain.lamderaCompilerPath != null;
+
+        val success = if(lamderaEnabled) {
+            val lamderaCLI = settings.toolchain.lamderaCLI
                     ?: throw ProjectLoadException("Must specify a valid path to Lamdera binary in Settings")
-/* TODO check version for something important
-                val lamderaCompilerVersion = lamderaCLI.queryVersion(intellijProject).orNull()
-                    ?: throw ProjectLoadException("Could not determine version of the Lamdera compiler")
-*/
-                lamderaCLI.make(intellijProject, workDir = dir.toPath(), null, listOf(tmpEntryPoint))
-            }
+            /* TODO check version for something important
+                            val lamderaCompilerVersion = lamderaCLI.queryVersion(intellijProject).orNull()
+                                ?: throw ProjectLoadException("Could not determine version of the Lamdera compiler")
+            */
+            lamderaCLI.make(intellijProject, workDir = dir.toPath(), null, listOf(tmpEntryPoint))
+        } else {
+            elmCLI.make(intellijProject, workDir = dir.toPath(), null, listOf(tmpEntryPoint)) // path = tempMain.toPath()
+        }
 
         // Cleanup
         FileUtil.delete(dir)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,10 +1,38 @@
 <idea-plugin>
-    <id>Elm IntelliJ NG</id>
-    <name>Elm / Lamdera</name>
-    <vendor url="https://github.com/klazuka/intellij-elm">Keith Lazuka</vendor>
+    <id>org.elm.klazuka</id>
+    <name>Elm</name>
+    <version>x.y.z</version>
+    <vendor url="https://github.com/klazuka/intellij-elm">
+        Keith Lazuka
+    </vendor>
 
     <description><![CDATA[
-        Provides support for Elm & Lamdera projects
+      Provides support for the <a href="http://elm-lang.org">Elm</a> programming language.<br>
+
+      Features:<br>
+      <ul>
+          <li>Code completion</li>
+          <li>Go to declaration</li>
+          <li>Go to symbol</li>
+          <li>Find usages</li>
+          <li>Type Inference and Type Checking</li>
+          <li>Rename refactoring</li>
+          <li>Introduce "variable" refactoring (`let/in`)</li>
+          <li>Generate JSON encoders/decoders</li>
+          <li>Generate type annotation for un-annotated function</li>
+          <li>Graphical UI for running elm-test</li>
+          <li>Re-format code using elm-format</li>
+          <li>Detect unused code</li>
+          <li>Detect and remove unused imports</li>
+          <li>'Add Import' quick fix for unresolved references</li>
+          <li>Code folding</li>
+          <li>Structure view</li>
+          <li>Syntax highlighting</li>
+          <li>WebGL/GLSL support</li>
+          <li>Spell checking</li>
+          <li>Lamdera platform support</li>
+          <li>etc.</li>
+      </ul>
     ]]></description>
 
     <!-- please see https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html


### PR DESCRIPTION
While it's nice to make accommodations for users who use the Lamdera platform, the primary purpose of this plugin is support for the Elm language. Most likely the majority of users have never even heard of Lamdera, and shouldn't be required to learn about it or install it to have support for Elm in their editor. :)

This PR also bumps the max Intellij version so that we can use this plugin in Intellij 2022.