### PR TITLE
improved syntax highlight

### DIFF
--- a/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorSettingsPage.kt
@@ -10,71 +10,89 @@ class ElmColorSettingsPage : ColorSettingsPage {
     private val ATTRS = ElmColor.values().map { it.attributesDescriptor }.toTypedArray()
 
     override fun getDisplayName() =
-            "Elm"
+        "Elm"
 
     override fun getIcon() =
-            ElmIcons.FILE
+        ElmIcons.FILE
 
     override fun getAttributeDescriptors() =
-            ATTRS
+        ATTRS
 
     override fun getColorDescriptors(): Array<ColorDescriptor> =
-            ColorDescriptor.EMPTY_ARRAY
+        ColorDescriptor.EMPTY_ARRAY
 
     override fun getHighlighter() =
-            ElmSyntaxHighlighter()
+        ElmSyntaxHighlighter()
 
     override fun getAdditionalHighlightingTagToDescriptorMap() =
-    // special tags in [demoText] for semantic highlighting
-            mapOf(
-                    "type" to ElmColor.TYPE_EXPR,
-                    "variant" to ElmColor.UNION_VARIANT,
-                    "accessor" to ElmColor.RECORD_FIELD_ACCESSOR,
-                    "field" to ElmColor.RECORD_FIELD,
-                    "func_decl" to ElmColor.DEFINITION_NAME
+        // special tags in [demoText] for semantic highlighting
+        mapOf(
+            "type" to ElmColor.TYPE_EXPR,
+            "type_decl" to ElmColor.TYPE_DECLARATION,
+            "variant" to ElmColor.UNION_VARIANT,
+            "accessor" to ElmColor.RECORD_FIELD_ACCESSOR,
+            "field" to ElmColor.RECORD_FIELD,
+            "func_decl" to ElmColor.DEFINITION_NAME,
+
+            "fn_arg" to ElmColor.FUNCTION_ARGUMENT,
+            "fn_loc" to ElmColor.LOCAL_FUNCTION,
+            "fn_loc_arg" to ElmColor.LOCAL_FUNCTION_ARGUMENT,
+            "pattern_arg" to ElmColor.PATTERN_ARGUMENT,
+            "fn_inl_arg" to ElmColor.INLINE_FUNCTION_ARGUMENT,
+
+            "ext_module" to ElmColor.EXTERNAL_MODULE,
+            "ext_fn_call" to ElmColor.EXTERNAL_FUNCTION_CALL,
+            "port" to ElmColor.PORT,
+
             ).mapValues { it.value.textAttributesKey }
 
     override fun getDemoText() =
-            demoCodeText
+        demoCodeText
 }
 
 private const val demoCodeText = """
 module Todo exposing (..)
 
-import Html exposing (div, h1, ul, li, text)
+import <ext_module>Html</ext_module> exposing (<ext_fn_call>div</ext_fn_call>, <ext_fn_call>h1</ext_fn_call>, <ext_fn_call>ul</ext_fn_call>, <ext_fn_call>li</ext_fn_call>, <ext_fn_call>text</ext_fn_call>)
 
 -- a single line comment
 
-type alias Model =
+port <port>samplePort</port> : () -> <type>Cmd msg</type>
+
+type alias <type_decl>Model</type_decl> =
     { <field>page</field> : <type>Int</type>
     , <field>title</field> : <type>String</type>
     , <field>stepper</field> : <type>Int</type> -> <type>Int</type>
     }
 
-type Msg <type>a</type>
+type <type_decl>Msg</type_decl> <type>a</type>
     = <variant>ModeA</variant>
     | <variant>ModeB</variant> <type>Maybe a</type>
 
 <func_decl>update</func_decl> : <type>Msg</type> -> <type>Model</type> -> ( <type>Model</type>, <type>Cmd Msg</type> )
-<func_decl>update</func_decl> msg model =
-    case msg of
-        <variant>ModeA</variant> ->
-            { model
+<func_decl>update</func_decl> <fn_arg>msg</fn_arg> <fn_arg>model</fn_arg> =
+    let
+        <fn_loc>localFunction</fn_loc> <fn_loc_arg>a</fn_loc_arg> =
+            <fn_loc_arg>a</fn_loc_arg>
+    in
+    case <fn_arg>msg</fn_arg> of
+        <variant>ModeB</variant> <pattern_arg>maybe</pattern_arg> ->
+            { <fn_arg>model</fn_arg>
                 | <field>page</field> = 0
-                , <field>title</field> = "Mode A"
-                , <field>stepper</field> = (\k -> k + 1)
+                , <field>title</field> = "Mode " ++ (<fn_loc>localFunction</fn_loc> "B")
+                , <field>stepper</field> = (\<fn_inl_arg>k</fn_inl_arg> -> <fn_inl_arg>k</fn_inl_arg> + 1)
             }
                 ! []
 
 <func_decl>view</func_decl> : <type>Model</type> -> <type>Html.Html Msg</type>
-<func_decl>view</func_decl> model =
+<func_decl>view</func_decl> <fn_arg>model</fn_arg> =
     let
-        <func_decl>itemify</func_decl> label =
-            li [] [ text label ]
+        <func_decl>itemify</func_decl> <fn_arg>label</fn_arg> =
+            <ext_fn_call>li</ext_fn_call> [] [ <ext_fn_call>text</ext_fn_call> <fn_arg>label</fn_arg> ]
     in
-        div []
-            [ h1 [] [ text "Chapter One" ]
-            , ul []
-                (List.map <accessor>.value</accessor> model.<field>items</field>)
+        <ext_fn_call>div</ext_fn_call> []
+            [ <ext_fn_call>h1</ext_fn_call> [] [ <ext_fn_call>text</ext_fn_call> "Chapter One" ]
+            , <ext_fn_call>ul</ext_fn_call> []
+                (<ext_module>List.</ext_module><ext_fn_call>map</ext_fn_call> <accessor>.value</accessor> <fn_arg>model</fn_arg>.<field>items</field>)
             ]
 """

--- a/src/main/kotlin/org/elm/ide/color/ElmColors.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColors.kt
@@ -26,6 +26,16 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
     EQ("Punctuation//Equals", Default.OPERATION_SIGN),
     PIPE("Punctuation//Pipe", Default.OPERATION_SIGN),
 
+    FUNCTION_ARGUMENT("Function Argument", Default.PARAMETER),
+    LOCAL_FUNCTION("Local Function//Declaration", Default.INSTANCE_METHOD),
+    LOCAL_FUNCTION_ARGUMENT("Local Function//Argument", Default.LOCAL_VARIABLE),
+    PATTERN_ARGUMENT("Pattern Argument", Default.LOCAL_VARIABLE),
+    INLINE_FUNCTION_ARGUMENT("Inline Function Argument", Default.LOCAL_VARIABLE),
+
+    EXTERNAL_MODULE("Module//Qualifier", Default.CLASS_REFERENCE),
+    EXTERNAL_FUNCTION_CALL("Module//Function Call", Default.STATIC_METHOD),
+    PORT("Port", Default.CLASS_REFERENCE),
+
     /**
      * The name of a definition.
      *
@@ -43,7 +53,8 @@ enum class ElmColor(humanName: String, default: TextAttributesKey) {
      *
      * e.g. 'String' and 'Cmd msg' in 'foo : String -> Cmd msg'
      */
-    TYPE_EXPR("Type", Default.CLASS_REFERENCE),
+    TYPE_EXPR("Type//Reference", Default.CLASS_REFERENCE),
+    TYPE_DECLARATION("Type//Declaration", Default.CLASS_REFERENCE),
 
     RECORD_FIELD("Records//Field", Default.INSTANCE_FIELD),
     RECORD_FIELD_ACCESSOR("Records//Field Accessor", Default.STATIC_FIELD);

--- a/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
+++ b/src/main/kotlin/org/elm/ide/highlight/ElmSyntaxHighlightAnnotator.kt
@@ -7,7 +7,9 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.elm.ide.color.ElmColor
+import org.elm.lang.core.psi.ancestors
 import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.psi.isTopLevel
 
 
 class ElmSyntaxHighlightAnnotator : Annotator {
@@ -18,6 +20,12 @@ class ElmSyntaxHighlightAnnotator : Annotator {
 
     private fun AnnotationHolder.highlight(element: PsiElement) {
         when (element) {
+            is ElmTypeDeclaration -> typeDecl(element)
+            is ElmTypeAliasDeclaration -> typeAliasDecl(element)
+            is ElmImportClause -> importClause(element)
+            is ElmPortAnnotation -> portAnnotation(element)
+            is ElmRecordBaseIdentifier -> recordUpdate(element)
+            is ElmLowerPattern -> functionArgument(element)
             is ElmValueDeclaration -> valueDeclaration(element)
             is ElmTypeAnnotation -> typeAnnotation(element)
             is ElmUpperCaseQID -> upperCaseQID(element)
@@ -28,6 +36,142 @@ class ElmSyntaxHighlightAnnotator : Annotator {
             is ElmUnionVariant -> unionVariant(element.upperCaseIdentifier)
             is ElmTypeVariable -> typeExpr(element)
             is ElmLowerTypeName -> typeExpr(element)
+            is ElmValueExpr -> valueExpr(element)
+        }
+    }
+
+    private fun AnnotationHolder.typeDecl(element: ElmTypeDeclaration) {
+        applyColor(element.nameIdentifier, ElmColor.TYPE_DECLARATION)
+    }
+
+    private fun AnnotationHolder.typeAliasDecl(element: ElmTypeAliasDeclaration) {
+        applyColor(element.nameIdentifier, ElmColor.TYPE_DECLARATION)
+    }
+
+    private fun AnnotationHolder.importClause(element: ElmImportClause) {
+        applyColor(element.moduleQID, ElmColor.EXTERNAL_MODULE)
+        element.exposingList?.exposedTypeList?.forEach { applyColor(it, ElmColor.TYPE_EXPR) }
+        element.exposingList?.exposedValueList?.forEach { applyColor(it, ElmColor.EXTERNAL_FUNCTION_CALL) }
+    }
+
+    private fun AnnotationHolder.portAnnotation(element: ElmPortAnnotation) {
+        applyColor(element.lowerCaseIdentifier, ElmColor.PORT)
+    }
+
+    private fun AnnotationHolder.recordUpdate(element: ElmRecordBaseIdentifier) {
+        annotateArgument(element)
+    }
+
+    private fun AnnotationHolder.annotateArgument(element: PsiElement): Boolean {
+        val parentFunction = element.ancestors
+            .filterIsInstance<ElmValueDeclaration>()
+            .firstOrNull {
+                it.functionDeclarationLeft?.namedParameters?.any { p -> p.nameIdentifier.text == element.text } ?: false
+            }
+        if (parentFunction != null) {
+            if (parentFunction.isTopLevel) {
+                applyColor(element, ElmColor.FUNCTION_ARGUMENT)
+            } else {
+                applyColor(element, ElmColor.LOCAL_FUNCTION_ARGUMENT)
+            }
+            return true
+        }
+
+        val isInlineFunctionArgument = element.ancestors
+            .filterIsInstance<ElmAnonymousFunctionExpr>()
+            .firstOrNull {
+                it.namedParameters.any { p -> p.nameIdentifier.text == element.text }
+            } != null
+        if (isInlineFunctionArgument) {
+            applyColor(element, ElmColor.INLINE_FUNCTION_ARGUMENT)
+            return true
+        }
+
+        val isUnionPattern =
+            element.ancestors.any { it is ElmCaseOfBranch && it.destructuredNames.any { name -> name.nameIdentifier.text == element.text } }
+        if (isUnionPattern) {
+            applyColor(element, ElmColor.PATTERN_ARGUMENT)
+            return true
+        }
+
+        return false
+    }
+
+    private fun AnnotationHolder.valueExpr(element: ElmValueExpr) {
+        if (element.flavor == Flavor.BareConstructor || element.flavor == Flavor.QualifiedConstructor) {
+            return
+        }
+
+        if (annotateArgument(element)) {
+            return
+        }
+
+        val isLocalFunction = element.ancestors
+            .filterIsInstance<ElmLetInExpr>()
+            .any {
+                it.valueDeclarationList.any { decl -> decl.functionDeclarationLeft?.lowerCaseIdentifier?.text == element.text }
+            }
+        if (isLocalFunction) {
+            applyColor(element, ElmColor.LOCAL_FUNCTION)
+            return
+        }
+
+        val functionDeclaration =
+            element.elmFile.children.any { it is ElmValueDeclaration && it.functionDeclarationLeft?.name == element.text }
+        if (functionDeclaration) {
+            applyColor(element, ElmColor.DEFINITION_NAME)
+            return
+        }
+
+        val isPortAnnotation =
+            element.elmFile.children.any { it is ElmPortAnnotation && it.lowerCaseIdentifier.text == element.text }
+        if (isPortAnnotation) {
+            applyColor(element, ElmColor.PORT)
+            return
+        }
+
+        val qid = element.valueQID
+        if (qid != null && qid.isQualified == true) {
+            qid.qualifiers.forEach {
+                applyColor(it, ElmColor.EXTERNAL_MODULE)
+            }
+            applyColor(qid.lowerCaseIdentifier, ElmColor.EXTERNAL_FUNCTION_CALL)
+            return
+        }
+
+        applyColor(element, ElmColor.EXTERNAL_FUNCTION_CALL)
+    }
+
+    private fun AnnotationHolder.functionArgument(element: ElmLowerPattern) {
+        val parentFunction = PsiTreeUtil.getParentOfType(
+            element,
+            ElmFunctionDeclarationLeft::class.java
+        );
+        if (parentFunction != null) {
+            if (parentFunction.isTopLevel) {
+                applyColor(element, ElmColor.FUNCTION_ARGUMENT)
+            } else {
+                applyColor(element, ElmColor.LOCAL_FUNCTION_ARGUMENT)
+            }
+            return
+        }
+
+        val anonymousFunction = PsiTreeUtil.getParentOfType(
+            element,
+            ElmAnonymousFunctionExpr::class.java
+        );
+        if (anonymousFunction != null) {
+            applyColor(element, ElmColor.INLINE_FUNCTION_ARGUMENT)
+            return
+        }
+
+        val unionPattern = PsiTreeUtil.getParentOfType(
+            element,
+            ElmUnionPattern::class.java
+        );
+        if (unionPattern != null) {
+            applyColor(element, ElmColor.PATTERN_ARGUMENT)
+            return
         }
     }
 
@@ -62,7 +206,13 @@ class ElmSyntaxHighlightAnnotator : Annotator {
 
     private fun AnnotationHolder.valueDeclaration(declaration: ElmValueDeclaration) {
         declaration.declaredNames(includeParameters = false).forEach {
-            applyColor(it.nameIdentifier, ElmColor.DEFINITION_NAME)
+            if (it is ElmFunctionDeclarationLeft) {
+                if (it.ancestors.filterIsInstance<ElmLetInExpr>().any()) {
+                    applyColor(it.nameIdentifier, ElmColor.LOCAL_FUNCTION)
+                } else {
+                    applyColor(it.nameIdentifier, ElmColor.DEFINITION_NAME)
+                }
+            }
         }
     }
 
@@ -80,6 +230,9 @@ class ElmSyntaxHighlightAnnotator : Annotator {
     }
 
     private fun AnnotationHolder.applyColor(element: PsiElement, color: ElmColor) {
-        newSilentAnnotation(HighlightSeverity.INFORMATION).textAttributes(color.textAttributesKey).range(element.textRange).create()
+        newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .textAttributes(color.textAttributesKey)
+            .range(element.textRange)
+            .create()
     }
 }


### PR DESCRIPTION
With this PR I'm trying to improve the Syntax Highlight for ELM.

Current highlight support is very minimal and doesn't make any difference for various elements like: function calls of different scopes and arguments with some hard to read results.

Since in Elm basically everything is a Function Call or Arguments, it's important to know at least the _scope_ of the function being called.

For this reason, I introduced different level of highlighting based on scope:
- Imported Module, Imported Module Function
- Ports
- Function Calls related to the current file (and their arguments)
- Function Calls declared in `let-in` blocks (and their arguments)
- Anonymous Function Calls (and their arguments)
- Pattern match arguments.

Here two comparison images:
1. previous this PR: 
<img width="500" alt="previous" src="https://github.com/user-attachments/assets/3b6fe1ff-c729-4992-93da-3bb578bb4b82" />

2. after this PR (default color scheme): 
<img width="505" alt="after" src="https://github.com/user-attachments/assets/802a4b0e-1e70-4c26-8198-4e69f11a2db0" />

3. with some random colors: 
<img width="509" alt="after_custom_colors" src="https://github.com/user-attachments/assets/97887de3-23f6-4603-b1ad-367e7fd89248" />

